### PR TITLE
Create needed paths for MSI and OSX packages deployment

### DIFF
--- a/msi/publish.sh
+++ b/msi/publish.sh
@@ -2,4 +2,5 @@
 set -o pipefail
 sha256sum ${MSI} | sed 's, .*/, ,' > ${MSI_SHASUM}
 cat ${MSI_SHASUM}
+ssh $SSH_OPTS $PKGSERVER mkdir -p "'$MSIDIR/'"
 rsync -avz -e "ssh $SSH_OPTS" "$MSI" "$MSI_SHASUM" "$PKGSERVER:$MSIDIR/"

--- a/osx/publish.sh
+++ b/osx/publish.sh
@@ -2,4 +2,5 @@
 set -o pipefail
 sha256sum ${OSX} | sed 's, .*/, ,' > ${OSX_SHASUM}
 cat ${OSX_SHASUM}
+ssh $SSH_OPTS $PKGSERVER mkdir -p "'$OSXDIR/'"
 rsync -avz -e "ssh $SSH_OPTS" "${OSX}" "${OSX_SHASUM}" "$PKGSERVER:$OSXDIR/"


### PR DESCRIPTION
Create the needed paths in MSI and OSX before deploying the same way it's done for the rest of the packages.

@reviewbybees esp @armfergom 