### PR TITLE
Clean up installers during installer testing workflow

### DIFF
--- a/workflow/installertest.groovy
+++ b/workflow/installertest.groovy
@@ -309,8 +309,14 @@ void runJenkinsInstallTests(String packagingTestBranch='master',
   
   stage 'Run Installation Tests'
   String[] stepNames = ['install', 'servicecheck']
-  this.executeInstallTestset(osesToTest("core"), scriptPath, artifactName, jenkinsPort, stepNames)
-  this.executeInstallTestset(osesToTest("extended"), scriptPath, artifactName, jenkinsPort, stepNames)
+  try {
+    this.executeInstallTestset(osesToTest("core"), scriptPath, artifactName, jenkinsPort, stepNames)
+    this.executeInstallTestset(osesToTest("extended"), scriptPath, artifactName, jenkinsPort, stepNames)  
+  } catch (Exception ex) {
+    throw ex
+  } finally {
+    sh 'rm -rf installers || true'
+  }
 }
 
 /** Fetch jenkins artifacts and run installer tests


### PR DESCRIPTION
Does cleanup on the installer binaries when running installer testing workflow to avoid cluttering the workspace

@reviewbybees 