### PR TITLE
[JENKINS-38134] Generate checksums for war, Windows and OS X distributables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,9 @@ setup:
 
 package: war msi osx deb rpm suse
 
-publish: war.publish msi.publish osx.publish deb.publish rpm.publish suse.publish
+publish: 
+	bash ./toolAvailability.sh
+	war.publish msi.publish osx.publish deb.publish rpm.publish suse.publish
 
 test: deb.test rpm.test suse.test
 

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,10 @@ docker.test: docker.images
 war: ${WAR}
 war.publish: ${WAR}
 	ssh ${SSH_OPTS} ${PKGSERVER} mkdir -p "'${WARDIR}/${VERSION}/'"
+	sha256sum ${WAR} | sed 's, .*/, ,' > ${WAR_SHASUM}
+	cat ${WAR_SHASUM}
 	rsync -avz -e "ssh ${SSH_OPTS}" "${WAR}" "${PKGSERVER}:${WARDIR}/${VERSION}/${ARTIFACTNAME}.war"
+	rsync -avz -e "ssh ${SSH_OPTS}" "${WAR_SHASUM}" "${PKGSERVER}:${WARDIR}/${VERSION}/"
 
 
 

--- a/msi/publish.sh
+++ b/msi/publish.sh
@@ -1,2 +1,4 @@
 #!/bin/bash -ex
-rsync -avz -e "ssh $SSH_OPTS" "$MSI" "$PKGSERVER:$MSIDIR/"
+sha256sum ${MSI} | sed 's, .*/, ,' > ${MSI_SHASUM}
+cat ${MSI_SHASUM}
+rsync -avz -e "ssh $SSH_OPTS" "$MSI" "$MSI_SHASUM" "$PKGSERVER:$MSIDIR/"

--- a/msi/publish.sh
+++ b/msi/publish.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -ex -o pipefail
 sha256sum ${MSI} | sed 's, .*/, ,' > ${MSI_SHASUM}
 cat ${MSI_SHASUM}
 rsync -avz -e "ssh $SSH_OPTS" "$MSI" "$MSI_SHASUM" "$PKGSERVER:$MSIDIR/"

--- a/osx/publish.sh
+++ b/osx/publish.sh
@@ -1,2 +1,4 @@
 #!/bin/bash -ex
-rsync -avz -e "ssh $SSH_OPTS" "${OSX}" "$PKGSERVER:$OSXDIR/"
+sha256sum ${OSX} | sed 's, .*/, ,' > ${OSX_SHASUM}
+cat ${OSX_SHASUM}
+rsync -avz -e "ssh $SSH_OPTS" "${OSX}" "${OSX_SHASUM}" "$PKGSERVER:$OSXDIR/"

--- a/osx/publish.sh
+++ b/osx/publish.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -ex -o pipefail
 sha256sum ${OSX} | sed 's, .*/, ,' > ${OSX_SHASUM}
 cat ${OSX_SHASUM}
 rsync -avz -e "ssh $SSH_OPTS" "${OSX}" "${OSX_SHASUM}" "$PKGSERVER:$OSXDIR/"

--- a/setup.mk
+++ b/setup.mk
@@ -1,5 +1,6 @@
 # war file to release
 export WAR?=$(error Required variable WAR must point to the jenkins.war file you are packaging)
+export WAR_SHASUM=${WAR}.sha256
 
 # sanitized version number
 export VERSION:=$(shell unzip -p "${WAR}" META-INF/MANIFEST.MF | grep Implementation-Version | cut -d ' ' -f2 | tr -d '\r' | sed -e "s/-SNAPSHOT//" | sed -e "s/-alpha-.*//" | sed -e "s/-beta-.*//" | sed -e "s/-rc-.*//" | tr - .)
@@ -12,9 +13,11 @@ export CLI:=${TARGET}/jenkins-cli.jar
 
 # where to generate MSI file?
 export MSI:=${TARGET}/msi/${ARTIFACTNAME}-${VERSION}.zip
+export MSI_SHASUM:=${MSI}.sha256
 
 # where to generate OSX PKG file?
 export OSX=${TARGET}/osx/${ARTIFACTNAME}-${VERSION}.pkg
+export OSX_SHASUM=${OSX}.sha256
 
 # where to generate Debian/Ubuntu DEB file?
 export DEB=${TARGET}/debian/${ARTIFACTNAME}_${VERSION}_all.deb

--- a/toolAvailability.sh
+++ b/toolAvailability.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -ex
+which sha256sum >/dev/null 2>&1 || { echo "sha256sum not found" >&2 ; exit 1 ; }
+


### PR DESCRIPTION
[JENKINS-38134](https://issues.jenkins-ci.org/browse/JENKINS-38134), supersedes #69 and #70

Generate and publish shasums for WAR and OSX and Windows installers.

@daniel-beck @rtyler @olivergondza can I have your thoughts?

@reviewbybees