### PR TITLE
[FIXED JENKINS-26240] Use backwards compatible gzip compression

### DIFF
--- a/deb/build/build.sh
+++ b/deb/build/build.sh
@@ -33,7 +33,7 @@ pushd $D
       mv $f ${ARTIFACTNAME}$(echo $f | cut -b8-)
     done
   popd
-  debuild -us -uc -A
+  debuild -us -uc -Zgzip -A
 popd
 
 mkdir "$(dirname "${DEB}")" || true


### PR DESCRIPTION
Copy of https://github.com/jenkinsci/jenkins/pull/1555 for packaging repo.

Untested.