### PR TITLE
Switch to sh2ju, various related tweaks.

### DIFF
--- a/deb/build/build.sh
+++ b/deb/build/build.sh
@@ -2,6 +2,7 @@
 #
 # build a debian package from a release build
 
+hostname
 dir=$(dirname $0)
 
 # tmp dir

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,4 +11,6 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Requirement, note that v2 or later runs into issues with gem install due to Ruby 2 req
-RUN gem install net-sftp -v 1.1.1    
+RUN gem install net-sftp -v 1.1.1
+
+RUN chsh -s /bin/bash root

--- a/docker/sudo-centos6/Dockerfile
+++ b/docker/sudo-centos6/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:6
 MAINTAINER samvanoort@gmail.com
 
-RUN yum install -y sudo
+RUN yum install -y sudo bc which
 RUN useradd mysudoer -u @@MYUSERID@@
 RUN echo 'mysudoer ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 RUN sed -i 's/requiretty/!requiretty/g' /etc/sudoers

--- a/docker/sudo-centos7/Dockerfile
+++ b/docker/sudo-centos7/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:7
 MAINTAINER samvanoort@gmail.com
 
-RUN yum install -y sudo initscripts
+RUN yum install -y sudo initscripts bc which
 RUN useradd mysudoer -u @@MYUSERID@@
 RUN echo 'mysudoer ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 RUN sed -i 's/requiretty/!requiretty/g' /etc/sudoers

--- a/docker/sudo-debian/Dockerfile
+++ b/docker/sudo-debian/Dockerfile
@@ -2,6 +2,6 @@ FROM debian:wheezy
 MAINTAINER samvanoort@gmail.com
 
 RUN apt-get update 
-RUN apt-get install -y sudo
+RUN apt-get install -y sudo bc
 RUN useradd mysudoer -u @@MYUSERID@@
 RUN echo 'mysudoer ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers

--- a/docker/sudo-opensuse/Dockerfile
+++ b/docker/sudo-opensuse/Dockerfile
@@ -4,6 +4,6 @@ MAINTAINER samvanoort@gmail.com
 # For some reason the base docker image doesn't include chkconfig
 # So we install aaa_base for that and vim for tests and because it 
 # conveniently pulls in required perl deps needed for chkconfig too!
-RUN zypper --non-interactive in sudo aaa_base vim
+RUN zypper --non-interactive in sudo aaa_base vim bc which
 RUN useradd mysudoer -u @@MYUSERID@@
 RUN echo 'mysudoer ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers

--- a/docker/sudo-ubuntu14/Dockerfile
+++ b/docker/sudo-ubuntu14/Dockerfile
@@ -2,6 +2,6 @@ FROM ubuntu:14.04
 MAINTAINER samvanoort@gmail.com
 
 RUN apt-get update 
-RUN apt-get install -y sudo
+RUN apt-get install -y sudo bc
 RUN useradd mysudoer -u @@MYUSERID@@
 RUN echo 'mysudoer ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers

--- a/docker/sudo-ubuntu15/Dockerfile
+++ b/docker/sudo-ubuntu15/Dockerfile
@@ -2,6 +2,6 @@ FROM ubuntu:15.10
 MAINTAINER samvanoort@gmail.com
 
 RUN apt-get update 
-RUN apt-get install -y sudo
+RUN apt-get install -y sudo bc
 RUN useradd mysudoer -u @@MYUSERID@@
 RUN echo 'mysudoer ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers

--- a/installtests/centos.sh
+++ b/installtests/centos.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-set -ex  # Exit on any command failure
+set -x  # Exit on any command failure
+
+. `dirname $0`/sh2ju.sh
 
 if [ -z "$1" ]; then
   PKG_FOLDER='/tmp/packaging/target/rpm/*.rpm'
@@ -7,7 +9,11 @@ else
   PKG_FOLDER="$1"
 fi
 
-# Assume packaging is mounted to /tmp/packaging and built
-yum install -y curl
-yum install -y system-config-services java-1.7.0-openjdk  # First is b/c docker does not include service command, second is prereq
-yum -y --nogpgcheck localinstall "$PKG_FOLDER"
+dockerInstall() {
+    # Assume packaging is mounted to /tmp/packaging and built
+    yum install -y curl
+    yum install -y system-config-services java-1.7.0-openjdk  # First is b/c docker does not include service command, second is prereq
+    yum -y --nogpgcheck localinstall "$PKG_FOLDER"
+}
+
+juLog -name=centosDockerInstall dockerInstall

--- a/installtests/debian.sh
+++ b/installtests/debian.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-set -ex  # Exit on any command failure
+set -x  # Exit on any command failure
+
+. `dirname $0`/sh2ju.sh
 
 if [ -z "$1" ]; then
   PKG_FOLDER='/tmp/packaging/target/debian/*.deb'
