### PR TITLE
Debian package postinst script attempts to remove /var/lib/jenkins when migrating from Hudson

### DIFF
--- a/deb/build/debian/jenkins.postinst
+++ b/deb/build/debian/jenkins.postinst
@@ -45,7 +45,7 @@ case "$1" in
             # This also ensures that the .??* wildcard matches something
             touch /var/lib/hudson/.from-hudson
             mv -f /var/lib/hudson/* /var/lib/hudson/.??* /var/lib/@@ARTIFACTNAME@@
-            rmdir /var/lib/@@ARTIFACTNAME@@
+            rmdir /var/lib/hudson
             find /var/lib/@@ARTIFACTNAME@@ -user hudson -exec chown $JENKINS_USER {} + || true
         fi
       


### PR DESCRIPTION
Hi,

I upgraded an old installation of Hudson 1.395 on Debian to the latest Jenkins LTS 1.625.2 and I encountered the following error:

    root@eureka:~# sudo dpkg -i jenkins_1.625.2_all.deb
    Selecting previously unselected package jenkins.
    dpkg: considering removing hudson in favour of jenkins ...
    dpkg: yes, will remove hudson in favour of jenkins
    (Reading database ... 92077 files and directories currently installed.)
    Unpacking jenkins (from jenkins_1.625.2_all.deb) ...
    [ ok ] Stopping Hudson Continuous Integration Server: hudson.
    Setting up jenkins (1.625.2) ...
    rmdir: failed to remove `/var/lib/jenkins': Directory not empty
    dpkg: error processing jenkins (--install):
     subprocess installed post-installation script returned error exit status 1
    Errors were encountered while processing:
     jenkins

The postinst script attempts to remove the `/var/lib/jenkins` directory instead of `/var/lib/hudson` after transferring the data to the new directory. It looks like this was accidentally changed in the commit 8e6f377 earlier this year. It affects the Debian package since the version 1.608.

Here is a simple patch fixing this issue.