### PR TITLE
[JENKINS-36403] Fixes following newly added SSH_OPTS env variable

### DIFF
--- a/bin/list-packages.rb
+++ b/bin/list-packages.rb
@@ -8,8 +8,12 @@ require 'net/sftp' # gem install net-sftp
 def list_packages(path,glob,rel)
 	# user name and server name
 	u,s=ENV['PKGSERVER'].split("@")
+        # Look for port option
+        portOption = ENV['SSH_OPTS'].scan(/-p [0-9]+/)
+        # Get port if set
+        p = portOption.empty? ? 22 : portOption.first.split(" ").last
 
-    Net::SFTP.start(s,u) do |sftp|
+    Net::SFTP.start(s,u,:port=>p) do |sftp|
         debs = [];
         sftp.dir.glob(path,glob) { |f| debs << f }
         

--- a/env/release.mk
+++ b/env/release.mk
@@ -7,7 +7,8 @@ export JENKINS_URL=https://cloudbees.ci.cloudbees.com/
 
 # the host to publish bits to
 export PKGSERVER=mirrorbrain@pkg.jenkins.io
-export SSH_OPTS="-p 22"
+export SSH_OPTS=-p 22
+export SCP_OPTS=-P 22
 
 # where to put binary files
 export WARDIR=/srv/releases/jenkins/war${RELEASELINE}

--- a/env/test.mk
+++ b/env/test.mk
@@ -7,7 +7,8 @@ export JENKINS_URL=https://cloudbees.ci.cloudbees.com/
 
 # the host to publish bits to
 export PKGSERVER=${USER}@localhost
-export SSH_OPTS=""
+export SSH_OPTS=
+export SCP_OPTS=
 
 # where to put binary files
 export TESTDIR=$(realpath .)/pkg.jenkins.io

--- a/suse/publish/publish.sh
+++ b/suse/publish/publish.sh
@@ -24,9 +24,9 @@ pushd $D
   ssh $SSH_OPTS $PKGSERVER createrepo --update -o "'$SUSE_WEBDIR'" "'$SUSEDIR/'"
 
   # sign the final artifact and upload the signature
-  scp $SSH_OPTS "$PKGSERVER:$(echo $SUSE_WEBDIR | sed 's/ /\\ /g')/repodata/repomd.xml" repodata/
+  scp $SCP_OPTS "$PKGSERVER:$(echo $SUSE_WEBDIR | sed 's/ /\\ /g')/repodata/repomd.xml" repodata/
 
   gpg --batch --no-use-agent --no-default-keyring --keyring "$GPG_KEYRING" --secret-keyring="$GPG_SECRET_KEYRING" --passphrase-file "$GPG_PASSPHRASE_FILE" \
     -a --detach-sign --yes repodata/repomd.xml
-  scp $SSH_OPTS repodata/repomd.xml.asc "$PKGSERVER:$(echo $SUSE_WEBDIR | sed 's/ /\\ /g')/repodata/"
+  scp $SCP_OPTS repodata/repomd.xml.asc "$PKGSERVER:$(echo $SUSE_WEBDIR | sed 's/ /\\ /g')/repodata/"
 popd


### PR DESCRIPTION
There were changes made in #62 to allow custom ssh ports for the packaging scripts. 

The bit included in this PR was missed and causes errors when using a port different from 22.

- [x] Fix in ruby script to use correct port
- [x] Use scp ops since they are not equivalent to ssh ops

@reviewbybees esp. @jtnord 