### PR TITLE
[JENKINS-44556] introduce a mechanism to set the debian packaging version

### DIFF
--- a/deb/build/build.sh
+++ b/deb/build/build.sh
@@ -23,7 +23,7 @@ sed -i.bak -e 's/^\s*$/./' -e 's/^/ /' $DESCRIPTION_FILE
 mv "$DESCRIPTION_FILE.bak" "$DESCRIPTION_FILE"
 
 cat > $D/debian/changelog << EOF
-${ARTIFACTNAME} ($VERSION) unstable; urgency=low
+${ARTIFACTNAME} ($VERSION${DEB_REVISION}) unstable; urgency=low
 
   * Packaged ${VERSION}
 
@@ -45,6 +45,6 @@ pushd $D
 popd
 
 mkdir -p "$(dirname "${DEB}")" || true
-mv $D/../${ARTIFACTNAME}_${VERSION}_all.deb ${DEB}
+mv $D/../${ARTIFACTNAME}_${VERSION}${DEB_REVISION}_all.deb ${DEB}
 
 rm -rf $D

--- a/deb/publish/publish.sh
+++ b/deb/publish/publish.sh
@@ -25,7 +25,7 @@ popd
 
 # merge the result
 pushd $D/binary
-  mvn org.kohsuke:apt-ftparchive-merge:1.4:merge -Durl="$DEB_URL/binary/" -Dout=../merged
+  mvn org.kohsuke:apt-ftparchive-merge:1.6:merge -Durl="$DEB_URL/binary/" -Dout=../merged
 popd
 
 cat $D/merged/Packages > $D/binary/Packages

--- a/setup.mk
+++ b/setup.mk
@@ -20,7 +20,7 @@ export OSX=${TARGET}/osx/${ARTIFACTNAME}-${VERSION}.pkg
 export OSX_SHASUM=${OSX}.sha256
 
 # where to generate Debian/Ubuntu DEB file?
-export DEB=${TARGET}/debian/${ARTIFACTNAME}_${VERSION}_all.deb
+export DEB=${TARGET}/debian/${ARTIFACTNAME}_${VERSION}${DEB_REVISION}_all.deb
 
 # where to generate RHEL/CentOS RPM file?
 export RPM=${TARGET}/rpm/${ARTIFACTNAME}-${VERSION}-1.1.noarch.rpm


### PR DESCRIPTION
This allows us to regenerate a new debian package without causing downstream pains.

I've already used this in releasing 2.60.1-1