### PR TITLE
we don't use and never have used shared libraries.

### DIFF
--- a/deb/build/debian/control
+++ b/deb/build/debian/control
@@ -8,7 +8,7 @@ Homepage: @@HOMEPAGE@@
 
 Package: @@ARTIFACTNAME@@
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, daemon, adduser, psmisc, default-jre-headless | java-runtime-headless
+Depends: ${misc:Depends}, daemon, adduser, psmisc, default-jre-headless | java-runtime-headless
 Conflicts: hudson
 Replaces: hudson
 Description: continuous integration system


### PR DESCRIPTION
On top of that fact `dpkg-shlibdep` was never called from rules so the
substitute file would never be generated.  And if if it was generated it
would be empty as we have no binaries in the build dir that use shared
libs.  So this just produced warnings in the build
  `dpkg-gencontrol: warning: Depends field of package jenkins: unknown
  substitution variable ${shlibs:Depends}`

@reviewbybees 