### PR TITLE
Fix issues with 2.0 rc versions including illegal hyphens

### DIFF
--- a/setup.mk
+++ b/setup.mk
@@ -2,7 +2,7 @@
 export WAR?=$(error Required variable WAR must point to the jenkins.war file you are packaging)
 
 # sanitized version number
-export VERSION:=$(shell unzip -p "${WAR}" META-INF/MANIFEST.MF | grep Implementation-Version | cut -d ' ' -f2 | tr -d '\r' | sed -e "s/-SNAPSHOT//" | sed -e "s/-alpha-.*//" | sed -e "s/-beta-.*//")
+export VERSION:=$(shell unzip -p "${WAR}" META-INF/MANIFEST.MF | grep Implementation-Version | cut -d ' ' -f2 | tr -d '\r' | sed -e "s/-SNAPSHOT//" | sed -e "s/-alpha-.*//" | sed -e "s/-beta-.*//" | tr - .)
 
 # directory to place marker files for build artifacts
 export TARGET:=target


### PR DESCRIPTION
This was breaking 2.0 builds, since RC flags were added without alpha/beta: https://ci.jenkins-ci.org/job/jenkins_pipeline/branch/master/7/console

RPMs are not allowed to include hyphens in versions.