### PR TITLE
[JENKINS-38134] Use same file for all shasums in the same folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,10 @@ docker.test: docker.images
 war: ${WAR}
 war.publish: ${WAR}
 	ssh ${SSH_OPTS} ${PKGSERVER} mkdir -p "'${WARDIR}/${VERSION}/'"
-	sha256sum ${WAR} > ${WAR_SHASUM}
+	rsync -avz -e "ssh ${SSH_OPTS}" "${WAR}" "${PKGSERVER}:${WARDIR}/${VERSION}/${ARTIFACTNAME}.war"
+	sha256sum ${WAR} | sed 's, .*/, ,' > ${WAR_SHASUM}
 	cat ${WAR_SHASUM}
-	rsync -avz -e "ssh ${SSH_OPTS}" "${WAR}" "${WAR_SHASUM}" "${PKGSERVER}:${WARDIR}/${VERSION}/${ARTIFACTNAME}.war"
+	cat ${WAR_SHASUM} | ssh ${SSH_OPTS} ${PKGSERVER} "cat >> ${WARDIR}/${VERSION}/SHA256SUMS"
 
 
 

--- a/msi/publish.sh
+++ b/msi/publish.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -ex
-sha256sum ${MSI} > ${MSI_SHASUM}
+rsync -avz -e "ssh $SSH_OPTS" "${MSI}" "$PKGSERVER:$MSIDIR/"
+sha256sum ${MSI} | sed 's, .*/, ,' > ${MSI_SHASUM}
 cat ${MSI_SHASUM}
-rsync -avz -e "ssh $SSH_OPTS" "$MSI" "$MSI_SHASUM" "$PKGSERVER:$MSIDIR/"
+cat ${MSI_SHASUM} | ssh ${SSH_OPTS} ${PKGSERVER} "cat >> $MSIDIR/SHA256SUMS"

--- a/osx/publish.sh
+++ b/osx/publish.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -ex
-sha256sum ${OSX} > ${OSX_SHASUM}
+rsync -avz -e "ssh $SSH_OPTS" "${OSX}" "$PKGSERVER:$OSXDIR/"
+sha256sum ${OSX} | sed 's, .*/, ,' > ${OSX_SHASUM}
 cat ${OSX_SHASUM}
-rsync -avz -e "ssh $SSH_OPTS" "${OSX}" "${OSX_SHASUM}" "$PKGSERVER:$OSXDIR/"
+cat ${OSX_SHASUM} | ssh ${SSH_OPTS} ${PKGSERVER} "cat >> $OSXDIR/SHA256SUMS"

--- a/setup.mk
+++ b/setup.mk
@@ -1,6 +1,5 @@
 # war file to release
 export WAR?=$(error Required variable WAR must point to the jenkins.war file you are packaging)
-export WAR_SHASUM=${WAR}-SHA256SUMS
 
 # sanitized version number
 export VERSION:=$(shell unzip -p "${WAR}" META-INF/MANIFEST.MF | grep Implementation-Version | cut -d ' ' -f2 | tr -d '\r' | sed -e "s/-SNAPSHOT//" | sed -e "s/-alpha-.*//" | sed -e "s/-beta-.*//" | sed -e "s/-rc-.*//" | tr - .)
@@ -11,13 +10,15 @@ export TARGET:=target
 # jenkins-cli.jar
 export CLI:=${TARGET}/jenkins-cli.jar
 
+export WAR_SHASUM=${TARGET}/SHA256SUMS
+
 # where to generate MSI file?
 export MSI:=${TARGET}/msi/${ARTIFACTNAME}-${VERSION}.zip
-export MSI_SHASUM:=${MSI}-SHA256SUMS
+export MSI_SHASUM:=${TARGET}/msi/SHA256SUMS
 
 # where to generate OSX PKG file?
 export OSX=${TARGET}/osx/${ARTIFACTNAME}-${VERSION}.pkg
-export OSX_SHASUM=${OSX}-SHA256SUMS
+export OSX_SHASUM=${TARGET}/osx/SHA256SUMS
 
 # where to generate Debian/Ubuntu DEB file?
 export DEB=${TARGET}/debian/${ARTIFACTNAME}_${VERSION}_all.deb


### PR DESCRIPTION
See [JENKINS-38134](https://issues.jenkins-ci.org/browse/JENKINS-38134)

Maintain just one SHA256SUMS file per folder with one entry per distributable in the folder instead of maintaining one SHA256SUMS file per distributable.

@reviewbybees @recena 