### PR TITLE
Add and initially document installertest workflows

### DIFF
--- a/workflow/README.md
+++ b/workflow/README.md
@@ -10,7 +10,8 @@ Workflows for direct use as a full flow (from SCM) are parameterized workflows, 
 ## installertest.groovy: shared library of functions to run dockerized tests
 
 - Most people will want to use execute_install_testset to run a set of tests in parallel using multiple containers
-- Each test starts up a slightly customized container mimicking a stripped down linux VM, with the Jenkins user set up as a sudoer
+- Each test starts up a slightly customized container mimicking a stripped down linux VM, with the Jenkins user set up as a sudoer.
+- Containers only exist while the tests are run, and the number of non-cached image builds is limited
 - Installation tests are structured as a series of shell commands to run, with each command run in the container (which has the workspace mounted as a docker volume)
 - Caution: you can't use single quotes in your arguments, you will need to use double quotes because of how commands are passed in
 - Each command may have a name set, and each command's output will be archived to testresults

--- a/workflow/README.md
+++ b/workflow/README.md
@@ -23,3 +23,4 @@ Workflows for direct use as a full flow (from SCM) are parameterized workflows, 
 - Depends on the sudo docker images
 - To use this, you will need a set of built debian, rpm, and suse packages uploaded to specific URLs 
 - It is quite easy to customize this workflow if packages are already built locally earlier in the flow
+- Note that you will need some script approvals here

--- a/workflow/README.md
+++ b/workflow/README.md
@@ -1,0 +1,24 @@
+# How to use the installer test workflows
+
+There are two full workflow here that may be of interest.
+
+Workflows intended for library use include javadoc style comments for shared functions explaining parameters. 
+
+Workflows for direct use as a full flow (from SCM) are parameterized workflows, and include a header explaining the necessary parameters. 
+
+
+## installertest.groovy: shared library of functions to run dockerized tests
+
+- Most people will want to use execute_install_testset to run a set of tests in parallel using multiple containers
+- Each test starts up a slightly customized container mimicking a stripped down linux VM, with the Jenkins user set up as a sudoer
+- Installation tests are structured as a series of shell commands to run, with each command run in the container (which has the workspace mounted as a docker volume)
+- Caution: you can't use single quotes in your arguments, you will need to use double quotes because of how commands are passed in
+- Each command may have a name set, and each command's output will be archived to testresults
+
+
+## full-installertest-flow.groovy: a full test flow for testing Jenkins packaging on linux
+
+- This contains a set of shell commands to verify jenkins installation and service behavior
+- Depends on the sudo docker images
+- To use this, you will need a set of built debian, rpm, and suse packages uploaded to specific URLs 
+- It is quite easy to customize this workflow if packages are already built locally earlier in the flow

--- a/workflow/full-installertest-flow.groovy
+++ b/workflow/full-installertest-flow.groovy
@@ -18,7 +18,7 @@
 
 // Basic parameters
 String packagingTestBranch = (binding.hasVariable('packagingTestBranch')) ? packagingTestBranch : 'oss-dockerized-tests'
-String artifactName = (binding.hasVariable('artifactName')) ? artifactName : jenkins
+String artifactName = (binding.hasVariable('artifactName')) ? artifactName : 'jenkins'
 String jenkinsPort = (binding.hasVariable('jenkinsPort')) ? jenkinsPort : '8080'
 
 // Set up

--- a/workflow/full-installertest-flow.groovy
+++ b/workflow/full-installertest-flow.groovy
@@ -23,16 +23,16 @@ String jenkinsPort = (binding.hasVariable('jenkinsPort')) ? jenkinsPort : '8080'
 
 // Set up
 String scriptPath = 'packaging-docker/installtests'
-String checkCmd = "sudo $scriptPath/service-check.sh $artifactname $jenkinsPort"
+String checkCmd = "sudo $scriptPath/service-check.sh $artifactName $jenkinsPort"
 
 // Core tests represent the basic supported linuxes, extended tests build out coverage further
 def coreTests = []
 def extendedTests = []
 coreTests[0]=["sudo-ubuntu:14.04",  ["sudo $scriptPath/debian.sh installers/deb/*.deb", checkCmd]]
-coreTests[1]=["sudo-centos:7",      ["sudo $scriptPath/centos.sh installers/rpm/*.rpm", checkCmd]]
+coreTests[1]=["sudo-centos:6",      ["sudo $scriptPath/centos.sh installers/rpm/*.rpm", checkCmd]]
 coreTests[2]=["sudo-opensuse:13.2", ["sudo $scriptPath/suse.sh installers/suse/*.rpm", checkCmd]]
 extendedTests[0]=["sudo-debian:wheezy", ["sudo $scriptPath/debian.sh installers/deb/*.deb", checkCmd]]