@@ -7,10 +9,14 @@ else
   PKG_FOLDER="$1"
 fi
 
-# Installation within Docker
-# Assume packaging is mounted to /tmp/packaging and built
-apt-get update
-# Below will fail because missing dependencies, which apt-get will install
-dpkg -i "$PKG_FOLDER" || true
-apt-get install -fy && apt-get install -fy curl
-dpkg -i "$PKG_FOLDER"
+dockerInstall() {
+    # Installation within Docker
+    # Assume packaging is mounted to /tmp/packaging and built
+    apt-get update
+    # Below will fail because missing dependencies, which apt-get will install
+    dpkg -i "$PKG_FOLDER" || true
+    apt-get install -fy && apt-get install -fy curl
+    dpkg -i "$PKG_FOLDER"
+}
+
+juLog -name=debianDockerInstall dockerInstall

--- a/installtests/run_tests.sh
+++ b/installtests/run_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -x 
-set -e 
+
 
 # Get a path to use for absolute docker path to container
 PACKAGING_DIR=$(dirname $(dirname "$0"))

--- a/installtests/sh2ju.sh
+++ b/installtests/sh2ju.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+### Copyright 2010 Manuel Carrasco Moñino. (manolo at apache.org) 
+###
+### Licensed under the Apache License, Version 2.0.
+### You may obtain a copy of it at
+### http://www.apache.org/licenses/LICENSE-2.0
+
+###
+### A library for shell scripts which creates reports in jUnit format.
+### These reports can be used in Jenkins, or any other CI.
+###
+### Usage: 
+###     - Include this file in your shell script
+###     - Use juLog to call your command any time you want to produce a new report
+###        Usage:   juLog <options> command arguments
+###           options:
+###             -name="TestName" : the test name which will be shown in the junit report
+###             -error="RegExp"  : a regexp which sets the test as failure when the output matches it
+###             -ierror="RegExp" : same as -error but case insensitive
+###     - Junit reports are left in the folder 'result' under the directory where the script is executed.
+###     - Configure Jenkins to parse junit files from the generated folder
+###
+PATH=$PATH:/usr/bin
+
+asserts=00; errors=0; total=0; content=""
+date=`which gdate || which date`
+# create output folder
+juDIR=`pwd`/results
+mkdir -p "$juDIR" || exit
+
+# The name of the suite is calculated based in your script name
+suite=`basename $0 | sed -e 's/.sh$//' | tr "." "_"`
+
+# A wrapper for the eval method witch allows catching seg-faults and use tee
+errfile=/tmp/evErr.$$.log
+eVal() {
+  eval "$1"
+  echo $? | tr -d "\n" >$errfile
+}
+
+# Method to clean old tests
+juLogClean() {
+  echo "+++ Removing old junit reports from: $juDIR "
+  rm -f "$juDIR"/TEST-*
+}
+
+# Execute a command and record its results 
+juLog() {
+  
+  # parse arguments
+  ya=""; icase=""
+  while [ -z "$ya" ]; do  
+    case "$1" in
+  	  -name=*)   name=$asserts-`echo "$1" | sed -e 's/-name=//'`;   shift;;
+      -ierror=*) ereg=`echo "$1" | sed -e 's/-ierror=//'`; icase="-i"; shift;;
+      -error=*)  ereg=`echo "$1" | sed -e 's/-error=//'`;  shift;;
+      *)         ya=1;;
+    esac
+  done  
+
+  # use first arg as name if it was not given 
+  if [ -z "$name" ]; then
+    name="$asserts-$1" 
+    shift
+  fi
+
+  # calculate command to eval
+  [ -z "$1" ] && return
+  cmd="$1"; shift
+  while [ -n "$1" ]
+  do
+     cmd="$cmd \"$1\""
+     shift
+  done
+
+  # eval the command sending output to a file
+  outf=/var/tmp/ju$$.txt
+  >$outf
+  echo ""                         | tee -a $outf
+  echo "+++ Running case: $name " | tee -a $outf
+  echo "+++ working dir: "`pwd`           | tee -a $outf
+  echo "+++ command: $cmd"            | tee -a $outf
+  ini=`$date +%s.%N`
+  eVal "$cmd" 2>&1                | tee -a $outf
+  evErr=`cat $errfile`
+  rm -f $errfile
+  end=`date +%s.%N`
+  echo "+++ exit code: $evErr"        | tee -a $outf
+  
+  # set the appropriate error, based in the exit code and the regex  
+  [ $evErr != 0 ] && err=1 || err=0
+  out=`cat $outf | sed -e 's/^\([^+]\)/| \1/g'`
+  if [ $err = 0 -a -n "$ereg" ]; then
+      H=`echo "$out" | egrep $icase "$ereg"`
+      [ -n "$H" ] && err=1
+  fi
+  echo "+++ error: $err"         | tee -a $outf
+  rm -f $outf
+
+  # calculate vars
+  asserts=`expr $asserts + 1`
+  asserts=`printf "%.2d" $asserts`
+  errors=`expr $errors + $err`
+  time=`echo "$end - $ini" | bc -l`
+  total=`echo "$total + $time" | bc -l`
+
+  # write the junit xml report
+  ## failure tag
+  [ $err = 0 ] && failure="" || failure="
+      <failure type=\"ScriptError\" message=\"Script Error\"></failure>
+  "
+  ## testcase tag
+  content="$content
+    <testcase assertions=\"1\" name=\"$name\" time=\"$time\">
+    $failure
+    <system-out>
+<![CDATA[
+$out
+]]>
+    </system-out>
+    </testcase>
+  "
+  ## testsuite block
+  cat <<EOF > "$juDIR/TEST-$suite.xml"
+  <testsuite failures="0" assertions="$assertions" name="$suite" tests="1" errors="$errors" time="$total">
+    $content
+  </testsuite>
+EOF
+
+}
+

