### PR TITLE
authenticate the CLI against the server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,9 @@ ${CLI}:
 	mv $@.tmp $@
 
 
+cliauth: ${CLI}
+	java -jar jenkins-cli.jar login --username ${JENKINS_USERNAME} --password ${JENKINS_PASSWORD}
+
 
 test.local.setup:
 	# start a test Apache server that acts as package server


### PR DESCRIPTION
jenkins needs security and the CLI does not yet support support [ssh-agents](https://github.com/jenkinsci/jenkins/pull/920) so add a make target so that we can login and store the credentials on a CI system..

Urgh - this makes me feel very unwell.

@reviewbybees esp @kohsuke 