### PR TITLE
[INFRA-717] sign with SHA-2

### DIFF
--- a/deb/publish/publish.sh
+++ b/deb/publish/publish.sh
@@ -37,7 +37,7 @@ cat $D/merged/Contents | gzip -9c > $D/binary/Contents.gz
 apt-ftparchive -c $bin/release.conf release $D/binary > $D/binary/Release
 # sign the release file
 rm $D/binary/Release.gpg || true
-gpg --batch --no-use-agent --no-default-keyring --keyring "$GPG_KEYRING" --secret-keyring="$GPG_SECRET_KEYRING" --passphrase-file "$GPG_PASSPHRASE_FILE" \
+gpg --batch --no-use-agent --no-default-keyring --digest-algo=sha256 --keyring "$GPG_KEYRING" --secret-keyring="$GPG_SECRET_KEYRING" --passphrase-file "$GPG_PASSPHRASE_FILE" \
   -abs -o $D/binary/Release.gpg $D/binary/Release
 
 cp $D/binary/Packages.* $D/binary/Release $D/binary/Release.gpg $D/binary/Contents.gz $D/contents/binary


### PR DESCRIPTION
Debian upstream and Ubuntu 16.04 started deprecating SHA1, which is currently used for signing. This explicit command line option changes the hash algorithm for dsig, removing a warning.

The upstream documentation mentions that the key has to be first upgraded to RSA/2048, but according to my experiment, this was not required to make `apt-get update` happy.

While using a stronger key would be preferrable, it has a wider impact; specifically, it would start breaking signature checks for existing users who have already run `apt-key add jenkins-ci.org.key` long time
ago. The packaging script uses the same GPG key for all the platforms, so this impact will be felt by users of RPMs, too.

To start the eventual key switching, I've updated my jenkins-ci.org.key to contain the current key as well as the new RSA/4096 key. Starting today, users installing RPM/DEB packages will get both keys, so when we
eventually switch the signing key, the impact will be less.