### PR TITLE
Remove trailing white spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The location of this file is set via the `WAR` variable.
 
 # Generating packages
 Run `make package` to build all the native packages.
-At minimum, you have to specify the `WAR` variable that points to the war file to be packaged and a branding file (for licensing and package descriptions). 
+At minimum, you have to specify the `WAR` variable that points to the war file to be packaged and a branding file (for licensing and package descriptions).
 You will probably need to pass in the build environment and credentials.
 
 For example:
@@ -83,7 +83,7 @@ Specify the branding file via the `BRAND` variable.
 
 You can create your own branding definition to customize the package generation process.
 See [branding readme](branding/README.md) for more details. In the rest of the packaging script files,
-these branding parameters are referenced via `@@NAME@@` and get substituted by `bin/branding.py`.  
+these branding parameters are referenced via `@@NAME@@` and get substituted by `bin/branding.py`.
 To escape a string normally like @@VALUE@@, add an additional two @@ symbols as a prefix: @@@@VALUE@@.
 
 # Environment

--- a/rpm/build/SOURCES/jenkins.init.in
+++ b/rpm/build/SOURCES/jenkins.init.in
@@ -2,17 +2,17 @@
 #
 #     SUSE system statup script for Jenkins
 #     Copyright (C) 2007  Pascal Bleser
-#          
+#
 #     This library is free software; you can redistribute it and/or modify it
 #     under the terms of the GNU Lesser General Public License as published by
 #     the Free Software Foundation; either version 2.1 of the License, or (at
 #     your option) any later version.
-#			      
+#
 #     This library is distributed in the hope that it will be useful, but
 #     WITHOUT ANY WARRANTY; without even the implied warranty of
 #     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 #     Lesser General Public License for more details.
-#      
+#
 #     You should have received a copy of the GNU Lesser General Public
 #     License along with this library; if not, write to the Free Software
 #     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307,
@@ -32,7 +32,7 @@
 
 # Check for missing binaries (stale symlinks should not happen)
 JENKINS_WAR="~~WAR~~"
-test -r "$JENKINS_WAR" || { echo "$JENKINS_WAR not installed"; 
+test -r "$JENKINS_WAR" || { echo "$JENKINS_WAR not installed";
 	if [ "$1" = "stop" ]; then exit 0;
 	else exit 5; fi; }
 
@@ -50,7 +50,7 @@ JENKINS_PID_FILE="/var/run/@@ARTIFACTNAME@@.pid"
 # Source function library.
 . /etc/init.d/functions
 
-# Read config	
+# Read config
 [ -f "$JENKINS_CONFIG" ] && . "$JENKINS_CONFIG"
 
 # Set up environment accordingly to the configuration settings

--- a/rpm/publish/gen.rb
+++ b/rpm/publish/gen.rb
@@ -9,12 +9,12 @@ url=ENV['RPM_URL']
 puts <<-EOS
 <html>
 <!-- generated. do not manually edit -->
-<head> 
-  <title>RedHat Repository for #{productName}</title> 
-  <style> 
+<head>
+  <title>RedHat Repository for #{productName}</title>
+  <style>
     TH { font-weight: bold; }
     #rpms { border-spacing:3em 0em; margin-top:2em; }
-  </style> 
+  </style>
 </head>
 <body>
 <h1>RedHat Linux RPM packages for #{productName}</h1>


### PR DESCRIPTION
I don't like trailing whitespaces in source files I work with.  I could have done all of the files in this repository but only chose to do the ones I care about to help limit the size of the PR.  I replaced the trailing whitespace on my Mac using the following commands.

```bash
find README.md rpm -type f -exec sed -i.bak -E 's/[[:space:]]+$//' {} \;
git clean -xfd
```

If you wish to further do this on all files in this repository then simply execute:

```bash
find * -type f -exec sed -i.bak -E 's/[[:space:]]+$//' {} \;
git clean -xfd
```