### PR TITLE
Avloid 'setup.mk:34: *** unterminated variable reference.  Stop.'

### DIFF
--- a/setup.mk
+++ b/setup.mk
@@ -31,7 +31,7 @@ export BASE:=$(CURDIR)
 # read license file and do reformatting for proper display
 export LICENSE_TEXT:=$(cat LICENSE_FILE)
 export LICENSE_TEXT_COLUMN:=$(fold -w 78 -s LICENSE_FILE)  # Format to 80 characters
-export LICENSE_TEXT_COMMENTED:=$(LICENSE_TEXT_COLUMN | sed -e 's/^/# /g')
+export LICENSE_TEXT_COMMENTED:=$(LICENSE_TEXT_COLUMN | sed -e 's/^/\# /g')
 
 # Put a dot in place of an empty line, and prepend a space
 export LICENSE_TEXT_DEB:=$(LICENSE_TEXT_COLUMN | sed -e 's/^$/./g' -e 's/^/ /g')


### PR DESCRIPTION
This seems necessary for gnu make 3.81 and 4.1. Is there any public CI build I can inspect?