### PR TITLE
[JENKINS-23273] RPM post-install should not do a "chown -R ${JENKINS_USER:-jenkins} ${JENKINS_HOME:-/var/lib/jenkins}"

### DIFF
--- a/rpm/build/SPECS/jenkins.spec
+++ b/rpm/build/SPECS/jenkins.spec
@@ -79,42 +79,6 @@ rm -rf "%{buildroot}"
 %post
 /sbin/chkconfig --add %{name}
 
-# If we have an old hudson install, rename it to jenkins
-if test -d /var/lib/hudson; then
-    # leave a marker to indicate this came from Hudson.
-    # could be useful down the road
-    # This also ensures that the .??* wildcard matches something
-    touch /var/lib/hudson/.moving-hudson
-    # remove the hudson default update site to prevent it to be used by jenkins
-    if test -e /var/lib/hudson/updates/default.json; then
-      rm /var/lib/hudson/updates/default.json
-    fi
-    mv -f /var/lib/hudson/* /var/lib/hudson/.??* /var/lib/%{name}
-    rmdir /var/lib/hudson
-    find /var/lib/%{name} -user hudson -exec chown %{name} {} + || true
-fi
-if test -d /var/run/hudson; then
-    mv -f /var/run/hudson/* /var/run/%{name}
-    rmdir /var/run/hudson
-fi
-
-# Ensure the right ownership on files only if not owned by JENKINS_USER
-. /etc/sysconfig/%{name}
-if test x"$JENKINS_INSTALL_SKIP_CHOWN" != "xtrue"; then
-  owner=$(ls -ld /var/cache/%{name} | awk 'NR==1 {print $3}')
-  if [ "$owner" != "${JENKINS_USER:-%{name}}" ] ; then
-    chown -R ${JENKINS_USER:-%{name}} /var/cache/%{name}
-  fi
-  owner=$(ls -ld /var/log/%{name} | awk 'NR==1 {print $3}')
-  if [ "$owner" != "${JENKINS_USER:-%{name}}" ] ; then
-   chown -R ${JENKINS_USER:-%{name}} /var/log/%{name}
-  fi
-  owner=$(ls -ld ${JENKINS_HOME:-%{workdir}}| awk 'NR==1 {print $3}')
-  if [ "$owner" != "${JENKINS_USER:-%{name}}" ] ; then
-    chown -R ${JENKINS_USER:-%{name}} ${JENKINS_HOME:-%{workdir}}
-   fi
-fi
-
 %preun
 if [ "$1" = 0 ] ; then
     # if this is uninstallation as opposed to upgrade, delete the service

--- a/rpm/build/SPECS/jenkins.spec
+++ b/rpm/build/SPECS/jenkins.spec
@@ -93,7 +93,7 @@ rm -rf "%{buildroot}"
 %post
 /sbin/chkconfig --add %{name}
 
-function chownIfNeccesary {
+function chownIfNecessary {
   logger -t %{name}.installer "Checking ${2} ownership"
   if [ -f "${1}" ] ; then
     owner=$(cat $1)
@@ -118,9 +118,9 @@ function chownIfNeccesary {
 # the existing semantics
 . /etc/sysconfig/%{name}
 if test x"$JENKINS_INSTALL_SKIP_CHOWN" != "xtrue"; then
-      chownIfNeccesary "/tmp/%{name}.installer.cacheowner"  /var/cache/%{name}
-      chownIfNeccesary "/tmp/%{name}.installer.logowner"  /var/log/%{name}
-      chownIfNeccesary "/tmp/%{name}.installer.workdirowner"  ${JENKINS_HOME:-%{workdir}}
+      chownIfNecessary "/tmp/%{name}.installer.cacheowner"  /var/cache/%{name}
+      chownIfNecessary "/tmp/%{name}.installer.logowner"  /var/log/%{name}
+      chownIfNecessary "/tmp/%{name}.installer.workdirowner"  ${JENKINS_HOME:-%{workdir}}
 fi
 
 %preun

--- a/rpm/build/SPECS/jenkins.spec
+++ b/rpm/build/SPECS/jenkins.spec
@@ -77,8 +77,7 @@ rm -rf "%{buildroot}"
 	-d "%{workdir}" %{name} &>/dev/null || :
 
   # Used to decide later if we should perform a chown in case JENKINS_INSTALL_SKIP_CHOWN is false
-  # Check if a previous installation exists, if so use the configured JENKINS_USER to generate a files file for later use
-  # And check the JENKINS_HOME value and existing owners of work, log and cache dir, need to to this check
+  # Check if a previous installation exists, if so check the JENKINS_HOME value and existing owners of work, log and cache dir, need to to this check
   # here because the %files directive overwrites folder owners, I have not found a simple way to make the
   # files directive to use JENKINS_USER as owner.
   if [ -f "/etc/sysconfig/%{name}" ]; then
@@ -94,7 +93,10 @@ rm -rf "%{buildroot}"
 %post
 /sbin/chkconfig --add %{name}
 
-# Ensure the right ownership on files only if not owned by JENKINS_USER
+# Ensure the right ownership on files only if not owned by JENKINS_USER and JENKINS_USER
+# != %{name}, namely all cases but the default one (configured for %{name} owned by %{name})
+# In any case if JENKINS_INSTALL_SKIP_CHOWN is true we do not chown anything to maintain
+# the existing semantics
 . /etc/sysconfig/%{name}
 if test x"$JENKINS_INSTALL_SKIP_CHOWN" != "xtrue"; then
     if [ -f "/tmp/cacheowner" ]; then

--- a/rpm/build/SPECS/jenkins.spec
+++ b/rpm/build/SPECS/jenkins.spec
@@ -118,8 +118,8 @@ exit 0
 %dir %{_prefix}
 %{_prefix}/%{name}.war
 %attr(0755,%{name},%{name}) %dir %{workdir}
-%attr(2750,%{name},%{name}) /var/log/%{name}
-%attr(2750,%{name},%{name}) /var/cache/%{name}
+%attr(0750,%{name},%{name}) /var/log/%{name}
+%attr(0750,%{name},%{name}) /var/cache/%{name}
 %config /etc/logrotate.d/%{name}
 %config(noreplace) /etc/init.d/%{name}
 %config(noreplace) /etc/sysconfig/%{name}

--- a/rpm/build/SPECS/jenkins.spec
+++ b/rpm/build/SPECS/jenkins.spec
@@ -85,6 +85,10 @@ if test -d /var/lib/hudson; then
     # could be useful down the road
     # This also ensures that the .??* wildcard matches something
     touch /var/lib/hudson/.moving-hudson
+    # remove the hudson default update site to prevent it to be used by jenkins
+    if test -e /var/lib/hudson/updates/default.json; then
+      rm /var/lib/hudson/updates/default.json
+    fi
     mv -f /var/lib/hudson/* /var/lib/hudson/.??* /var/lib/%{name}
     rmdir /var/lib/hudson
     find /var/lib/%{name} -user hudson -exec chown %{name} {} + || true

--- a/rpm/build/SPECS/jenkins.spec
+++ b/rpm/build/SPECS/jenkins.spec
@@ -82,10 +82,10 @@ rm -rf "%{buildroot}"
   # files directive to use JENKINS_USER as owner.
   if [ -f "/etc/sysconfig/%{name}" ]; then
       logger -t %{name}.installer "Found previous config file /etc/sysconfig/%{name}"
-      . /etc/sysconfig/%{name}
-      stat --format=%U /var/cache/%{name} > /tmp/%{name}.installer.cacheowner
-      stat --format=%U /var/log/%{name}  >  /tmp/%{name}.installer.logowner
-      stat --format=%U ${JENKINS_HOME:-%{workdir}}  > /tmp/%{name}.installer.workdirowner
+      . "/etc/sysconfig/%{name}"
+      stat --format=%U "/var/cache/%{name}" > "/tmp/%{name}.installer.cacheowner"
+      stat --format=%U "/var/log/%{name}"  >  "/tmp/%{name}.installer.logowner"
+      stat --format=%U ${JENKINS_HOME:-%{workdir}}  > "/tmp/%{name}.installer.workdirowner"
   else
       logger -t %{name}.installer "No previous config file /etc/sysconfig/%{name} found"
   fi
@@ -96,17 +96,17 @@ rm -rf "%{buildroot}"
 function chownIfNecessary {
   logger -t %{name}.installer "Checking ${2} ownership"
   if [ -f "${1}" ] ; then
-    owner=$(cat $1)
-    rm -f $1
+    owner=$(cat "$1")
+    rm -f "$1"
     logger -t %{name}.installer "Found previous owner of ${2}: ${owner} "
   fi
   if  [ "${owner:-%{name}}" != "${JENKINS_USER:-%{name}}" ] ; then
     logger -t %{name}.installer "Previous owner of ${2} is different than configured JENKINS_USER... Doing a recursive chown of ${2} "
-    chown -R ${JENKINS_USER:-%{name}} $2
+    chown -R ${JENKINS_USER:-%{name}} "$2"
   elif [ "${JENKINS_USER:-%{name}}" != "%{name}" ] ; then
     # User has changed ownership of files and JENKINS_USER, chown only the folder
     logger -t %{name}.installer "Configured JENKINS_USER is different than default... Doing a non recursive chown of ${2} "
-    chown ${JENKINS_USER:-%{name}} $2
+    chown ${JENKINS_USER:-%{name}} "$2"
   else
     logger -t %{name}.installer "No chown needed for ${2} "
   fi
@@ -118,8 +118,8 @@ function chownIfNecessary {
 # the existing semantics
 . /etc/sysconfig/%{name}
 if test x"$JENKINS_INSTALL_SKIP_CHOWN" != "xtrue"; then
-      chownIfNecessary "/tmp/%{name}.installer.cacheowner"  /var/cache/%{name}
-      chownIfNecessary "/tmp/%{name}.installer.logowner"  /var/log/%{name}
+      chownIfNecessary "/tmp/%{name}.installer.cacheowner"  "/var/cache/%{name}"
+      chownIfNecessary "/tmp/%{name}.installer.logowner"  "/var/log/%{name}"
       chownIfNecessary "/tmp/%{name}.installer.workdirowner"  ${JENKINS_HOME:-%{workdir}}
 fi
 

--- a/rpm/build/SPECS/jenkins.spec
+++ b/rpm/build/SPECS/jenkins.spec
@@ -103,22 +103,29 @@ if test x"$JENKINS_INSTALL_SKIP_CHOWN" != "xtrue"; then
       cacheOwner=$(cat /tmp/cacheowner)
       rm -f /tmp/cacheowner
     fi
-    if [ "${JENKINS_USER:-%{name}}" != "%{name}" ] || [ "${cacheOwner:-%{name}}" != "${JENKINS_USER:-%{name}}" ] ; then
+    if  [ "${cacheOwner:-%{name}}" != "${JENKINS_USER:-%{name}}" ] ; then
         chown -R ${JENKINS_USER:-%{name}} /var/cache/%{name}
+    elif [ "${JENKINS_USER:-%{name}}" != "%{name}" ] ; then
+        # User has changed ownership of files and JENKINS_USER, chown only the folder
+        chown ${JENKINS_USER:-%{name}} /var/cache/%{name}
     fi
     if [ -f "/tmp/logowner" ]; then
       logOwner=$(cat /tmp/logowner)
       rm -f /tmp/logowner
     fi
-    if [ "${JENKINS_USER:-%{name}}" != "%{name}" ] || [ "${logOwner:-%{name}}" != "${JENKINS_USER:-%{name}}" ] ; then
+    if [ "${logOwner:-%{name}}" != "${JENKINS_USER:-%{name}}" ] ; then
         chown -R ${JENKINS_USER:-%{name}} /var/log/%{name}
+    elif [ "${JENKINS_USER:-%{name}}" != "%{name}" ] ; then
+      chown  ${JENKINS_USER:-%{name}} /var/log/%{name}
     fi
     if [ -f "/tmp/workdirowner" ]; then
       workdirOwner=$(cat /tmp/workdirowner)
       rm -f /tmp/workdirowner
     fi
-    if [ "${JENKINS_USER:-%{name}}" != "%{name}" ] || [ "${workdirOwner:-%{name}}" != "${JENKINS_USER:-%{name}}" ] ; then
+    if [ "${workdirOwner:-%{name}}" != "${JENKINS_USER:-%{name}}" ] ; then
         chown -R ${JENKINS_USER:-%{name}} ${JENKINS_HOME:-%{workdir}}
+    elif [ "${JENKINS_USER:-%{name}}" != "%{name}" ] ; then
+        chown ${JENKINS_USER:-%{name}} ${JENKINS_HOME:-%{workdir}}
     fi
 fi
 


### PR DESCRIPTION
[JENKINS-23273](https://issues.jenkins-ci.org/browse/JENKINS-23273)

Change ownership only if needed:

* Now `/var/cache/%{name}` `/var/log/%{name}` and workdir files are chowned only if parent folder is not already owned by appropriate user
* Also added sticky bit to that folders so only the appropriate user can create files there

@reviewbybees (specially, @kohsuke and @daniel-beck)