### PR TITLE
Fix sh2ju quoting

### DIFF
--- a/bin/rpm-sign
+++ b/bin/rpm-sign
@@ -5,7 +5,7 @@
 ## setting a custom value to an RPM macro, but rpm still insists on getting passphrase
 ## from terminal, even though we use GPG --passphrase-file option. This expect script
 ## feeds a dummy NL to make rpm happy.
-spawn ${argv0}.bin [lindex $argv 0]
+spawn "${argv0}.bin" [lindex $argv 0]
 expect -exact "Enter pass phrase: "
 send -- "\r"
 expect eof

--- a/bin/rpm-sign.bin
+++ b/bin/rpm-sign.bin
@@ -5,8 +5,8 @@ exec rpm \
   -D "%_gpg_name ignored" \
   -D "__gpg_check_password_cmd /bin/true" \
   -D "__gpg_sign_cmd %{__gpg} \
-      gpg --batch --no-use-agent --no-verbose --no-armor --passphrase-file=$GPG_PASSPHRASE_FILE \
-      --no-default-keyring --keyring=$GPG_KEYRING --secret-keyring=$GPG_SECRET_KEYRING \
+      gpg --batch --no-use-agent --no-verbose --no-armor --passphrase-file=\"$GPG_PASSPHRASE_FILE\" \
+      --no-default-keyring --keyring=\"$GPG_KEYRING\" --secret-keyring=\"$GPG_SECRET_KEYRING\" \
       %{?_gpg_digest_algo:--digest-algo %{_gpg_digest_algo}} \
       --no-secmem-warning \
       -sbo %{__signature_filename} %{__plaintext_filename}" --resign "$@"

--- a/installtests/centos.sh
+++ b/installtests/centos.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ux  # Exit on any command failure or unset variables.
 
-. $(dirname $0)/sh2ju.sh
+. "$(dirname $0)/sh2ju.sh"
 
 if [ -z "$1" ]; then
   PKG_FOLDER='/tmp/packaging/target/rpm/*.rpm'

--- a/installtests/debian.sh
+++ b/installtests/debian.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ux  # Exit on any command failure or unset variables.
 
-. $(dirname $0)/sh2ju.sh
+. "$(dirname $0)/sh2ju.sh"
 
 if [ -z "$1" ]; then
   PKG_FOLDER='/tmp/packaging/target/debian/*.deb'

--- a/installtests/service-check.sh
+++ b/installtests/service-check.sh
@@ -3,7 +3,7 @@
 # ARGUMENTS: first argument is the artifact name, jenkins by default if not given
 # Second argument is the port number it will run on for testing
 
-. `dirname $0`/sh2ju.sh
+. "$(dirname $0)/sh2ju.sh"
 
 SERVICE_WAIT=5
 MAX_START_WAIT=120

--- a/installtests/suse.sh
+++ b/installtests/suse.sh
@@ -2,7 +2,7 @@
 
 set -ux  # Exit on any command failure or unset variables.
 
-. $(dirname $0)/sh2ju.sh
+. "$(dirname $0)/sh2ju.sh"
 # Assume packaging is mounted to /tmp/packaging and built
 
 if [ -z "$1" ]; then

--- a/rpm/build/build.sh
+++ b/rpm/build/build.sh
@@ -15,7 +15,7 @@ pushd $D
 
   # sign the results
   for rpm in $(find RPMS -name '*.rpm'); do
-    "$BASE/bin/rpm-sign" $rpm
+    "$BASE/bin/rpm-sign" "${rpm}"
   done
 popd
 


### PR DESCRIPTION
Tests are still failing in large numbers, but that doesn't seem to be due to quotes. There's a red herring error message ("packaging-docker/installtests/sh2ju.sh: line 70: $1: unbound variable") - that really just means there are no additional arguments to the test command and we're only seeing this because we're using the "-u" flag to bash. 