### PR TITLE
Fix handling of zombie processes

### DIFF
--- a/deb/build/debian/jenkins.init
+++ b/deb/build/debian/jenkins.init
@@ -129,7 +129,7 @@ do_start()
 # 
 get_running() 
 {
-    return `ps -U $JENKINS_USER --no-headers -f | egrep -e '(java|daemon)' | grep -c . `
+    return `ps -U $JENKINS_USER --no-headers -f | egrep -e '(java)' | grep -v defunct | grep -c . `
 }
 
 force_stop() 

--- a/installtests/service-check.sh
+++ b/installtests/service-check.sh
@@ -74,6 +74,7 @@ function repeatedly_test {
 # Fetch the PID values
 function set_pids {
     DAEMON_PID=$(ps -U $ARTIFACT_NAME aux | grep daemon | grep -v grep | awk '{print $2}')
+    echo "$(ps aux -U $ARTIFACT_NAME | grep 'java\|daemon' | grep -v grep)"
     JAVA_PID=$(ps -U $ARTIFACT_NAME aux | grep java | grep -v grep | awk '{print $2}')
     if [ -f "/var/run/$ARTIFACT_NAME/$ARTIFACT_NAME.pid"  ]; then
         PIDFILE="$(cat "/var/run/$ARTIFACT_NAME/$ARTIFACT_NAME.pid")"

--- a/installtests/service-check.sh
+++ b/installtests/service-check.sh
@@ -76,7 +76,7 @@ function set_pids {
     DAEMON_PID=$(ps -U jenkins aux | grep daemon | grep -v grep | awk '{print $2}')
     JAVA_PID=$(ps -U jenkins aux | grep java | grep -v grep | awk '{print $2}')
     if [ -f "/var/run/$ARTIFACT_NAME/$ARTIFACT_NAME.pid"  ]; then
-        PIDFILE=$(cat "/var/run/$ARTIFACT_NAME/$ARTIFACT_NAME.pid")
+        PIDFILE="$(cat "/var/run/$ARTIFACT_NAME/$ARTIFACT_NAME.pid")"
     else 
         PIDFILE=null
     fi
@@ -97,7 +97,7 @@ COMMAND='service "$ARTIFACT_NAME" status 2>&1'
 juLog -name=serviceStatusRunningTest repeatedly_test "$COMMAND" 0 "$MAX_START_WAIT" "$ARTIFACT_NAME service status after initial start"
 
 set_pids()
-juLog -name=initialServiceStartPid report_test "$ARTIFACT_NAME daemon PID/PIDFILE" $DAEMON_PID $PIDFILE "(no output)"
+juLog -name=initialServiceStartPid report_test "$ARTIFACT_NAME daemon PID/PIDFILE" "$DAEMON_PID" "$PIDFILE" "(no output)"
 
 # Try to curl the server and verify status resolves as started
 COMMAND='curl -sS 127.0.0.1:$PORT -o /dev/null 2>&1'
@@ -134,7 +134,7 @@ COMMAND='service "$ARTIFACT_NAME" status 2>&1'
 juLog -name=serviceRestartedCheckTest repeatedly_test "$COMMAND" 0 "$MAX_START_WAIT" "$ARTIFACT_NAME service status after restart from stopped state"
 
 set_pids()
-juLog -name=restartServiceAfterStopPid report_test "$ARTIFACT_NAME daemon PID/PIDFILE" $DAEMON_PID $PIDFILE "(no output)"
+juLog -name=restartServiceAfterStopPid report_test "$ARTIFACT_NAME daemon PID/PIDFILE" "$DAEMON_PID" "$PIDFILE" "(no output)"
 
 # Try to curl the server and verify status resolves as started
 COMMAND='curl -sS 127.0.0.1:$PORT -o /dev/null 2>&1'

--- a/installtests/service-check.sh
+++ b/installtests/service-check.sh
@@ -96,7 +96,7 @@ juLog -name=initialServiceStartTest report_test "$ARTIFACT_NAME initial service 
 COMMAND='service "$ARTIFACT_NAME" status 2>&1'
 juLog -name=serviceStatusRunningTest repeatedly_test "$COMMAND" 0 "$MAX_START_WAIT" "$ARTIFACT_NAME service status after initial start"
 
-set_pids()
+set_pids
 juLog -name=initialServiceStartPid report_test "$ARTIFACT_NAME daemon PID/PIDFILE" "$DAEMON_PID" "$PIDFILE" "(no output)"
 
 # Try to curl the server and verify status resolves as started
@@ -109,7 +109,7 @@ juLog -name=serviceRestartTest report_test "$ARTIFACT_NAME service first restart
 
 sleep $SERVICE_WAIT
 
-set_pids()
+set_pids
 juLog -name=restartStartPid report_test "$ARTIFACT_NAME daemon PID/PIDFILE" $DAEMON_PID $PIDFILE "(no output)"
 
 SERVICE_OUTPUT=$(service "$ARTIFACT_NAME" stop 2>&1)
@@ -120,7 +120,7 @@ juLog -name=serviceStopTest report_test "$ARTIFACT_NAME service stop" $SERVICE_E
 COMMAND='service "$ARTIFACT_NAME" status 2>&1'
 juLog -name=serviceStatusStoppedTest repeatedly_test "$COMMAND" 3 "$MAX_STOP_WAIT" "$ARTIFACT_NAME service status check when stopped"
 
-set_pids()
+set_pids
 juLog -name=stoppedServiceDaemonPid report_test "$ARTIFACT_NAME daemon PID absent" $DAEMON_PID "" "(no output)"
 juLog -name=stoppedServiceJavaPid report_test "$ARTIFACT_NAME java PID absent" $JAVA_PID "" "(no output)"
 juLog -name=stoppedServicePidFile report_test "$ARTIFACT_NAME pidfile absent" $PIDFILE "null" "(no output)"
@@ -133,7 +133,7 @@ juLog -name=serviceRestartFromStoppedTest report_test "$ARTIFACT_NAME service re
 COMMAND='service "$ARTIFACT_NAME" status 2>&1'
 juLog -name=serviceRestartedCheckTest repeatedly_test "$COMMAND" 0 "$MAX_START_WAIT" "$ARTIFACT_NAME service status after restart from stopped state"
 
-set_pids()
+set_pids
 juLog -name=restartServiceAfterStopPid report_test "$ARTIFACT_NAME daemon PID/PIDFILE" "$DAEMON_PID" "$PIDFILE" "(no output)"
 
 # Try to curl the server and verify status resolves as started

--- a/installtests/service-check.sh
+++ b/installtests/service-check.sh
@@ -73,8 +73,8 @@ function repeatedly_test {
 
 # Fetch the PID values
 function set_pids {
-    DAEMON_PID=$(ps -U $ARTIFACT_NAME aux | grep daemon | grep -v grep | awk '{print $2}')
-    echo "$(ps aux -U $ARTIFACT_NAME | grep 'java\|daemon' | grep -v grep)"
+    DAEMON_PID=$(ps -U $ARTIFACT_NAME aux | grep daemon | grep -v grep | grep -v defunct | awk '{print $2}')
+    echo "$(ps aux -U $ARTIFACT_NAME | grep 'java\|daemon' | grep -v defunct | grep -v grep)"
     JAVA_PID=$(ps -U $ARTIFACT_NAME aux | grep java | grep -v grep | grep -v defunct | awk '{print $2}')
     if [ -f "/var/run/$ARTIFACT_NAME/$ARTIFACT_NAME.pid"  ]; then
         PIDFILE="$(cat "/var/run/$ARTIFACT_NAME/$ARTIFACT_NAME.pid")"

--- a/installtests/service-check.sh
+++ b/installtests/service-check.sh
@@ -75,7 +75,7 @@ function repeatedly_test {
 function set_pids {
     DAEMON_PID=$(ps -U $ARTIFACT_NAME aux | grep daemon | grep -v grep | awk '{print $2}')
     echo "$(ps aux -U $ARTIFACT_NAME | grep 'java\|daemon' | grep -v grep)"
-    JAVA_PID=$(ps -U $ARTIFACT_NAME aux | grep java | grep -v grep | awk '{print $2}')
+    JAVA_PID=$(ps -U $ARTIFACT_NAME aux | grep java | grep -v grep | grep -v defunct | awk '{print $2}')
     if [ -f "/var/run/$ARTIFACT_NAME/$ARTIFACT_NAME.pid"  ]; then
         PIDFILE="$(cat "/var/run/$ARTIFACT_NAME/$ARTIFACT_NAME.pid")"
     else 

--- a/installtests/service-check.sh
+++ b/installtests/service-check.sh
@@ -110,7 +110,7 @@ juLog -name=serviceRestartTest report_test "$ARTIFACT_NAME service first restart
 
 sleep $SERVICE_WAIT
 
-JENKINS_JAVA_PROC_COUNT=$(ps -U $ARTIFACT_NAME aux | grep java | grep -v grep | wc -l)
+JENKINS_JAVA_PROC_COUNT=$(ps -U $ARTIFACT_NAME aux | grep java | grep -v grep | grep -v defunct| wc -l)
 juLog -name=serviceRetartJavaProcessCount report_test "Java process count for user after restart" $JENKINS_JAVA_PROC_COUNT 1 "no output"
 
 set_pids
@@ -120,7 +120,7 @@ SERVICE_OUTPUT=$(service "$ARTIFACT_NAME" stop 2>&1)
 SERVICE_EXIT_CODE=$?
 juLog -name=serviceStopTest report_test "$ARTIFACT_NAME service stop" $SERVICE_EXIT_CODE 0 $SERVICE_OUTPUT
 
-JENKINS_JAVA_PROC_COUNT=$(ps -U $ARTIFACT_NAME aux | grep java | grep -v grep | wc -l)
+JENKINS_JAVA_PROC_COUNT=$(ps -U $ARTIFACT_NAME aux | grep java | grep -v grep | grep -v defunct | wc -l)
 juLog -name=serviceStopNoJavaProcess report_test "Java process count for user after stop" $JENKINS_JAVA_PROC_COUNT 0 "no output"
 
 # Test status comes up as stopped eventually

--- a/installtests/service-check.sh
+++ b/installtests/service-check.sh
@@ -33,7 +33,7 @@ function report_test {
     if [[ -z "$2" && -z "$3" ]]; then
             echo "TEST PASSED - $1  with both inputs empty as expected"
     else
-        if [ "$2" -ne "$3" ]; then
+        if [ "$2" != "$3" ]; then
             echo "TEST FAILED - $1 - with status code $2, expected $3"
             echo "Test command output:"
             echo "$4"

--- a/installtests/service-check.sh
+++ b/installtests/service-check.sh
@@ -110,7 +110,7 @@ juLog -name=serviceRestartTest report_test "$ARTIFACT_NAME service first restart
 
 sleep $SERVICE_WAIT
 
-JENKINS_JAVA_PROC_COUNT=$(ps -U $ARTIFACT_NAME aux | grep java | grep -v grep | grep -v defunct| wc -l)
+JENKINS_JAVA_PROC_COUNT=$(ps -U $ARTIFACT_NAME aux | grep java | grep -v grep | grep -v daemon | grep -v defunct| wc -l)
 juLog -name=serviceRetartJavaProcessCount report_test "Java process count for user after restart" $JENKINS_JAVA_PROC_COUNT 1 "no output"
 
 set_pids


### PR DESCRIPTION
Resolves the issues noted in [JENKINS-32057](https://issues.jenkins-ci.org/browse/JENKINS-32057) - root cause of that was the init script and installtests are not filtering defunct "zombie" processes.

Adds a set of tests for PID handling & correct process counts as well.