--- a/installtests/suse.sh
+++ b/installtests/suse.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-set -ex  # Exit on any command failure
+set -x  # Exit on any command failure
+
+. `dirname $0`/sh2ju.sh
 # Assume packaging is mounted to /tmp/packaging and built
 
 if [ -z "$1" ]; then
@@ -9,6 +11,10 @@ else
   PKG_FOLDER="$1"
 fi
 
-# Ignore signature verification and default to yes
-zypper --non-interactive in curl
-zypper --no-gpg-checks --non-interactive in $PKG_FOLDER
+dockerInstall() {
+    # Ignore signature verification and default to yes
+    zypper --non-interactive in curl
+    zypper --no-gpg-checks --non-interactive in $PKG_FOLDER
+}
+
+juLog -name=suseDockerInstall dockerInstall

--- a/workflow/full-installertest-flow.groovy
+++ b/workflow/full-installertest-flow.groovy
@@ -17,10 +17,9 @@
 // @stringparameter (optional) artifactName - (jenkins artifactname, defaults to 'jenkins')
 
 // Basic parameters
-String packagingTestBranch = (binding.hasVariable('packagingTestBranch')) ? packagingTestBranch : 'oss-dockerized-tests'
+String packagingTestBranch = (binding.hasVariable('packagingTestBranch')) ? packagingTestBranch : 'master'
 String artifactName = (binding.hasVariable('artifactName')) ? artifactName : 'jenkins'
 String jenkinsPort = (binding.hasVariable('jenkinsPort')) ? jenkinsPort : '8080'
-
 
 node(dockerLabel) {
     stage "Load Lib"

--- a/workflow/installertest.groovy
+++ b/workflow/installertest.groovy
@@ -205,7 +205,7 @@ def runShellTest(String imageName, def shellCommands, def stepNames=null) {
           // Second, the sh workflow step often will use the default posix shell
           // The default posix shell does not support pipefail, so we have to invoke bash to get it
           
-          String argument = cmd+" | tee \"testresults/${fileName}-${name}.log\""
+          String argument = "${cmd} | tee \"testresults/${fileName}-${name}.log\""
           sh argument
         }
       } catch (Exception ex) {

--- a/workflow/installertest.groovy
+++ b/workflow/installertest.groovy
@@ -205,7 +205,7 @@ def runShellTest(String imageName, def shellCommands, def stepNames=null) {
           // Second, the sh workflow step often will use the default posix shell
           // The default posix shell does not support pipefail, so we have to invoke bash to get it
           
-          String argument = 'bash -c \''+cmd+" | tee \"testresults/$fileName-$name"+'.log'+'" \''
+          String argument = cmd+" | tee \"testresults/${fileName}-${name}.log\""
           sh argument
         }
       } catch (Exception ex) {

--- a/workflow/installertest.groovy
+++ b/workflow/installertest.groovy
@@ -298,7 +298,7 @@ void runJenkinsInstallTests(String packagingTestBranch='master',
   // Run the actual work
   sh 'rm -rf packaging-docker'
   dir('packaging-docker') {
-    git branch: packagingTestBranch, url: 'https://github.com/abayer/packaging.git'
+    git branch: packagingTestBranch, url: 'https://github.com/jenkinsci/packaging.git'
   }
   
   // Build the sudo dockerfiles


### PR DESCRIPTION
- change format for specifying tests so we can have distinct shell
  script files for each distro, since sh2ju uses the filenames to
  determine the test suite.
- Stop failing all over the place when tests fail - keep going so we
  can actually archive the test results, unless things blow up real good.
- Add bc and which to the sudo images to make sh2ju happy.

cc @reviewbybees 