### PR TITLE
Incorrect branding vars

### DIFF
--- a/rpm/build/SOURCES/jenkins.init.in
+++ b/rpm/build/SOURCES/jenkins.init.in
@@ -31,7 +31,7 @@
 ### END INIT INFO
 
 # Check for missing binaries (stale symlinks should not happen)
-JENKINS_WAR="@@WAR@@"
+JENKINS_WAR="~~WAR~~"
 test -r "$JENKINS_WAR" || { echo "$JENKINS_WAR not installed"; 
 	if [ "$1" = "stop" ]; then exit 0;
 	else exit 5; fi; }

--- a/rpm/build/SOURCES/jenkins.sysconfig.in
+++ b/rpm/build/SOURCES/jenkins.sysconfig.in
@@ -1,13 +1,13 @@
 ## Path:        Development/@@CAMELARTIFACTNAME@@
 ## Description: @@SUMMARY@@
 ## Type:        string
-## Default:     "@@HOME@@"
+## Default:     "~~HOME~~"
 ## ServiceRestart: jenkins
 #
 # Directory where Jenkins store its configuration and working
 # files (checkouts, build reports, artifacts, ...).
 #
-JENKINS_HOME="@@HOME@@"
+JENKINS_HOME="~~HOME~~"
 
 ## Type:        string
 ## Default:     ""

--- a/rpm/build/SPECS/jenkins.spec
+++ b/rpm/build/SPECS/jenkins.spec
@@ -65,7 +65,7 @@ rm -rf "%{buildroot}"
 %__ln_s "../../etc/init.d/%{name}" "%{buildroot}/usr/sbin/rc%{name}"
 
 %__install -D -m0600 "%{SOURCE2}" "%{buildroot}/etc/sysconfig/%{name}"
-%__sed -i 's,@@HOME@@,%{workdir},g' "%{buildroot}/etc/sysconfig/%{name}"
+%__sed -i 's,~~HOME~~,%{workdir},g' "%{buildroot}/etc/sysconfig/%{name}"
 
 %__install -D -m0644 "%{SOURCE3}" "%{buildroot}/etc/logrotate.d/%{name}"
 

--- a/rpm/build/SPECS/jenkins.spec
+++ b/rpm/build/SPECS/jenkins.spec
@@ -60,7 +60,7 @@ rm -rf "%{buildroot}"
 %__install -d "%{buildroot}/var/cache/%{name}"
 
 %__install -D -m0755 "%{SOURCE1}" "%{buildroot}/etc/init.d/%{name}"
-%__sed -i 's,@@WAR@@,%{_prefix}/%{name}.war,g' "%{buildroot}/etc/init.d/%{name}"
+%__sed -i 's,~~WAR~~,%{_prefix}/%{name}.war,g' "%{buildroot}/etc/init.d/%{name}"
 %__install -d "%{buildroot}/usr/sbin"
 %__ln_s "../../etc/init.d/%{name}" "%{buildroot}/usr/sbin/rc%{name}"
 

--- a/suse/build/SOURCES/jenkins.init.in
+++ b/suse/build/SOURCES/jenkins.init.in
@@ -31,7 +31,7 @@
 ### END INIT INFO
 
 # Check for missing binaries (stale symlinks should not happen)
-JENKINS_WAR="@@WAR@@"
+JENKINS_WAR="~~WAR~~"
 test -r "$JENKINS_WAR" || { echo "$JENKINS_WAR not installed"; 
 	if [ "$1" = "stop" ]; then exit 0;
 	else exit 5; fi; }

--- a/suse/build/SOURCES/jenkins.sysconfig.in
+++ b/suse/build/SOURCES/jenkins.sysconfig.in
@@ -1,13 +1,13 @@
 ## Path:        Development/@@PRODUCTNAME@@
 ## Description: @@SUMMARY@@
 ## Type:        string
-## Default:     "@@HOME@@"
+## Default:     "~~HOME~~"
 ## ServiceRestart: @@ARTIFACTNAME@@
 #
 # Directory where Jenkins store its configuration and working
 # files (checkouts, build reports, artifacts, ...).
 #
-JENKINS_HOME="@@HOME@@"
+JENKINS_HOME="~~HOME~~"
 
 ## Type:        string
 ## Default:     "/bin/bash"

--- a/suse/build/SPECS/jenkins.spec
+++ b/suse/build/SPECS/jenkins.spec
@@ -65,7 +65,7 @@ rm -rf "%{buildroot}"
 %__ln_s "../../etc/init.d/%{name}" "%{buildroot}/usr/sbin/rc%{name}"
 
 %__install -D -m0644 "%{SOURCE2}" "%{buildroot}/etc/sysconfig/%{name}"
-%__sed -i 's,@@HOME@@,%{workdir},g' "%{buildroot}/etc/sysconfig/%{name}"
+%__sed -i 's,~~HOME~~,%{workdir},g' "%{buildroot}/etc/sysconfig/%{name}"
 
 %__install -D -m0644 "%{SOURCE3}" "%{buildroot}/etc/logrotate.d/%{name}"
 

--- a/suse/build/SPECS/jenkins.spec
+++ b/suse/build/SPECS/jenkins.spec
@@ -60,7 +60,7 @@ rm -rf "%{buildroot}"
 %__install -d "%{buildroot}/var/cache/%{name}"
 
 %__install -D -m0755 "%{SOURCE1}" "%{buildroot}/etc/init.d/%{name}"
-%__sed -i 's,@@WAR@@,%{_prefix}/%{name}.war,g' "%{buildroot}/etc/init.d/%{name}"
+%__sed -i 's,~~WAR~~,%{_prefix}/%{name}.war,g' "%{buildroot}/etc/init.d/%{name}"
 %__install -d "%{buildroot}/usr/sbin"
 %__ln_s "../../etc/init.d/%{name}" "%{buildroot}/usr/sbin/rc%{name}"
 


### PR DESCRIPTION
@reviewbybees 

@@WAR@@ and @@HOME@@ are not branding variables - and so when using a more strict branding approach the build will fail.
As they are not branding variables they should not look and smell like branding variables.

Long term I question the sanity of doing this - as the paths being replaced can be known and created from the branding variables anyway (unless someone redefines _usr or _var macros in RPM - but that would be a WAAT...)