### PR TITLE
[JENKINS-38206] Add the artifact name to the Windows installer

### DIFF
--- a/msi/build.sh
+++ b/msi/build.sh
@@ -51,7 +51,7 @@ candle -dJreDir="$JREDIR" -dWAR="$war" -dJavaExeId=$JavaExeId -nologo -ext WixUI
 light -o ${ARTIFACTNAME}.msi -sval -nologo -dcl:high -ext WixUIExtension -ext WixUtilExtension -ext WixFirewallExtension jenkins.wixobj jre.wixobj
 
 set +x
-signtool sign /v /f key.pkcs12 /p $(cat key.password) /t http://timestamp.verisign.com/scripts/timestamp.dll ${ARTIFACTNAME}.msi
+signtool sign /v /f key.pkcs12 /p $(cat key.password) /t http://timestamp.verisign.com/scripts/timestamp.dll /d "$ARTIFACTNAME" ${ARTIFACTNAME}.msi
 set -x
 
 zip ${ARTIFACTNAME}-windows.zip ${ARTIFACTNAME}.msi

--- a/msi/build.sh
+++ b/msi/build.sh
@@ -51,7 +51,7 @@ candle -dJreDir="$JREDIR" -dWAR="$war" -dJavaExeId=$JavaExeId -nologo -ext WixUI
 light -o ${ARTIFACTNAME}.msi -sval -nologo -dcl:high -ext WixUIExtension -ext WixUtilExtension -ext WixFirewallExtension jenkins.wixobj jre.wixobj
 
 set +x
-signtool sign /v /f key.pkcs12 /p $(cat key.password) /t http://timestamp.verisign.com/scripts/timestamp.dll /d "$ARTIFACTNAME" ${ARTIFACTNAME}.msi
+signtool sign /v /f key.pkcs12 /p $(cat key.password) /t http://timestamp.verisign.com/scripts/timestamp.dll /d "${ARTIFACTNAME}" ${ARTIFACTNAME}.msi
 set -x
 
 zip ${ARTIFACTNAME}-windows.zip ${ARTIFACTNAME}.msi


### PR DESCRIPTION
[JENKINS-38206](https://issues.jenkins-ci.org/browse/JENKINS-38206)

Normally the signed file is a random string of characters, which doesn't make sense.  By adding the /d (description ) here, the name of the requesting program will match the .msi file.

@reviewbybees 