### PR TITLE
[JENKINS-37721] the service in the jenkins.xml must match what wix installed

### DIFF
--- a/msi/build-on-jenkins.sh
+++ b/msi/build-on-jenkins.sh
@@ -30,10 +30,10 @@ fi
 case "$(uname)" in
   CYGWIN*)
     java -jar $TARGET/jenkins-cli.jar $CLI_SSH_ARGS dist-fork -z `cygpath --dos $D/bundle.tgz` -f ${ARTIFACTNAME}.war="${WAR}" -l "windows && packaging" -F "${MSI}=${ARTIFACTNAME}-windows.zip" \
-          bash -ex build.sh ${ARTIFACTNAME}.war $encodedv ${ARTIFACTNAME} "${PRODUCTNAME}" ${PORT} ;;
+          bash -ex build.sh ${ARTIFACTNAME}.war $encodedv ${ARTIFACTNAME} "${PRODUCTNAME}" ${PORT} ${CAMELARTIFACTNAME} ;;
   *)
     java -jar $TARGET/jenkins-cli.jar $CLI_SSH_ARGS dist-fork -z $D/bundle.tgz -f ${ARTIFACTNAME}.war="${WAR}" -l "windows && packaging" -F "${MSI}=${ARTIFACTNAME}-windows.zip" \
-          bash -ex build.sh ${ARTIFACTNAME}.war $encodedv ${ARTIFACTNAME} "${PRODUCTNAME}" ${PORT} ;;
+          bash -ex build.sh ${ARTIFACTNAME}.war $encodedv ${ARTIFACTNAME} "${PRODUCTNAME}" ${PORT} ${CAMELARTIFACTNAME} ;;
 esac
 
 touch ${MSI}


### PR DESCRIPTION
Make sure that the service name used by `jenkins.exe` is the same as the
service name registered by the msi.

Not an issue for vanilla Jenkins as the registry is case insensitive and
the fact that jenkins != Jenkins is ok, however when the artifact name
contains a dash such as jenkins-oc and the camel artifact name is
forbidden to cotain dashes such that they artifact name is not jusy a
lower case equivallent of camelartifactname then things do not work.

Whilst I was there I also corrected the description of the service in the
XML - ot that it is used , but more because it looks better (and someone
could use this to install the service if they did not want to use the MSI
by copying the files and running `jenkins.exe install`

@reviewbybees - this internally maps to CJP-4641