-extendedTests[1]=["sudo-centos:6",      ["sudo $scriptPath/centos.sh installers/rpm/*.rpm", checkCmd]]
+extendedTests[1]=["sudo-centos:7",      ["sudo $scriptPath/centos.sh installers/rpm/*.rpm", checkCmd]]
 extendedTests[2]=["sudo-ubuntu:15.10",  ["sudo $scriptPath/debian.sh installers/deb/*.deb", checkCmd]]
 
 node(dockerLabel) {

--- a/workflow/full-installertest-flow.groovy
+++ b/workflow/full-installertest-flow.groovy
@@ -1,0 +1,66 @@
+// Full installer test flow, in one file
+// You must parameterize the build with: 
+
+// @stringparameter dockerLabel (node label for docker nodes)
+// @stringparameter packagingBranch - branch to use in packaging build
+
+// **ARTIFACTS URLS**
+// Note: you can use an artifact archived in a Job build by an artifact:// URL
+//  Ex: 'artifact://full/path/to/job/buildNr#artifact.ext'
+// @stringparameter debfile URL to Debian package
+// @stringparameter rpmfile URL to CentOS/RHEL RPM package
+// @stringparameter susefile URL to SUSE RPM package
+// @stringparameter testLibraryBranch branchname to load the installertests workflow lib from
+
+// Optional build parameters
+// @stringparameter (optional) port - port number to use in testing jenkins (default 8080)
+// @stringparameter (optional) artifact (jenkins artifactname, defaults to 'jenkins')
+
+// Basic parameters
+String dockerLabel = 'ubuntu-ope01'
+String packagingBranch = 'feature-docker-test-env-fixes'
+String artifactname = (artifact == null ) ? 'jenkins' : artifact
+String jenkinsPort = (port == null ) ? '8080' : "$port"
+
+// Set up
+String scriptPath = 'packaging-docker/installtests'
+String checkCmd = "sudo $scriptPath/service-check.sh $artifactname $jenkinsPort"
+
+// Core tests represent the basic supported linuxes, extended tests build out coverage further
+def coreTests = []
+def extendedTests = []
+coreTests[0]=["sudo-ubuntu:14.04",  ["sudo $scriptPath/debian.sh installers/deb/*.deb", checkCmd]]
+coreTests[1]=["sudo-centos:7",      ["sudo $scriptPath/centos.sh installers/rpm/*.rpm", checkCmd]]
+coreTests[2]=["sudo-opensuse:13.2", ["sudo $scriptPath/suse.sh installers/suse/*.rpm", checkCmd]]
+extendedTests[0]=["sudo-debian:wheezy", ["sudo $scriptPath/debian.sh installers/deb/*.deb", checkCmd]]
+extendedTests[1]=["sudo-centos:6",      ["sudo $scriptPath/centos.sh installers/rpm/*.rpm", checkCmd]]
+extendedTests[2]=["sudo-ubuntu:15.10",  ["sudo $scriptPath/debian.sh installers/deb/*.deb", checkCmd]]
+
+node(dockerLabel) {
+    stage "Load Lib"
+    sh 'rm -rf workflowlib'
+    dir ('workflowlib') {
+        git branch: testLibraryBranch, url: 'https://github.com/jenkinsci/packaging.git'
+        flow = load 'workflow/installertest.groovy'
+    }
+    
+
+    stage 'Fetch Installer'
+    flow.fetch_installers(debfile, rpmfile, susefile)
+    
+    sh 'rm -rf packaging-docker'
+    dir('packaging-docker') {
+      git branch: packagingBranch, url: 'https://github.com/jenkinsci/packaging.git'
+    }
+    
+    // Build the sudo dockerfiles
+    stage 'Build sudo dockerfiles'
+    withEnv(['HOME='+pwd()]) {
+        sh 'packaging-docker/docker/build-sudo-images.sh'
+    }
+    
+    stage 'Run Installation Tests'
+    String[] stepNames = ['install', 'servicecheck']
+    flow.execute_install_testset(coreTests, stepNames)
+    flow.execute_install_testset(extendedTests, stepNames)
+}

--- a/workflow/full-installertest-flow.groovy
+++ b/workflow/full-installertest-flow.groovy
@@ -18,8 +18,8 @@
 
 // Basic parameters
 String packagingTestBranch = (binding.hasVariable('packagingTestBranch')) ? packagingTestBranch : 'oss-dockerized-tests'
-String artifactName = (binding.hasVariable('artifactName') ? artifactName : jenkins
-String jenkinsPort = binding.hasVariable('jenkinsPort') ? jenkinsPort : '8080'
+String artifactName = (binding.hasVariable('artifactName')) ? artifactName : jenkins
+String jenkinsPort = (binding.hasVariable('jenkinsPort')) ? jenkinsPort : '8080'
 
 // Set up
 String scriptPath = 'packaging-docker/installtests'

--- a/workflow/full-installertest-flow.groovy
+++ b/workflow/full-installertest-flow.groovy
@@ -21,19 +21,6 @@ String packagingTestBranch = (binding.hasVariable('packagingTestBranch')) ? pack
 String artifactName = (binding.hasVariable('artifactName')) ? artifactName : 'jenkins'
 String jenkinsPort = (binding.hasVariable('jenkinsPort')) ? jenkinsPort : '8080'
 
-// Set up
-String scriptPath = 'packaging-docker/installtests'
-String checkCmd = "sudo $scriptPath/service-check.sh $artifactName $jenkinsPort"
-
-// Core tests represent the basic supported linuxes, extended tests build out coverage further
-def coreTests = []
-def extendedTests = []
-coreTests[0]=["sudo-ubuntu:14.04",  ["sudo $scriptPath/debian.sh installers/deb/*.deb", checkCmd]]
-coreTests[1]=["sudo-centos:6",      ["sudo $scriptPath/centos.sh installers/rpm/*.rpm", checkCmd]]
-coreTests[2]=["sudo-opensuse:13.2", ["sudo $scriptPath/suse.sh installers/suse/*.rpm", checkCmd]]
-extendedTests[0]=["sudo-debian:wheezy", ["sudo $scriptPath/debian.sh installers/deb/*.deb", checkCmd]]
-extendedTests[1]=["sudo-centos:7",      ["sudo $scriptPath/centos.sh installers/rpm/*.rpm", checkCmd]]
-extendedTests[2]=["sudo-ubuntu:15.10",  ["sudo $scriptPath/debian.sh installers/deb/*.deb", checkCmd]]
 
 node(dockerLabel) {
     stage "Load Lib"
@@ -42,24 +29,7 @@ node(dockerLabel) {
         git branch: packagingTestBranch, url: 'https://github.com/jenkinsci/packaging.git'
         flow = load 'workflow/installertest.groovy'
     }
-    
-
-    stage 'Fetch Installer'
-    flow.fetchInstallers(debfile, rpmfile, susefile)
-    
-    sh 'rm -rf packaging-docker'
-    dir('packaging-docker') {
-      git branch: packagingTestBranch, url: 'https://github.com/jenkinsci/packaging.git'
-    }
-    
-    // Build the sudo dockerfiles
-    stage 'Build sudo dockerfiles'
-    withEnv(['HOME='+pwd()]) {
-        sh 'packaging-docker/docker/build-sudo-images.sh'
-    }
-    
-    stage 'Run Installation Tests'
-    String[] stepNames = ['install', 'servicecheck']
-    flow.execute_install_testset(coreTests, stepNames)
-    flow.execute_install_testset(extendedTests, stepNames)
 }
+// Run the real tests within docker node label
+flow.fetchAndRunJenkinsInstallerTest(dockerLabel, rpmfile, susefile, debfile, 
+    packagingTestBranch, artifactName, jenkinsPort)

--- a/workflow/installertest.groovy
+++ b/workflow/installertest.groovy
@@ -139,7 +139,7 @@ def executeInstallTestset(def coreTests, def stepNames=null) {
 *  @param jenkinsPort port to use for speaking to jenkins (default 8080)
 */
 void runJenkinsInstallTests(String packagingBranch='master', 
-    String artifactName='jenkins', int jenkinsPort=8080) {
+    String artifactName='jenkins', String jenkinsPort='8080') {
   // Set up
   String scriptPath = 'packaging-docker/installtests'
   String checkCmd = "sudo $scriptPath/service-check.sh $artifactName $jenkinsPort"
@@ -178,7 +178,7 @@ void runJenkinsInstallTests(String packagingBranch='master',
 *  @param rpmUrl, suseUrl, debUrl:  artifact URLs to fetch packes from
 */
 void fetchAndRunJenkinsInstallerTest(String dockerNodeLabel, String rpmUrl, String suseUrl, String debUrl,
-  String packagingBranch='master', String artifactName='jenkins', int jenkinsPort=8080) {
+  String packagingBranch='master', String artifactName='jenkins', String jenkinsPort='8080') {
 
   node(dockerNodeLabel) {
     stage 'Fetch Installer'

--- a/workflow/installertest.groovy
+++ b/workflow/installertest.groovy
@@ -35,7 +35,7 @@ def getComponentsFromArtifactUrl(String url) {
  *              Example: {@code 'artifact://full/path/to/job/buildNr#artifact.ext'}.
  *              Anything else will be downloaded via wget
  */
-def fetch_artifact(String url) {
+def fetchArtifact(String url) {
   if (url == null) {
     fail 'required parameter url is missing'
   } else if (url.startsWith("artifact://")) {
@@ -49,18 +49,18 @@ def fetch_artifact(String url) {
 }
 
 // Pull down the artifacts, must run in a node block
-def fetch_installers(String debFileUrl, String rpmFileUrl, String suseFileUrl) {
+def fetchInstallers(String debFileUrl, String rpmFileUrl, String suseFileUrl) {
  sh 'rm -rf installers'
  dir('installers') {
    sh 'rm -rf deb rpm suse'
    dir('deb') {
-      fetch_artifact(debFileUrl)
+      fetchArtifact(debFileUrl)
    }
    dir('rpm') {
-      fetch_artifact(rpmFileUrl)
+      fetchArtifact(rpmFileUrl)
    }
    dir('suse') {
-      fetch_artifact(suseFileUrl)
+      fetchArtifact(suseFileUrl)
    }
   }
 }

--- a/workflow/installertest.groovy
+++ b/workflow/installertest.groovy
@@ -1,0 +1,133 @@
+// Replace colons in image with hyphens and append text
+String convertImageNameToString(String imageName, String append="") {
+    return (imageName+append).replaceAll(':','-')
+}
+
+/**
+ * Extracts the components from an {@code 'artifact://full/path/to/job/buildNr#artifact.ext'} type url.
+ * @param url the url
+ */
+@NonCPS
+def getComponentsFromArtifactUrl(String url) {
+    def pattern = /^artifact:\/\/([\/\w-_ ]+)\/(\d+)\/{0,1}#([\/\w\.]+)$/
+    def matcher = url =~ pattern
+    if (matcher) {
+        return [
+            item: matcher.group(1),
+            run: matcher.group(2),
+            artifact: matcher.group(3)
+        ]
+    } else {
+        throw new MalformedURLException("Expected format: 'artifact://full/path/to/job/buildNr#dir/artifact.ext' but got '${url}'")
+    }
+}
+
+/**
+ * Downloads an arifact to the workspace for further use in the flow.
+ * This is a stripped down version of a CloudBees workflow utility function
+ * It has been generified to use with artifacts besides jenkins.war (for packaging use)
+ * 
+ * Caveats:
+ * Needs to run inside a node block, and does not stash the artifact (avoids issues with big artifacts)
+ * For smaller artifacts, you may wish to stash them
+ * @param url the url to download
+ *              {@code 'artifact://' will be downloaded via CopyArtifact build step},
+ *              Example: {@code 'artifact://full/path/to/job/buildNr#artifact.ext'}.
+ *              Anything else will be downloaded via wget
+ */
+def fetch_artifact(String url) {
+  if (url == null) {
+    fail 'required parameter url is missing'
+  } else if (url.startsWith("artifact://")) {
+    echo "Fetching ${url} as artifact."
+    def comp = this.getComponentsFromArtifactUrl(url)
+    step([$class: 'CopyArtifact', filter: comp.artifact, projectName: comp.item, selector: [$class: 'SpecificBuildSelector', buildNumber: comp.run]])
+  } else {
+      echo "Fetching ${url} as URL file."
+      sh "wget -q ${url}"
+  }
+}
+
+// Pull down the artifacts, must run in a node block
+def fetch_installers(String debFileUrl, String rpmFileUrl, String suseFileUrl) {
+ sh 'rm -rf installers'
+ dir('installers') {
+   sh 'rm -rf deb rpm suse'
+   dir('deb') {
+      fetch_artifact(debFileUrl)
+   }
+   dir('rpm') {
+      fetch_artifact(rpmFileUrl)
+   }
+   dir('suse') {
+      fetch_artifact(suseFileUrl)
+   }
+  }
+}
+
+/** Runs a series of shell commands inside a docker image
+* The output of each command set is saved to a specific file and archived
+* Errors are propagated back up the chain. 
+* @param imageName docker image name to use (must support sudo, based off the sudoable images)
+* @param shellCommands List of (string) shell commands to run within the container
+* @param stepNames List of names for each shell command step, optional
+*                    (if not supplied, then the step # will be used)
+*/
+def run_shell_test(String imageName, def shellCommands, def stepNames=null) {
+  withEnv(['HOME='+pwd()]) { // Works around issues not being able to find docker install
+    def img = docker.image(imageName)
+    def fileName = convertImageNameToString(imageName,"-testOutput-")
+    img.inside() {  // Needs to be root for installation to work
+      try {
+        for(int i=0; i<shellCommands.size(); i++) {
+          String cmd = shellCommands.get(i)
+          def name = (stepNames != null && i < stepNames.size()) ? stepNames.get(i) : i
+          
+          // Workaround for two separate and painful issues
+          // One, in shells, piped commands return the exit status of the last command
+          // This means that errors in our actual command get eaten by the success of the tee we use to log
+          // Thus, failures would get eaten and ignored. 
+          // Setting pipefail in bash fixes this by returning the first nonsuccessful exit in the pipe
+
+          // Second, the sh workflow step often will use the default posix shell
+          // The default posix shell does not support pipefail, so we have to invoke bash to get it
+          
+          String argument = 'bash -c \'set -o pipefail; '+cmd+" | tee \"testresults/$fileName-$name"+'.log'+'" \''
+          sh argument
+        }
+      } catch (Exception ex) {
+        archive("testresults/$fileName"+'*.log')
+        throw ex
+      }
+      archive("testresults/$fileName"+'*.log')
+    }
+  } 
+}
+
+
+/** Install tests are a set of ["dockerImage:version", [shellCommand,shellCommand...]] entries
+* They will need sudo-able containers to install
+* @param stepNames Names for each step (if not supplied, the index of the step will be used)
+*/
+def execute_install_testset(def coreTests, def stepNames=null) {
+  // Within this node, execute our docker tests
+  def parallelTests = [:]
+  sh 'rm -rf testresults'
+  sh 'mkdir testresults'
+  for (int i=0; i<coreTests.size(); i++) {
+    def imgName = coreTests[i][0]
+    def tests = coreTests[i][1]
+    parallelTests[imgName] = {
+      try {
+       run_shell_test(imgName, tests, stepNames)
+      } catch(Exception e) {
+        // Keep on trucking so we can see the full failures list
+        echo "$e"
+        error("Test for $imgName failed")
+      }
+    }
+  }
+  parallel parallelTests
+}
+
+return this

--- a/workflow/installertest.groovy
+++ b/workflow/installertest.groovy
@@ -134,11 +134,11 @@ def executeInstallTestset(def coreTests, def stepNames=null) {
 *   Note: MUST be inside a node block! 
 *   Installers are in installers/deb/*.deb, installers/rpm/*.rpm, installers/suse/*.rpm
 *
-*  @param packagingBranch branch of packaging repo to use for test + docker images
+*  @param packagingTestBranch branch of packaging repo to use for test + docker images
 *  @param artifactName jenkins artifactName
 *  @param jenkinsPort port to use for speaking to jenkins (default 8080)
 */
-void runJenkinsInstallTests(String packagingBranch='master', 
+void runJenkinsInstallTests(String packagingTestBranch='master', 
     String artifactName='jenkins', String jenkinsPort='8080') {
   // Set up
   String scriptPath = 'packaging-docker/installtests'
@@ -178,13 +178,13 @@ void runJenkinsInstallTests(String packagingBranch='master',
 *  @param rpmUrl, suseUrl, debUrl:  artifact URLs to fetch packes from
 */
 void fetchAndRunJenkinsInstallerTest(String dockerNodeLabel, String rpmUrl, String suseUrl, String debUrl,
-  String packagingBranch='master', String artifactName='jenkins', String jenkinsPort='8080') {
+  String packagingTestBranch='master', String artifactName='jenkins', String jenkinsPort='8080') {
 
   node(dockerNodeLabel) {
     stage 'Fetch Installer'
     this.fetchInstallers(debUrl, rpmUrl, suseUrl)
 
-    this.runJenkinsInstallTests(packagingBranch, artifactName, jenkinsPort)
+    this.runJenkinsInstallTests(packagingTestBranch, artifactName, jenkinsPort)
   }
 }
 

--- a/workflow/installertest.groovy
+++ b/workflow/installertest.groovy
@@ -168,8 +168,8 @@ void runJenkinsInstallTests(String packagingTestBranch='master',
   
   stage 'Run Installation Tests'
   String[] stepNames = ['install', 'servicecheck']
-  this.execute_install_testset(coreTests, stepNames)
-  this.execute_install_testset(extendedTests, stepNames)
+  this.executeInstallTestset(coreTests, stepNames)
+  this.executeInstallTestset(extendedTests, stepNames)
 
 }
 


### PR DESCRIPTION
@abayer This is the initial hack here for OSSing the installer test flows.   I know docs are a little rough still, need to add links across the various components, but this should offer a good starting point