### PR TITLE
Fix postinstall script for OS X

### DIFF
--- a/osx/scripts/postinstall-launchd-jenkins
+++ b/osx/scripts/postinstall-launchd-jenkins
@@ -19,8 +19,23 @@ else
     echo 'No @@ARTIFACTNAME@@ user found, creating @@ARTIFACTNAME@@ user and group'
 
 # Find free uid under 500
-    uid=$(dscl . -list /Users uid | sort -nrk 2 | awk '$2 < 500 {print $2 + 1; exit 0}')
-    if [ $uid -eq 500 ]; then
+    uids=$(dscl . -list /Users uid | sort -nrk 2 | awk '$2 < 500 {print $2;}')
+    echo "uids: $uids"
+    uid=0
+    prev_uid=500
+    found_uid=false
+    for i in $uids;
+    do
+        uid=$(($i + 1))
+        if [ "$uid" != "$prev" ]
+        then
+            echo "Found an available uid"
+            found_uid=true
+            break
+        fi
+        prev_uid=$i
+    done
+    if [ "$found_uid" = false ]; then
         echo 'ERROR: All system uids are in use!'
         exit 1
     fi


### PR DESCRIPTION
The installer looks for an available uid bellow 500. The logic of
the script list the uids of the system in descending order and pickup
the first below 500 and adds 1 to it. This causes 2 issues:

1) If uid 499 exist it will try to use 500. 500 means in the script that
   all uids are used. This happens even though there is romm in lower
   uids.

2) The script does not check if the uid picked up is already in use
   which may cause some conflicts.

This fix walks the allocated uids below 500 takes every candidate and
checks whether the formed uid is already used.

More details can be found in:

https://issues.jenkins-ci.org/browse/JENKINS-43284
https://groups.google.com/forum/#!msg/jenkinsci-dev/ip-GAlRCetA/uYYKGksRBAAJ