### PR TITLE
Fix the sed command invalid filename

### DIFF
--- a/docker/build-sudo-images.sh
+++ b/docker/build-sudo-images.sh
@@ -4,7 +4,7 @@
 # Note: this modifies the original Dockerfiles so the current user can sudo
 
 cd "$(dirname "$0")"
-sed -i .orig -e "s#@@MYUSERID@@#`id -u`#g" sudo-*/Dockerfile
+sed -i -e "s#@@MYUSERID@@#`id -u`#g" sudo-*/Dockerfile
 docker build -t sudo-debian:wheezy sudo-debian
 docker build -t sudo-centos:6 sudo-centos6
 docker build -t sudo-centos:7 sudo-centos7


### PR DESCRIPTION
.orig doesnt exist so should be removed in sed command.
```
sed -i .orig -e "s#@@MYUSERID@@#`id -u`#g" sudo-*/Dockerfile
sed: can't read .orig: No such file or directory
```