### PR TITLE
Add the ability to specify the location of the ssh identity.

### DIFF
--- a/msi/build-on-jenkins.sh
+++ b/msi/build-on-jenkins.sh
@@ -20,12 +20,19 @@ tar cvzf $D/bundle.tgz \
   -C $bin FindJava.java build.sh jenkins.exe.config bootstrapper.xml \
   -C $D jenkins.wxs key.pkcs12 key.password
 
+# we may not be able to control the location of the identity file and ssh does not support agent auth
+# so allow it to be optionally specified
+CLI_SSH_ARGS=
+if [ "x$JENKINS_SSH_KEY" != x ]; then
+  CLI_SSH_ARGS="-i $JENKINS_SSH_KEY"
+fi
+
 case "$(uname)" in
   CYGWIN*)
-    java -jar $TARGET/jenkins-cli.jar dist-fork -z `cygpath --dos $D/bundle.tgz` -f ${ARTIFACTNAME}.war="${WAR}" -l windows -F "${MSI}=${ARTIFACTNAME}-windows.zip" \
+    java -jar $TARGET/jenkins-cli.jar $CLI_SSH_ARGS dist-fork -z `cygpath --dos $D/bundle.tgz` -f ${ARTIFACTNAME}.war="${WAR}" -l windows -F "${MSI}=${ARTIFACTNAME}-windows.zip" \
           bash -ex build.sh ${ARTIFACTNAME}.war $encodedv ${ARTIFACTNAME} "${PRODUCTNAME}" ${PORT} ;;
   *)
-    java -jar $TARGET/jenkins-cli.jar dist-fork -z $D/bundle.tgz -f ${ARTIFACTNAME}.war="${WAR}" -l windows -F "${MSI}=${ARTIFACTNAME}-windows.zip" \
+    java -jar $TARGET/jenkins-cli.jar $CLI_SSH_ARGS dist-fork -z $D/bundle.tgz -f ${ARTIFACTNAME}.war="${WAR}" -l windows -F "${MSI}=${ARTIFACTNAME}-windows.zip" \
           bash -ex build.sh ${ARTIFACTNAME}.war $encodedv ${ARTIFACTNAME} "${PRODUCTNAME}" ${PORT} ;;
 esac
 

--- a/osx/build-on-jenkins.sh
+++ b/osx/build-on-jenkins.sh
@@ -22,7 +22,15 @@ cp ${KEYCHAIN_PASSWORD_FILE} $D/src/jenkins.keychain.password
 
 tar cvzf $D/script.tgz -C $D/src .
 
-java -jar $TARGET/jenkins-cli.jar dist-fork -z $D/script.tgz \
+# we may not be able to control the location of the identity file and ssh does not support agent auth
+# so allow it to be optionally specified
+CLI_SSH_ARGS=
+if [ "x$JENKINS_SSH_KEY" != x ]; then
+  CLI_SSH_ARGS="-i $JENKINS_SSH_KEY"
+fi
+
+
+java -jar $TARGET/jenkins-cli.jar $CLI_SSH_ARGS dist-fork -z $D/script.tgz \
   -f binary/${ARTIFACTNAME}.war="${WAR}" \
   -f build.sh=$bin/build.sh -l osx -F "${OSX}=${ARTIFACTNAME}.pkg" \
   /bin/bash -ex build.sh binary/${ARTIFACTNAME}.war $VERSION $ARTIFACTNAME "$PRODUCTNAME"


### PR DESCRIPTION
If "JENKINS_SSH_KEY" is set as an environment variable then use that as
the identity to pass to the Jenkins CLI.  Otherwise require the cli to
already be authenticated via jenkins-cli login as currently happens.

@reviewbybees 