### PR TITLE
Fix variable substitution with @ sign in branding strings

### DIFF
--- a/bin/branding.sh
+++ b/bin/branding.sh
@@ -17,6 +17,8 @@ do
   else
   	v="$(eval cat \$${t})"	
   fi
+  # Escape the @ signs in the variable as they will do bad things in Perl
+  v="$(echo $v | sed 's#\@#\\\@#g' )"
   ARGS+=("-e" "s%\@\@${t}\@\@%${v}%g;")
 done
 
@@ -24,6 +26,8 @@ done
 for t in $(cat $(dirname "$0")/branding.list);
 do
   v="$(eval echo \$${t})"
+  # Escape the @ signs in the variable as they will do bad things in Perl
+  v="$(echo $v | sed 's#\@#\\\@#g' )"
   ARGS+=("-e" "s%\@\@${t}\@\@%${v}%g;")
 done
 


### PR DESCRIPTION
This escapes the @ sign in branding variables to avoid causing incorrect results with perl substitution. 
Example of a bad string that caused issues before:   

`Kohsuke Kawaguchi <kk@kohsuke.org>`

[Builds on previous PR](https://github.com/jenkinsci/packaging/pull/14)

@reviewbybees 