### PR TITLE
[JENKINS-43495] - Updated Java dependency to Java 8

### DIFF
--- a/deb/build/debian/control
+++ b/deb/build/debian/control
@@ -8,7 +8,7 @@ Homepage: @@HOMEPAGE@@
 
 Package: @@ARTIFACTNAME@@
 Architecture: all
-Depends: ${misc:Depends}, daemon, adduser, procps, psmisc, net-tools, default-jre-headless (>= 2:1.7) | java7-runtime-headless
+Depends: ${misc:Depends}, daemon, adduser, procps, psmisc, net-tools, default-jre-headless (>= 2:1.8) | java8-runtime-headless
 Conflicts: hudson
 Replaces: hudson
 Description: @@DESCRIPTION_FILE@@


### PR DESCRIPTION
Tested the behavior is correct on:

* openjdk-8-jdk - ok
* openjdk-8-jre - ok
* Oracle JDK 8 /latest  ok
* openjdk-7-jdk - fails (as designed)
* openjdk-7-jre - fails (as designed)

https://issues.jenkins-ci.org/browse/JENKINS-43495

@reviewbybees @batmat 
