### PR TITLE
Fix debian package not using artifact name in chowning /var/run

### DIFF
--- a/deb/build/debian/jenkins.postinst
+++ b/deb/build/debian/jenkins.postinst
@@ -62,7 +62,7 @@ case "$1" in
 
         # older installations may use /var/run/jenkins
         # so make sure that they can delete too.
-        if test -d /var/run/jenkins ; then
+        if [ -d "/var/run/@@ARTIFACTNAME@@" ]; then
             chown -R $JENKINS_USER:$JENKINS_GROUP /var/run/@@ARTIFACTNAME@@
             chmod -R 750                          /var/run/@@ARTIFACTNAME@@
         fi


### PR DESCRIPTION
Fixes an issue with Debian packaging failing to install if:

* artifactname is *not* jenkins (example: jenkins-oc)
* /var/run/jenkins exists

Installation will fail during chown of /var/run/@@artifactname@@ because the directory does not exist.

Pending testing with installertest suite before review