### PR TITLE
Define the required "_gpg_name" macro.

### DIFF
--- a/bin/rpm-sign.bin
+++ b/bin/rpm-sign.bin
@@ -2,6 +2,7 @@
 # run 'rpm -E '%{__gpg_sign_cmd}' to see how it's expanded on your system.
 # normally it's defined in /usr/lib/rpm/macros
 exec rpm \
+  -D "%_gpg_name ignored" \
   -D "__gpg_check_password_cmd /bin/true" \
   -D "__gpg_sign_cmd %{__gpg} \
       gpg --batch --no-use-agent --no-verbose --no-armor --passphrase-file=$GPG_PASSPHRASE_FILE \


### PR DESCRIPTION
The _gpg_name macro is required by rpmbuild but it is normally defined per
user in ~/.rpmmacros.  

However on a CI sytem we don't want to have
something hard coded and left on the file system, and we also explicitly
state what keys to use this macro is completely ignored anyway.  So to
prevent build issues just define the macro to something.