### PR TITLE
Remove trailing white spaces from deb

### DIFF
--- a/deb/build/build.sh
+++ b/deb/build/build.sh
@@ -19,7 +19,7 @@ sed -i.bak -e 's/^\s*$/./' -e 's/^/ /' $DESCRIPTION_FILE
 # Expand variables in the definition
 "$BASE/bin/branding.py" $D/debian
 
-# Rewrite the file 
+# Rewrite the file
 mv "$DESCRIPTION_FILE.bak" "$DESCRIPTION_FILE"
 
 cat > $D/debian/changelog << EOF

--- a/deb/build/debian/jenkins.default
+++ b/deb/build/debian/jenkins.default
@@ -57,7 +57,7 @@ MAXOPENFILES=8192
 HTTP_PORT=@@PORT@@
 
 
-# servlet context, important if you want to use apache proxying  
+# servlet context, important if you want to use apache proxying
 PREFIX=/$NAME
 
 # arguments to pass to jenkins.

--- a/deb/build/debian/jenkins.init
+++ b/deb/build/debian/jenkins.init
@@ -87,7 +87,7 @@ check_tcp_port() {
     fi
 
     count=`netstat --listen --numeric-ports | grep $address\:$port[[:space:]] | grep -c . `
-    
+
     if [ $count -ne 0 ]; then
         echo "The selected $service port ($port) on address $address seems to be in use by another program "
         echo "Please select another address/port combination to use for $NAME"
@@ -112,14 +112,14 @@ do_start()
     # Verify that the jenkins port is not already in use, winstone does not exit
     # even for BindException
     check_tcp_port "http" "$HTTP_PORT" "@@PORT@@" "$HTTP_HOST" "0.0.0.0" || return 2
-    
-    # If the var MAXOPENFILES is enabled in /etc/default/jenkins then set the max open files to the 
+
+    # If the var MAXOPENFILES is enabled in /etc/default/jenkins then set the max open files to the
     # proper value
     if [ -n "$MAXOPENFILES" ]; then
         [ "$VERBOSE" != no ] && echo Setting up max open files limit to $MAXOPENFILES
         ulimit -n $MAXOPENFILES
     fi
-    
+
     # notify of explicit umask
     if [ -n "$UMASK" ]; then
         [ "$VERBOSE" != no ] && echo Setting umask to $UMASK
@@ -134,16 +134,16 @@ do_start()
 #
 # Verify that all jenkins processes have been shutdown
 # and if not, then do killall for them
-# 
-get_running() 
+#
+get_running()
 {
     return `ps -U $JENKINS_USER --no-headers -f | egrep -e '(java)' | grep -v defunct | grep -c . `
 }
 
-force_stop() 
+force_stop()
 {
     get_running
-    if [ $? -ne 0 ]; then 
+    if [ $? -ne 0 ]; then
 	killall -u $JENKINS_USER java daemon || return 3
     fi
 }
@@ -165,9 +165,9 @@ do_stop()
     #   1 if daemon was already stopped
     #   2 if daemon could not be stopped
     #   other if a failure occurred
-    get_daemon_status 
+    get_daemon_status
     case "$?" in
-	0) 
+	0)
 	    $DAEMON $DAEMON_ARGS --stop || return 2
         # wait for the process to really terminate
         for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
@@ -195,7 +195,7 @@ do_check_started_ok() {
     get_running
     if [ "$?" -eq "0" ]; then
         return 2
-    else 
+    else
         return 0
     fi
 }
@@ -246,30 +246,30 @@ case "$1" in
     ;;
   status)
 	get_daemon_status
-	case "$?" in 
-	 0) 
+	case "$?" in
+	 0)
 		echo "$DESC is running with the pid `cat $PIDFILE`"
 		rc=0
 		;;
-	*) 
+	*)
 		get_running
 		procs=$?
-		if [ $procs -eq 0 ]; then 
+		if [ $procs -eq 0 ]; then
 			echo -n "$DESC is not running"
-			if [ -f $PIDFILE ]; then 
+			if [ -f $PIDFILE ]; then
 				echo ", but the pidfile ($PIDFILE) still exists"
 				rc=1
-			else 
+			else
 				echo
 				rc=3
 			fi
-		
-		else 
+
+		else
 			echo "$procs instances of jenkins are running at the moment"
 			echo "but the pidfile $PIDFILE is missing"
 			rc=0
 		fi
-		
+
 		exit $rc
 		;;
 	esac

--- a/deb/build/debian/jenkins.postinst
+++ b/deb/build/debian/jenkins.postinst
@@ -20,7 +20,6 @@ set -e
 
 case "$1" in
     configure)
-    
         [ -r /etc/default/@@ARTIFACTNAME@@ ] && . /etc/default/@@ARTIFACTNAME@@
         : ${JENKINS_USER:=@@ARTIFACTNAME@@}
         : ${JENKINS_GROUP:=@@ARTIFACTNAME@@}
@@ -48,7 +47,7 @@ case "$1" in
             rmdir /var/lib/hudson
             find /var/lib/@@ARTIFACTNAME@@ -user hudson -exec chown $JENKINS_USER {} + || true
         fi
-      
+
         # directories needed for jenkins
         # we don't do -R because it can take a long time on big installation
         chown $JENKINS_USER:$JENKINS_GROUP /var/lib/@@ARTIFACTNAME@@ /var/log/@@ARTIFACTNAME@@

--- a/deb/publish/gen.rb
+++ b/deb/publish/gen.rb
@@ -16,31 +16,31 @@ puts <<-EOS
   </style>
 </head>
 <body>
-<h1>#{productName} Debian packages</h1> 
-<p> 
+<h1>#{productName} Debian packages</h1>
+<p>
 This is the Debian package repository of #{productName} to automate installation and upgrade.
- 
+
 To use this repository, first add the key to your system:
- 
+
 <pre style="padding:0.5em; margin:1em; background-color:black; color:white">
 wget -q -O - <a href="#{organization}.key" style="color:white">#{url}/#{organization}.key</a> | sudo apt-key add -
 </pre>
- 
+
 Then add the following entry in your <tt>/etc/apt/sources.list</tt>:
- 
+
 <pre style="padding:0.5em; margin:1em; background-color:black; color:white">
 deb #{url} binary/
-</pre> 
- 
-<p> 
+</pre>
+
+<p>
 Update your local package index, then finally install #{productName}:
- 
+
 <pre style="padding:0.5em; margin:1em; background-color:black; color:white">
 sudo apt-get update
 sudo apt-get install #{artifactName}
-</pre> 
- 
-<p> 
+</pre>
+
+<p>
 See <a href="http://wiki.jenkins-ci.org/display/JENKINS/Installing+Jenkins+on+Ubuntu">Wiki</a> for more information, including notes regarding upgrade from Hudson.
 </p>
 


### PR DESCRIPTION
I don't like trailing whitespaces in source files I work with.   I could have done all of the files in this repository but only chose to do the ones I care about to help limit the size of the PR.  I replaced the trailing whitespace using the following commands.

    find deb -type f -exec sed -i.bak -E 's/[[:space:]]+$//' {} \;
    git clean -xfd

If you wish to further do this on all files in this repository then simply execute:

    find * -type f -exec sed -i.bak -E 's/[[:space:]]+$//' {} \;
    git clean -xfd

See also #76.