### PR TITLE
[JENKINS-40414] Declared the package hudson in the section Conflicts

### DIFF
--- a/rpm/build/SPECS/jenkins.spec
+++ b/rpm/build/SPECS/jenkins.spec
@@ -34,10 +34,10 @@ BuildRoot:	%{_tmppath}/build-%{name}-%{version}
 #    I'm dropping this requirement.
 # Requires:	java >= 1:1.6.0
 Requires: procps
-Obsoletes:  hudson
-PreReq:		/usr/sbin/groupadd /usr/sbin/useradd
-#PreReq:		%{fillup_prereq}
-BuildArch:	noarch
+Obsoletes: hudson
+Conflicts: hudson
+PreReq: /usr/sbin/groupadd /usr/sbin/useradd
+BuildArch: noarch
 
 %description
 @@DESCRIPTION_FILE@@


### PR DESCRIPTION
[JENKINS-40414](https://issues.jenkins-ci.org/browse/JENKINS-40414)

Motivated by https://github.com/jenkinsci/packaging/pull/87

For reviewers, please, use [that](https://github.com/jenkinsci/packaging/pull/88/files?w=1).

- [x] File a JIRA issue
- [x] Smoke tests on CentOS, Fedora and RedHat. 

This PR tries to avoid conflicts with a previous installation of Hudson. The same way that we are doing on the DEB package.

@reviewbybees 
@jenkinsci/code-reviewers 