### PR TITLE
WIP for fixing issue with license branding transformation

### DIFF
--- a/deb/build/build.sh
+++ b/deb/build/build.sh
@@ -13,7 +13,7 @@ mkdir -p $D
 cp -R $dir/* $D
 
 # Expand variables in the definition
-$BASE/bin/branding.sh $D/debian
+$BASE/bin/branding.py $D/debian
 
 cat > $D/debian/changelog << EOF
 ${ARTIFACTNAME} ($VERSION) unstable; urgency=low

--- a/setup.mk
+++ b/setup.mk
@@ -34,5 +34,5 @@ export LICENSE_TEXT_COLUMN:=$(shell fold -w 78 -s $(LICENSE_FILE))  # Format to 
 export LICENSE_TEXT_COMMENTED:=$(shell echo $(LICENSE_TEXT_COLUMN) | sed  's!^!\# !g' )
 
 # Put a dot in place of an empty line, and prepend a space
-export LICENSE_TEXT_DEB:=$(shell echo "$(LICENSE_TEXT_COLUMN)" | sed -e s!^$$!.!g -e s!^! !g )
+export LICENSE_TEXT_DEB:=$(shell echo "$(LICENSE_TEXT_COLUMN)" | sed -e 's!^$$!.!g' -e 's!^! !g' )
 

--- a/setup.mk
+++ b/setup.mk
@@ -30,9 +30,9 @@ export BASE:=$(CURDIR)
 
 # read license file and do reformatting for proper display
 export LICENSE_TEXT:=$(cat LICENSE_FILE)
-export LICENSE_TEXT_COLUMN:=$(fold -w 78 -s LICENSE_FILE)  # Format to 80 characters
-export LICENSE_TEXT_COMMENTED:=$(LICENSE_TEXT_COLUMN | sed -e 's/^/\# /g')
+export LICENSE_TEXT_COLUMN:=$(shell fold -w 78 -s $(LICENSE_FILE))  # Format to 80 characters
+export LICENSE_TEXT_COMMENTED:=$(shell echo $(LICENSE_TEXT_COLUMN) | sed  's/^/\# /g' )
 
 # Put a dot in place of an empty line, and prepend a space
-export LICENSE_TEXT_DEB:=$(LICENSE_TEXT_COLUMN | sed -e 's/^$/./g' -e 's/^/ /g')
+export LICENSE_TEXT_DEB:=$(shell echo "$(LICENSE_TEXT_COLUMN)" | sed -e s/^$/./g -e s/^/ /g )
 


### PR DESCRIPTION
Root cause of bad license file transformation is the use of fold & probably sed commands (which is legal bash, but in the make file needs to be appropriately shelled out). 

@jtnord -- any ideas?  This is the one we were talking about yesterday, I think it's stuck on a silly escape issue with the sed quoting though. (If you've got a notion, feel free to either comment or push directly to the PR branch). 

I have tested the following and it assigns correctly:  
```make
VAR:=cheese
MYVAR2:=$(shell echo $(VAR) | sed s/che/bag/g )
```

This line however raises an error with the sed:
```make
export LICENSE_TEXT_COMMENTED:=$(shell echo $(LICENSE_TEXT_COLUMN) | sed  's/^/\# /g' )
```

(I know because that's as far as it gets before errors). 

Error:
```
/bin/sh: 1: Syntax error: "(" unexpected
sed: -e expression #1, char 6: unterminated `s' command
```

My suspicion is something idiotically simple to do with special characters, but I'm puzzled because a very similar string works in a demo makefile.  Ideas?