### PR TITLE
Clarify the option to use for interface binding #66

### DIFF
--- a/deb/build/debian/jenkins.default
+++ b/deb/build/debian/jenkins.default
@@ -64,6 +64,7 @@ PREFIX=/$NAME
 
 # arguments to pass to jenkins.
 # --javahome=$JAVA_HOME
+# --httpListenAddress=$HTTP_HOST (default 0.0.0.0)
 # --httpPort=$HTTP_PORT (default 8080; disable with -1)
 # --httpsPort=$HTTP_PORT
 # --ajp13Port=$AJP_PORT


### PR DESCRIPTION
Make it clearer how one should bind to a certain interface per https://wiki.jenkins-ci.org/display/JENKINS/Starting+and+Accessing+Jenkins. Relates to #66 