### PR TITLE
Ensure we're referring to the right base URL for packages

### DIFF
--- a/env/release.mk
+++ b/env/release.mk
@@ -24,9 +24,9 @@ export SUSE_WEBDIR=/var/www/pkg.jenkins.io.staging/opensuse${RELEASELINE}
 export  DEB_WEBDIR=/var/www/pkg.jenkins.io.staging/debian${RELEASELINE}
 
 # URL to the aforementioned webdir
-export  RPM_URL=http://pkg.jenkins.io/redhat${RELEASELINE}
-export SUSE_URL=http://pkg.jenkins.io/opensuse${RELEASELINE}
-export  DEB_URL=http://pkg.jenkins.io/debian${RELEASELINE}
+export  RPM_URL=https://pkg.jenkins.io/redhat${RELEASELINE}
+export SUSE_URL=https://pkg.jenkins.io/opensuse${RELEASELINE}
+export  DEB_URL=https://pkg.jenkins.io/debian${RELEASELINE}
 
 # additoinal contents to be overlayed during publishing
 export OVERLAY_CONTENTS=${BASE}/env/release


### PR DESCRIPTION
I /believe/ this is the right place to change things for INFRA-933, but I'm not
entirely sure whether this is the `RPM_URL` that will be used by `gen.rb` for
the generated page on https://pkg.jenkins.io/redhat

References [INFRA-933](https://issues.jenkins-ci.org/browse/INFRA-933)