### PR TITLE
Fixes issues with the debian and broken SuSe init scripts

### DIFF
--- a/deb/build/debian/control
+++ b/deb/build/debian/control
@@ -8,7 +8,7 @@ Homepage: @@HOMEPAGE@@
 
 Package: @@ARTIFACTNAME@@
 Architecture: all
-Depends: ${misc:Depends}, daemon, adduser, psmisc, net-tools, default-jre-headless (>= 2:1.7) | java7-runtime-headless
+Depends: ${misc:Depends}, daemon, adduser, procps, psmisc, net-tools, default-jre-headless (>= 2:1.7) | java7-runtime-headless
 Conflicts: hudson
 Replaces: hudson
 Description: continuous integration system

--- a/deb/build/debian/control
+++ b/deb/build/debian/control
@@ -8,7 +8,7 @@ Homepage: @@HOMEPAGE@@
 
 Package: @@ARTIFACTNAME@@
 Architecture: all
-Depends: ${misc:Depends}, daemon, adduser, psmisc, default-jre-headless | java-runtime-headless
+Depends: ${misc:Depends}, daemon, adduser, psmisc, net-tools, default-jre-headless (>= 2:1.7) | java7-runtime-headless
 Conflicts: hudson
 Replaces: hudson
 Description: continuous integration system

--- a/deb/build/debian/jenkins.init
+++ b/deb/build/debian/jenkins.init
@@ -180,10 +180,23 @@ do_stop()
     return 0
 }
 
+# Verify the process did in fact start successfully and didn't just bomb out
+do_check_started_ok() {
+    if [ $1 -ne 0 ]; then return $1; fi
+    get_running
+    if [ "$?" -eq 0 ]; then
+        return 2
+    else 
+        return 0
+    fi
+}
+
 case "$1" in
   start)
     log_daemon_msg "Starting $DESC" "$NAME"
     do_start
+    START_STATUS="$?"
+    do_check_started_ok "$START_STATUS"
     case "$?" in
         0|1) log_end_msg 0 ;;
         2) log_end_msg 1 ;;
@@ -207,6 +220,8 @@ case "$1" in
     case "$?" in
       0|1)
         do_start
+        START_STATUS="$?"
+        do_check_started_ok "$START_STATUS"
         case "$?" in
           0) log_end_msg 0 ;;
           1) log_end_msg 1 ;; # Old process is still running

--- a/deb/build/debian/jenkins.init
+++ b/deb/build/debian/jenkins.init
@@ -182,9 +182,10 @@ do_stop()
 
 # Verify the process did in fact start successfully and didn't just bomb out
 do_check_started_ok() {
-    if [ $1 -ne 0 ]; then return $1; fi
+    sleep 1
+    if [ "$1" -ne "0" ]; then return $1; fi
     get_running
-    if [ "$?" -eq 0 ]; then
+    if [ "$?" -eq "0" ]; then
         return 2
     else 
         return 0
@@ -199,7 +200,7 @@ case "$1" in
     do_check_started_ok "$START_STATUS"
     case "$?" in
         0|1) log_end_msg 0 ;;
-        2) log_end_msg 1 ;;
+        2) log_end_msg 1 ; exit 7 ;;
     esac
     ;;
   stop)
@@ -207,7 +208,7 @@ case "$1" in
     do_stop
     case "$?" in
         0|1) log_end_msg 0 ;;
-        2) log_end_msg 1 ;;
+        2) log_end_msg 1 ; exit 100 ;;
     esac
     ;;
   restart|force-reload)
@@ -221,11 +222,12 @@ case "$1" in
       0|1)
         do_start
         START_STATUS="$?"
+        sleep 1
         do_check_started_ok "$START_STATUS"
         case "$?" in
           0) log_end_msg 0 ;;
-          1) log_end_msg 1 ;; # Old process is still running
-          *) log_end_msg 1 ;; # Failed to start
+          1) log_end_msg 1 ; exit 100 ;; # Old process is still running
+          *) log_end_msg 1 ; exit 100 ;; # Failed to start
         esac
         ;;
       *)

