### PR TITLE
Create dedicated build user for packaging container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,15 @@
 FROM ubuntu:14.04
 MAINTAINER svanoort <samvanoort@gmail.com>
 
+# User id of the build user
+ARG uid=4242
+ENV uid $uid
+
+# Group id of the build user
+ARG gid=4242
+ENV gid $gid
+
+RUN groupadd builder -g $gid && useradd builder -u $uid -g $gid -m -d /home/builder
 
 # Dependencies plus vim for convenience, wget if you're trying to get fancy
 RUN apt-get update \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,20 +2,20 @@ FROM ubuntu:14.04
 MAINTAINER svanoort <samvanoort@gmail.com>
 
 # User id of the build user
-ARG uid=4242
+ARG uid=1000
 ENV uid $uid
 
 # Group id of the build user
-ARG gid=4242
+ARG gid=1000
 ENV gid $gid
 
-RUN groupadd builder -g $gid && useradd builder -u $uid -g $gid -m -d /home/builder
+RUN groupadd jenkins -g $gid && useradd jenkins -u $uid -g $gid -m -d /home/jenkins
 
 # Dependencies plus vim for convenience, wget if you're trying to get fancy
 RUN apt-get update \
   && apt-get install -y make unzip devscripts debhelper rpm expect createrepo ruby maven openjdk-7-jre \
   && apt-get install -y vim git \
-  && apt-get install -y wget \ 
+  && apt-get install -y wget \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
Add dedicated build users with configurable gid and uid. Otherwise, when used from `docker.build( ... ).inside { ... }`, the build is running with artificial uid/gid combination without proper environment configured causing tools to fail.

https://groups.google.com/forum/#!topic/jenkinsci-dev/BHGAEcQK7UE
