### PR TITLE
Set correct token for jenkins logrotate path.

### DIFF
--- a/rpm/build/SOURCES/jenkins.logrotate
+++ b/rpm/build/SOURCES/jenkins.logrotate
@@ -1,4 +1,4 @@
-/var/log/jenkins/@@ARTIFACTNAME@@.log /var/log/@@ARTIFACTNAME@@/access_log {
+/var/log/@@ARTIFACTNAME@@/@@ARTIFACTNAME@@.log /var/log/@@ARTIFACTNAME@@/access_log {
     compress
     dateext
     maxage 365

--- a/suse/build/SOURCES/jenkins.logrotate
+++ b/suse/build/SOURCES/jenkins.logrotate
@@ -1,4 +1,4 @@
-/var/log/jenkins/@@ARTIFACTNAME@@.log /var/log/@@ARTIFACTNAME@@/access_log {
+/var/log/@@ARTIFACTNAME@@/@@ARTIFACTNAME@@.log /var/log/@@ARTIFACTNAME@@/access_log {
     compress
     dateext
     maxage 365


### PR DESCRIPTION
Remove static path to /var/log/jenkins and replace with @@ARTIFACTNAME@@ to correct an issue where jenkins-oc path came up wrong for OC as /var/log/jenkins instead of /var/log/jenkins-oc.