### PR TITLE
[JENKINS-37583] Do not include quotes in SSH_OPTS

### DIFF
--- a/env/release.mk
+++ b/env/release.mk
@@ -7,7 +7,7 @@ export JENKINS_URL=https://cloudbees.ci.cloudbees.com/
 
 # the host to publish bits to
 export PKGSERVER=mirrorbrain@pkg.jenkins.io
-export SSH_OPTS="-p 22"
+export SSH_OPTS=-p 22
 
 # where to put binary files
 export WARDIR=/srv/releases/jenkins/war${RELEASELINE}

--- a/env/test.mk
+++ b/env/test.mk
@@ -7,7 +7,7 @@ export JENKINS_URL=https://cloudbees.ci.cloudbees.com/
 
 # the host to publish bits to
 export PKGSERVER=${USER}@localhost
-export SSH_OPTS=""
+export SSH_OPTS=
 
 # where to put binary files
 export TESTDIR=$(realpath .)/pkg.jenkins.io


### PR DESCRIPTION
See [JENKINS-37583](https://issues.jenkins-ci.org/browse/JENKINS-37583)

Seems like make `export` can handle spaces properly. Have tested it 

@reviewbybees 