### PR TITLE
Fix [JENKINS-31064] by bumping the java dependency to require JDK7

### DIFF
--- a/deb/build/debian/control
+++ b/deb/build/debian/control
@@ -8,7 +8,7 @@ Homepage: @@HOMEPAGE@@
 
 Package: @@ARTIFACTNAME@@
 Architecture: all
-Depends: ${misc:Depends}, daemon, adduser, psmisc, net-tools, default-jre-headless (>= 2:1.7) | java7-runtime-headless
+Depends: ${misc:Depends}, daemon, adduser, procps, psmisc, net-tools, default-jre-headless (>= 2:1.7) | java7-runtime-headless
 Conflicts: hudson
 Replaces: hudson
 Description: continuous integration system

--- a/deb/build/debian/control
+++ b/deb/build/debian/control
@@ -8,7 +8,7 @@ Homepage: @@HOMEPAGE@@
 
 Package: @@ARTIFACTNAME@@
 Architecture: all
-Depends: ${misc:Depends}, daemon, adduser, psmisc, default-jre-headless | java-runtime-headless
+Depends: ${misc:Depends}, daemon, adduser, psmisc, net-tools, default-jre-headless (>= 2:1.7) | java7-runtime-headless
 Conflicts: hudson
 Replaces: hudson
 Description: continuous integration system


### PR DESCRIPTION
[[JENKINS-31064](https://issues.jenkins-ci.org/browse/JENKINS-31064)

This is b/c as of Jenkins core 1.610, class files require Java 7
Additionally, added net-tools requires entry because init script needs it
Verified using the debian:wheezy docker image for installation, Jenkins starts cleanly and handles requests.

EDITED: removing silent init script failures component, this is a separate PR