--- a/rpm/build/SPECS/jenkins.spec
+++ b/rpm/build/SPECS/jenkins.spec
@@ -32,7 +32,8 @@ BuildRoot:	%{_tmppath}/build-%{name}-%{version}
 #    that there's no such packages. JRE/JDK RPMs from java.sun.com
 #    do not have this virtual package declarations. So for now,
 #    I'm dropping this requirement.
-# Requires:	java >= 1:1.6.0, procps
+# Requires:	java >= 1:1.6.0
+Requires: procps
 Obsoletes:  hudson
 PreReq:		/usr/sbin/groupadd /usr/sbin/useradd
 #PreReq:		%{fillup_prereq}

--- a/rpm/build/SPECS/jenkins.spec
+++ b/rpm/build/SPECS/jenkins.spec
@@ -32,7 +32,7 @@ BuildRoot:	%{_tmppath}/build-%{name}-%{version}
 #    that there's no such packages. JRE/JDK RPMs from java.sun.com
 #    do not have this virtual package declarations. So for now,
 #    I'm dropping this requirement.
-# Requires:	java >= 1:1.6.0
+# Requires:	java >= 1:1.6.0, procps
 Obsoletes:  hudson
 PreReq:		/usr/sbin/groupadd /usr/sbin/useradd
 #PreReq:		%{fillup_prereq}

--- a/suse/build/SOURCES/jenkins.init.in
+++ b/suse/build/SOURCES/jenkins.init.in
@@ -106,7 +106,7 @@ case "$1" in
                 else
                        HOME=$JENKINS_HOME startproc -n $JENKINS_NICE -s -e -l /var/log/@@ARTIFACTNAME@@.rc -u "$JENKINS_USER" -p "$JENKINS_PID_FILE" $JAVA_CMD $PARAMS
                 fi
-                JPROC=$( pgrep java -U jenkins )
+                JPROC=$( pgrep java -U $JENKINS_USER )
                 if [ -n "$JPROC" ]; then
                         echo "$JPROC" >"$JENKINS_PID_FILE"
                         rc_status -v

--- a/suse/build/SOURCES/jenkins.init.in
+++ b/suse/build/SOURCES/jenkins.init.in
@@ -106,9 +106,9 @@ case "$1" in
                 else
                        HOME=$JENKINS_HOME startproc -n $JENKINS_NICE -s -e -l /var/log/@@ARTIFACTNAME@@.rc -u "$JENKINS_USER" -p "$JENKINS_PID_FILE" $JAVA_CMD $PARAMS
                 fi
-                JPROC=$( find /proc -maxdepth 2 -user $JENKINS_USER -name exe -lname "*/bin/java" )
+                JPROC=$( pgrep java -U jenkins )
                 if [ -n "$JPROC" ]; then
-                        basename `dirname $JPROC` >"$JENKINS_PID_FILE"
+                        echo "$JPROC" >"$JENKINS_PID_FILE"
                         rc_status -v
                 else
                         rc_failed

--- a/suse/build/SPECS/jenkins.spec
+++ b/suse/build/SPECS/jenkins.spec
@@ -29,7 +29,7 @@ BuildRoot:	%{_tmppath}/build-%{name}-%{version}
 # provides >= 1.6.0 must specify the epoch, "java >= 1:1.6.0".
 #
 # java-1_6_0-sun provides this at least
-Requires:	java >= 1.6
+Requires:	java >= 1.6, procps
 Obsoletes:  hudson
 PreReq:		/usr/sbin/groupadd /usr/sbin/useradd
 #PreReq:		%{fillup_prereq}


### PR DESCRIPTION
Specifically [JENKINS-31348](https://issues.jenkins-ci.org/browse/JENKINS-31348) (broken SuSe init script due to abuse of the /proc system to find the Jenkins process) and the Debian script silently allowing Jenkins failures to pass [JENKINS-31064](https://issues.jenkins-ci.org/browse/JENKINS-31064). 

Builds on top of https://github.com/jenkinsci/packaging/pull/26

@reviewbybees 