### PR TITLE
cp fails when copying a file in a directory contianing a space.

### DIFF
--- a/msi/build-on-jenkins.sh
+++ b/msi/build-on-jenkins.sh
@@ -13,8 +13,8 @@ $(<$bin/jenkins.wxs)
 EOF
 " 2> /dev/null
 
-cp ${PKCS12_FILE} $D/key.pkcs12
-cp ${PKCS12_PASSWORD_FILE} $D/key.password
+cp "${PKCS12_FILE}" $D/key.pkcs12
+cp "${PKCS12_PASSWORD_FILE}" $D/key.password
 
 tar cvzf $D/bundle.tgz \
   -C $bin FindJava.java build.sh jenkins.exe.config bootstrapper.xml \


### PR DESCRIPTION
a directory may contain spaces - in which case the cp command will blow up
eg.

cp /scratch/workspace/my product/packaging/credentials/test.pkcs12 /tmp/1135/key.pkcs12
cp: target `/tmp/1135/key.pkcs12' is not a directory


@reviewbybees