### PR TITLE
Explain why the RPM dependencies are so wacky

### DIFF
--- a/installtests/centos.sh
+++ b/installtests/centos.sh
@@ -12,7 +12,7 @@ fi
 dockerInstall() {
     # Assume packaging is mounted to /tmp/packaging and built
     yum install -y curl
-    yum install -y system-config-services java-1.7.0-openjdk  # First is b/c docker does not include service command, second is prereq
+    yum install -y system-config-services java-1.8.0-openjdk  # First is b/c docker does not include service command, second is prereq
     yum -y --nogpgcheck localinstall "$PKG_FOLDER"
 }
 

--- a/installtests/suse.sh
+++ b/installtests/suse.sh
@@ -13,7 +13,7 @@ fi
 
 dockerInstall() {
     # Ignore signature verification and default to yes
-    zypper --non-interactive in curl
+    zypper --non-interactive in curl java-1_8_0-openjdk
     zypper --no-gpg-checks --non-interactive in $PKG_FOLDER
 }
 

--- a/rpm/build/SPECS/jenkins.spec
+++ b/rpm/build/SPECS/jenkins.spec
@@ -16,23 +16,10 @@ URL:		@@HOMEPAGE@@
 Group:		Development/Tools/Building
 License:	@@LICENSE@@
 BuildRoot:	%{_tmppath}/build-%{name}-%{version}
-# see the comment below from java-1.6.0-openjdk.spec that explains this dependency
-# java-1.5.0-ibm from jpackage.org set Epoch to 1 for unknown reasons,
-# and this change was brought into RHEL-4.  java-1.5.0-ibm packages
-# also included the epoch in their virtual provides.  This created a
-# situation where in-the-wild java-1.5.0-ibm packages provided "java =
-# 1:1.5.0".  In RPM terms, "1.6.0 < 1:1.5.0" since 1.6.0 is
-# interpreted as 0:1.6.0.  So the "java >= 1.6.0" requirement would be
-# satisfied by the 1:1.5.0 packages.  Thus we need to set the epoch in
-# JDK package >= 1.6.0 to 1, and packages referring to JDK virtual
-# provides >= 1.6.0 must specify the epoch, "java >= 1:1.6.0".
-#
-# Kohsuke - 2009/09/29
-#    test by mrooney on what he believes to be RHEL 5.2 indicates
-#    that there's no such packages. JRE/JDK RPMs from java.sun.com
-#    do not have this virtual package declarations. So for now,
-#    I'm dropping this requirement.
-# Requires:	java >= 1:1.6.0
+# Unfortunately the Oracle Java RPMs do not register as providing anything (including "java" or "jdk")
+# So either we make a hard requirement on the OpenJDK or none at all
+# Only workaround would be to use a java virtual package, see https://github.com/keystep/virtual-java-rpm
+# Requires: java >= 1:1.8.0
 Requires: procps
 Obsoletes: hudson
 Conflicts: hudson

--- a/rpm/publish/gen.rb
+++ b/rpm/publish/gen.rb
@@ -32,8 +32,14 @@ you already have a key. Please ignore that and move on.
 
 <p>
 You will need to explicitly install a Java runtime environment, because Oracle's Java RPMs are incorrect and fail to register as providing a java dependency. 
-Thus, adding an explicit dependency requirement on Java would have forced installation of the OpenJDK JVM.
+Thus, adding an explicit dependency requirement on Java would force installation of the OpenJDK JVM.
 <p>
+
+<ul>
+  <li>2.54 (2017-04) and newer: Java 8</li>
+  <li>1.612 (2015-05) and newer: Java 7</li>
+</ul>
+
 With that set up, the #{productName} package can be installed with:
 
 <pre style="padding:0.5em; margin:1em; background:black; color:white">

--- a/rpm/publish/gen.rb
+++ b/rpm/publish/gen.rb
@@ -31,6 +31,9 @@ If you've previously imported the key from Jenkins, the "rpm --import" will fail
 you already have a key. Please ignore that and move on.
 
 <p>
