### PR TITLE
Update descriptions

### DIFF
--- a/branding/common
+++ b/branding/common
@@ -4,7 +4,7 @@ export PRODUCTNAME=Jenkins
 export ARTIFACTNAME=jenkins
 export CAMELARTIFACTNAME=Jenkins
 export VENDOR=Jenkins project
-export SUMMARY=Jenkins Continuous Integration Server
+export SUMMARY=Jenkins Automation Server
 export PORT=8080
 
 export MSI_PRODUCTCODE=415933d8-4104-47c3-aee9-66b31de07a57

--- a/branding/description-file
+++ b/branding/description-file
@@ -1,13 +1,5 @@
-Jenkins monitors executions of repeated jobs, such as building a software
-project or jobs run by cron. Among those things, current Jenkins focuses on the
-following two jobs:
-- Building/testing software projects continuously, just like CruiseControl or
-  DamageControl. In a nutshell, Jenkins provides an easy-to-use so-called
-  continuous integration system, making it easier for developers to integrate
-  changes to the project, and making it easier for users to obtain a fresh
-  build. The automated, continuous build increases the productivity.
-- Monitoring executions of externally-run jobs, such as cron jobs and procmail
-  jobs, even those that are run on a remote machine. For example, with cron,
-  all you receive is regular e-mails that capture the output, and it is up to
-  you to look at them diligently and notice when it broke. Jenkins keeps those
-  outputs and makes it easy for you to notice when something is wrong.
+Jenkins is an open source automation server which enables developers around the world to reliably automate  their development lifecycle processes of all kinds, including build, document, test, package, stage, deployment, static analysis and many more.
+
+Jenkins is being widely used in areas of Continuos Integration, Continuous Delivery, DevOps, and other areas. And it is not only about software, the same automation techniques can be applied in other areas like Hardware Engineering, Embedded Systems, BioTech, etc. 
+
+For information see https://jenkins.io

--- a/branding/test.mk
+++ b/branding/test.mk
@@ -7,7 +7,7 @@ export PRODUCTNAME=Jenkins Test
 export ARTIFACTNAME=jenkinstest
 export CAMELARTIFACTNAME=JenkinsTest
 export VENDOR=Jenkins Test project
-export SUMMARY=Jenkins Continuous Integration Server (Test)
+export SUMMARY=Jenkins Automation Server (Test)
 export PORT=7777
 
 export MSI_PRODUCTCODE=e76baa9f-2bb2-49e5-b518-8a5b7d1cd084

--- a/deb/build/debian/jenkins.default
+++ b/deb/build/debian/jenkins.default
@@ -1,4 +1,4 @@
-# defaults for jenkins continuous integration server
+# defaults for Jenkins automation server
 
 # pulled in from the init script; makes things easier.
 NAME=@@ARTIFACTNAME@@
@@ -28,7 +28,7 @@ JENKINS_WAR=/usr/share/$NAME/$NAME.war
 # jenkins home location
 JENKINS_HOME=/var/lib/$NAME
 
-# set this to false if you don't want Hudson to run by itself
+# set this to false if you don't want Jenkins to run by itself
 # in this set up, you are expected to provide a servlet container
 # to host jenkins.
 RUN_STANDALONE=true

--- a/osx/docs/JenkinsWelcomePanel.rtf
+++ b/osx/docs/JenkinsWelcomePanel.rtf
@@ -1,19 +1,15 @@
-{\rtf1\ansi\ansicpg1252\cocoartf1038\cocoasubrtf350
-{\fonttbl\f0\fswiss\fcharset0 ArialMT;}
-{\colortbl;\red255\green255\blue255;}
-{\*\listtable{\list\listtemplateid1\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\*\levelmarker \{disc\}}{\leveltext\leveltemplateid1\'01\uc0\u8226 ;}{\levelnumbers;}\fi-360\li720\lin720 }{\listname ;}\listid1}}
-{\*\listoverridetable{\listoverride\listid1\listoverridecount0\ls1}}
+{\rtf1\ansi\ansicpg1252\cocoartf1504\cocoasubrtf810
+\cocoascreenfonts1{\fonttbl\f0\fswiss\fcharset0 ArialMT;}
+{\colortbl;\red255\green255\blue255;\red0\green0\blue0;\red0\green0\blue0;}
+{\*\expandedcolortbl;;\cssrgb\c0\c0\c0;\cssrgb\c0\c0\c0;}
 \margl1440\margr1440\vieww12440\viewh12240\viewkind0
 \deftab720
-\pard\pardeftab720\sl320\ql\qnatural
+\pard\pardeftab720\sl280\partightenfactor0
 
-\f0\fs24 \cf0 Jenkins monitors executions of repeated jobs, such as building a software project or jobs run by cron. Among those things, current Jenkins focuses on the following two jobs:\
+\f0\fs24 \cf2 \expnd0\expndtw0\kerning0
+\outl0\strokewidth0 \strokec2 Jenkins is an open source automation server which enables developers around the world to reliably automate  their \cf3 \outl0\strokewidth0 development lifecycle processes of all kinds, including build, document, test, package, stage, deployment, static analysis and many\'a0more\cf2 \outl0\strokewidth0 \strokec2 .\
 \
-\pard\tx220\tx720\pardeftab720\li720\fi-720\sl320\ql\qnatural
-\ls1\ilvl0\cf0 {\listtext	\'95	}Building/testing software projects continuously, just like CruiseControl or\'a0DamageControl. In a nutshell, Jenkins provides an easy-to-use so-called continuous integration system, making it easier for developers to integrate\'a0changes to the project, and making it easier for users to obtain a fresh\'a0build. The automated, continuous build increases the productivity.\
-{\listtext	\'95	}Monitoring executions of externally-run jobs, such as cron jobs and procmail\'a0jobs, even those that are run on a remote machine. For example, with cron,\'a0all you receive is regular e-mails that capture the output, and it is up to\'a0you to look at them diligently and notice when it broke. Jenkins keeps those\'a0outputs and makes it easy for you to notice when something is wrong\
-\pard\pardeftab720\sl320\ql\qnatural
-\cf0 \
-\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\pardeftab720\ql\qnatural\pardirnatural
-\cf0 For information on CI see http://www.martinfowler.com/articles/continuousIntegration.html\
+Jenkins is being widely used in areas of Continuos Integration, Continuous Delivery, DevOps, and other areas. And it is not only about software, the same automation techniques can be applied in other areas like Hardware Engineering, Embedded Systems, BioTech, etc. \
+\
+For information see https://jenkins.io\cf0 \kerning1\expnd0\expndtw0 \outl0\strokewidth0 \
 }


### PR DESCRIPTION
- [x] - No more "Continuous Integration Server"
- [x] - Update the common and MacOS descriptions, the original one is something ancient (external job monitor, etc.)

CC @jenkinsci/code-reviewers, esp. @rtyler and @daniel-beck . The description is IMHO not ideal, so I would appreciate any proposals.