### PR TITLE
[JENKINS-41413] Working around https://github.com/jenkinsci/distfork-plugin/pull/6

### DIFF
--- a/msi/build-on-jenkins.sh
+++ b/msi/build-on-jenkins.sh
@@ -29,12 +29,13 @@ fi
 
 case "$(uname)" in
   CYGWIN*)
-    java -jar $TARGET/jenkins-cli.jar $CLI_SSH_ARGS dist-fork -z `cygpath --dos $D/bundle.tgz` -f ${ARTIFACTNAME}.war="${WAR}" -l "windows && packaging" -F "${MSI}=${ARTIFACTNAME}-windows.zip" \
+    java -jar $TARGET/jenkins-cli.jar $CLI_SSH_ARGS dist-fork -z `cygpath --dos $D/bundle.tgz` -f ${ARTIFACTNAME}.war="${WAR}" -l "windows && packaging" -F "${MSI}.tmp=${ARTIFACTNAME}-windows.zip" \
           bash -ex build.sh ${ARTIFACTNAME}.war $encodedv ${ARTIFACTNAME} "${PRODUCTNAME}" ${PORT} ${CAMELARTIFACTNAME} ;;
   *)
-    java -jar $TARGET/jenkins-cli.jar $CLI_SSH_ARGS dist-fork -z $D/bundle.tgz -f ${ARTIFACTNAME}.war="${WAR}" -l "windows && packaging" -F "${MSI}=${ARTIFACTNAME}-windows.zip" \
+    java -jar $TARGET/jenkins-cli.jar $CLI_SSH_ARGS dist-fork -z $D/bundle.tgz -f ${ARTIFACTNAME}.war="${WAR}" -l "windows && packaging" -F "${MSI}.tmp=${ARTIFACTNAME}-windows.zip" \
           bash -ex build.sh ${ARTIFACTNAME}.war $encodedv ${ARTIFACTNAME} "${PRODUCTNAME}" ${PORT} ${CAMELARTIFACTNAME} ;;
 esac
 
+mv ${MSI}.tmp ${MSI}
 touch ${MSI}
 rm -rf $D


### PR DESCRIPTION
Make sure a failed windows installer build will not result in 0-byte msi file created at the expected location.