+You will need to explicitly install a Java runtime environment, because Oracle's Java RPMs are incorrect and fail to register as providing a java dependency. 
+Thus, adding an explicit dependency requirement on Java would have forced installation of the OpenJDK JVM.
+<p>
 With that set up, the #{productName} package can be installed with:
 
 <pre style="padding:0.5em; margin:1em; background:black; color:white">

--- a/suse/build/SPECS/jenkins.spec
+++ b/suse/build/SPECS/jenkins.spec
@@ -17,19 +17,11 @@ URL:		@@HOMEPAGE@@
 Group:		Development/Tools/Building
 License:	@@LICENSE@@
 BuildRoot:	%{_tmppath}/build-%{name}-%{version}
-# see the comment below from java-1.6.0-openjdk.spec that explains this dependency
-# java-1.5.0-ibm from jpackage.org set Epoch to 1 for unknown reasons,
-# and this change was brought into RHEL-4.  java-1.5.0-ibm packages
-# also included the epoch in their virtual provides.  This created a
-# situation where in-the-wild java-1.5.0-ibm packages provided "java =
-# 1:1.5.0".  In RPM terms, "1.6.0 < 1:1.5.0" since 1.6.0 is
-# interpreted as 0:1.6.0.  So the "java >= 1.6.0" requirement would be
-# satisfied by the 1:1.5.0 packages.  Thus we need to set the epoch in
-# JDK package >= 1.6.0 to 1, and packages referring to JDK virtual
-# provides >= 1.6.0 must specify the epoch, "java >= 1:1.6.0".
-#
-# java-1_6_0-sun provides this at least
-Requires:	java >= 1.6, procps
+# Unfortunately the Oracle Java RPMs do not register as providing anything (including "java" or "jdk")
+# So either we make a hard requirement on the OpenJDK or none at all
+# Only workaround would be to use a java virtual package, see https://github.com/keystep/virtual-java-rpm
+# Requires: java >= 1:1.8.0
+Requires:	procps
 Obsoletes:  hudson
 PreReq:		/usr/sbin/groupadd /usr/sbin/useradd
 #PreReq:		%{fillup_prereq}

--- a/suse/publish/gen.rb
+++ b/suse/publish/gen.rb
@@ -24,6 +24,10 @@ sudo zypper addrepo -f #{url}/ #{artifactName}
 </pre>
 
 <p>
+You will need to explicitly install a Java runtime environment, because Oracle's Java RPMs are incorrect and fail to register as providing a java dependency. 
+Thus, adding an explicit dependency requirement on Java would have forced installation of the OpenJDK JVM.
+
+<p>
 With that set up, the #{productName} package can be installed with <tt>zypper install #{artifactName}</tt>
 
 <h2>Individual Package Downloads</h2>

--- a/suse/publish/gen.rb
+++ b/suse/publish/gen.rb
@@ -25,7 +25,12 @@ sudo zypper addrepo -f #{url}/ #{artifactName}
 
 <p>
 You will need to explicitly install a Java runtime environment, because Oracle's Java RPMs are incorrect and fail to register as providing a java dependency. 
-Thus, adding an explicit dependency requirement on Java would have forced installation of the OpenJDK JVM.
+Thus, adding an explicit dependency requirement on Java would force installation of the OpenJDK JVM.
+
+<ul>
+  <li>2.54 (2017-04) and newer: Java 8</li>
+  <li>1.612 (2015-05) and newer: Java 7</li>
+</ul>
 
 <p>
 With that set up, the #{productName} package can be installed with <tt>zypper install #{artifactName}</tt>


### PR DESCRIPTION
If we can't fix it, and the hack (pushing a nasty virtual RPM to our own repo) is essentially worse... at least we can explain why it is the way it is. 

And the reason is Oracle.  

@reviewbybees 