### PR TITLE
[JENKINS-30137] set non_interactive for ruby sftp lib.

### DIFF
--- a/bin/list-packages.rb
+++ b/bin/list-packages.rb
@@ -9,7 +9,8 @@ def list_packages(path,glob,rel)
 	# user name and server name
 	u,s=ENV['PKGSERVER'].split("@")
 
-    Net::SFTP.start(s,u) do |sftp|
+    options = { :non_interactive => true }
+    Net::SFTP.start(s,u, options) do |sftp|
         debs = [];
         sftp.dir.glob(path,glob) { |f| debs << f }
         


### PR DESCRIPTION
The ruby sftp library will try and prompt for passwords etc which is
doomed to fail on a CI system in its default config.
Added the `non_interactive` option so that there should never be any
interaction.

@reviewbybees esp @kohsuke to make sure this won't cause a regression in his environment.