### PR TITLE
Quote access to multilined string variables

### DIFF
--- a/setup.mk
+++ b/setup.mk
@@ -30,8 +30,8 @@ export BASE:=$(CURDIR)
 
 # read license file and do reformatting for proper display
 export LICENSE_TEXT:=$(shell cat "$(LICENSE_FILE)")
-export LICENSE_TEXT_COLUMN:=$(shell fold -w 78 -s $(LICENSE_FILE))  # Format to 80 characters
-export LICENSE_TEXT_COMMENTED:=$(shell echo $(LICENSE_TEXT_COLUMN) | sed  's!^!\# !g' )
+export LICENSE_TEXT_COLUMN:=$(shell fold -w 78 -s "$(LICENSE_FILE)")  # Format to 80 characters
+export LICENSE_TEXT_COMMENTED:=$(shell echo "$(LICENSE_TEXT_COLUMN)" | sed  's!^!\# !g' )
 
 # Put a dot in place of an empty line, and prepend a space
 export LICENSE_TEXT_DEB:=$(shell echo "$(LICENSE_TEXT_COLUMN)" | sed -e 's!^$$!.!g' -e 's!^! !g' )


### PR DESCRIPTION
Without this fix:
```
$ make WAR=../jenkins/war/target/jenkins.war BRAND=branding/jenkins-stable-rc.mk BUILDENV=env/release.mk war.publish
/bin/sh: -c: line 0: syntax error near unexpected token `('
/bin/sh: -c: line 0: `echo The MIT License  Copyright (c) 2004-, Kohsuke Kawaguchi, Sun Microsystems, Inc., and a number  of other of contributers  Permission is hereby granted, free of charge, to any person obtaining a copy  of this software and associated documentation files (the "Software"), to deal  in the Software without restriction, including without limitation the rights  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell  copies of the Software, and to permit persons to whom the Software is  furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in  all copies or substantial portions of the Software.  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE  SOFTWARE.   | sed  's!^!# !g' '
```

I still suspect the multiline license variables are wrong (collapsed to single line) but it is almost unused so it is hard to tell.