### PR TITLE
Fixes from testing new packaging: exports do not need quoting, and RE…

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,13 @@ The location of this file is set via the `WAR` variable.
 
 # Generating packages
 Run `make package` to build all the native packages.
-At minimum, you have to specify the `WAR` variable that points to the war file to be packaged.
+At minimum, you have to specify the `WAR` variable that points to the war file to be packaged and a branding file (for licensing and package descriptions). 
+You will probably need to pass in the build environment and credentials.
+
+For example:
+```shell
+make package BRAND=./branding/jenkins.mk BUILDENV=./env/test.mk CREDENTIAL=./credentials/test.mk
+```
 
 Packages will be placed into `target/` directory.
 See the definition of the `package` goal for how to build individual packages selectively.

--- a/branding/common
+++ b/branding/common
@@ -9,8 +9,8 @@ export PORT=8080
 
 export MSI_PRODUCTCODE=415933d8-4104-47c3-aee9-66b31de07a57
 export OSX_IDPREFIX=org.jenkins-ci
-export AUTHOR="Kohsuke Kawaguchi <kk@kohsuke.org>"
-export LICENSE="MIT/X License, GPL/CDDL, ASL2"
+export AUTHOR=Kohsuke Kawaguchi <kk@kohsuke.org>
+export LICENSE=MIT/X License, GPL/CDDL, ASL2
 export HOMEPAGE=http://jenkins-ci.org/
 export CHANGELOG_PAGE=http://jenkins-ci.org/changelog
 


### PR DESCRIPTION
…ADME needs to explain passing in brand var to build package

This fixes issues discovered in testing builds for Debian: for export values, do not use quoting: this is not the shell "export" command, it is specifically for make, and handles whitespace correctly (verified). 
If you use quotes, the debian packaging will fail. 

Also, the documentation does not mention the need to supply a brand variable for initial packaging.

@reviewbybees 