### PR TITLE
Fix branding script hanging if one of the branding-file.list variables is empty or unset

### DIFF
--- a/bin/branding.sh
+++ b/bin/branding.sh
@@ -10,7 +10,13 @@ ARGS=()
 # Read branding files to environment variables and convert to search and replace args
 for t in $(cat $(dirname "$0")/branding-files.list);
 do
-  v="$(eval cat \$${t})"
+  # Keep going if file is not set, otherwise it'll hang on 'cat' command
+  if [ ! -z "$t" ]
+  then
+  	v=""
+  else
+  	v="$(eval cat \$${t})"	
+  fi
   ARGS+=("-e" "s%\@\@${t}\@\@%${v}%g;")
 done
 

--- a/bin/branding.sh
+++ b/bin/branding.sh
@@ -11,7 +11,7 @@ ARGS=()
 for t in $(cat $(dirname "$0")/branding-files.list);
 do
   # Keep going if file is not set, otherwise it'll hang on 'cat' command
-  if [ ! -z "$t" ]
+  if [ -n "$t" ]
   then
   	v=""
   else


### PR DESCRIPTION
This fixes an issue with the branding script handling if the "DESCRIPTION_FILE" variable is un-set or whitespace.  Before it would hang, now it will result in an empty result.

@reviewbybees 