### PR TITLE
[JENKINS-45287] Debian packaging should not be satisfied by Java 9

### DIFF
--- a/deb/build/debian/control
+++ b/deb/build/debian/control
@@ -8,7 +8,7 @@ Homepage: @@HOMEPAGE@@
 
 Package: @@ARTIFACTNAME@@
 Architecture: all
-Depends: ${misc:Depends}, daemon, adduser, procps, psmisc, net-tools, default-jre-headless (>= 2:1.8) | java8-runtime-headless
+Depends: ${misc:Depends}, daemon, adduser, procps, psmisc, net-tools
 Conflicts: hudson
 Replaces: hudson
 Description: @@DESCRIPTION_FILE@@

--- a/deb/build/debian/jenkins.default
+++ b/deb/build/debian/jenkins.default
@@ -4,7 +4,7 @@
 NAME=@@ARTIFACTNAME@@
 
 # location of java
-JAVA=/usr/bin/java
+JAVA=$(which java)
 
 # arguments to pass to java
 

--- a/deb/build/debian/jenkins.default
+++ b/deb/build/debian/jenkins.default
@@ -3,9 +3,6 @@
 # pulled in from the init script; makes things easier.
 NAME=@@ARTIFACTNAME@@
 
-# location of java
-JAVA=$(which java)
-
 # arguments to pass to java
 
 # Allow graphs etc. to work even when an X server is present

--- a/deb/build/debian/jenkins.init
+++ b/deb/build/debian/jenkins.init
@@ -25,6 +25,8 @@ SCRIPTNAME=/etc/init.d/$NAME
 DAEMON=/usr/bin/daemon
 DAEMON_ARGS="--name=$NAME --inherit --env=JENKINS_HOME=$JENKINS_HOME --output=$JENKINS_LOG --pidfile=$PIDFILE"
 
+JAVA_ALLOWED_VERSION="18"
+
 if [ -n "$UMASK" ]; then
     DAEMON_ARGS="$DAEMON_ARGS --umask=$UMASK"
 fi
@@ -40,6 +42,26 @@ fi
 # Exit if not supposed to run standalone
 if [ "$RUN_STANDALONE" = "false" ]; then
     echo "Not configured to run standalone" >&2
+    exit 1
+fi
+
+# Make sure there exists a java executable, it may not be allways the case
+if [ -z "$JAVA" ]; then
+    echo "ERROR: No Java executable found in the system" >&2
+    echo "If you actually have java installed on the system make sure 'which java' returns the java executable path" >&2
+    exit 1
+fi
+
+# Work out the JAVA version we are working with:
+JAVA_VERSION=$($JAVA -version 2>&1 | sed -n ';s/.* version "\(.*\)\.\(.*\)\..*"/\1\2/p;')
+
+if [ "$JAVA_VERSION" = "$JAVA_ALLOWED_VERSION" ]; then
+    echo "Correct java version found" >&2
+else
+    echo "Found an incorrect Java version" >&2
+    echo "Java version found:" >&2
+    echo $($JAVA -version) >&2
+    echo "Aborting" >&2
     exit 1
 fi
 

--- a/deb/build/debian/jenkins.init
+++ b/deb/build/debian/jenkins.init
@@ -47,8 +47,8 @@ fi
 
 # Make sure there exists a java executable, it may not be allways the case
 if [ -z "$JAVA" ]; then
-    echo "ERROR: No Java executable found in the system" >&2
-    echo "If you actually have java installed on the system make sure 'which java' returns the java executable path" >&2
+    echo "ERROR: No Java executable found in current PATH: $PATH" >&2
+    echo "If you actually have java installed on the system make sure the executable is in the aforementioned path and that 'which java' returns the java executable path" >&2
     exit 1
 fi
 

--- a/deb/build/debian/jenkins.init
+++ b/deb/build/debian/jenkins.init
@@ -49,7 +49,7 @@ fi
 # Make sure there exists a java executable, it may not be allways the case
 if [ -z "$JAVA" ]; then
     echo "ERROR: No Java executable found in current PATH: $PATH" >&2
-    echo "If you actually have java installed on the system make sure the executable is in the aforementioned path and that 'which java' returns the java executable path" >&2
+    echo "If you actually have java installed on the system make sure the executable is in the aforementioned path and that 'type -p java' returns the java executable path" >&2
     exit 1
 fi
 

--- a/deb/build/debian/jenkins.init
+++ b/deb/build/debian/jenkins.init
@@ -24,6 +24,7 @@ SCRIPTNAME=/etc/init.d/$NAME
 #DAEMON=$JENKINS_SH
 DAEMON=/usr/bin/daemon
 DAEMON_ARGS="--name=$NAME --inherit --env=JENKINS_HOME=$JENKINS_HOME --output=$JENKINS_LOG --pidfile=$PIDFILE"
+JAVA=`type -p java`
 
 JAVA_ALLOWED_VERSION="18"
 

--- a/deb/publish/gen.rb
+++ b/deb/publish/gen.rb
@@ -31,6 +31,20 @@ Then add the following entry in your <tt>/etc/apt/sources.list</tt>:
 <pre style="padding:0.5em; margin:1em; background-color:black; color:white">
 deb #{url} binary/
 </pre>
+</p>
+
+<p>
+You will need to explicitly install a Java runtime environment, given the current state of Java 9 is the safest way to
+ensure your system ends properly configured. Adding an explicit dependency requirement on Java could force installation
+of undesired versions of the JVM.
+</p>
+
+<p>
+<ul>
+  <li>2.54 (2017-04) and newer: Java 8</li>
+  <li>1.612 (2015-05) and newer: Java 7</li>
+</ul>
+</p>
 
 <p>
 Update your local package index, then finally install #{productName}:
@@ -39,6 +53,7 @@ Update your local package index, then finally install #{productName}:
 sudo apt-get update
 sudo apt-get install #{artifactName}
 </pre>
+</p>
 
 <p>
 See <a href="http://wiki.jenkins-ci.org/display/JENKINS/Installing+Jenkins+on+Ubuntu">Wiki</a> for more information, including notes regarding upgrade from Hudson.

--- a/deb/publish/gen.rb
+++ b/deb/publish/gen.rb
@@ -34,7 +34,7 @@ deb #{url} binary/
 </p>
 
 <p>
-You will need to explicitly install a Java runtime environment, given the current state of Java 9 is the safest way to
+You will need to explicitly install a Java runtime environment, because Java 9 does not work with Jenkins, this is the safest way to
 ensure your system ends properly configured. Adding an explicit dependency requirement on Java could force installation
 of undesired versions of the JVM.
 </p>

--- a/deb/publish/gen.rb
+++ b/deb/publish/gen.rb
@@ -36,7 +36,8 @@ deb #{url} binary/
 <p>
 You will need to explicitly install a Java runtime environment, <b>because Jenkins does not work with Java 9</b>, this is the safest way to
 ensure your system ends properly configured. Adding an explicit dependency requirement on Java could force installation
-of undesired versions of the JVM.
+of undesired versions of the JVM. Check <a href="https://issues.jenkins-ci.org/browse/JENKINS-40689">JENKINS-40689</a>
+for more details about Jenkins and Java 9 compatibility.
 </p>
 
 <p>

--- a/deb/publish/gen.rb
+++ b/deb/publish/gen.rb
@@ -34,7 +34,7 @@ deb #{url} binary/
 </p>
 
 <p>
-You will need to explicitly install a Java runtime environment, because Java 9 does not work with Jenkins, this is the safest way to
+You will need to explicitly install a Java runtime environment, <b>because Jenkins does not work with Java 9</b>, this is the safest way to
 ensure your system ends properly configured. Adding an explicit dependency requirement on Java could force installation
 of undesired versions of the JVM.
 </p>


### PR DESCRIPTION
[JENKINS-45287](https://issues.jenkins-ci.org/browse/JENKINS-45287)

As stated in the ticket I believe the best approach here is to mimic what the RPM package actually does, drop the java dependency on the package but add a Java check in the init script so it only starts jenkins if we are on Java 8 and prints an appropriate error message if not.

Also I have removed the hardcoded java route, now the installer uses `which java` to try to locate the java executable

I have performed the following tests: (all using Vagrant machines)

* Ubuntu 16.04 with OpenJDK 7 installed and configured as default via package manager -> Service does not start and shows the corresponding error message about using an incorrect java version

* Ubuntu 16.04 with OpenJDK 8 installed and configured as default via package manager -> Service starts
* Debian Stretch With OpenJDK 8 installed and configured as default via package manager -> Service starts

* Ubuntu 16.04 with OpenJDK 9 installed and configured as default via package manager -> Service does not start and shows the corresponding error message about using an incorrect java version
* Debian Stretch with OpenJDK 9 installed and configured as default via package manager -> Service does not start and shows the corresponding error message about using an incorrect java version

* Ubuntu 16.04 with Oracle Java 8 installed and configured as default via package manager -> Service starts
* Debian Stretch With Oracle Java 8 installed and configured as default via package manager -> Service starts

* Ubuntu 16.04 with Oracle Java 9 installed and configured as default via package manager -> Service does not start and shows the corresponding error message about using an incorrect java version
* Debian Stretch with Oracle Java 9 installed and configured as default via package manager -> Service does not start and shows the corresponding error message about using an incorrect java version

* Debian Stretch with Oracle Java 9 manually installed via tar.gz file and update-alternatives in a location not in path -> Service does not start with no java found error message
* Debian Stretch with Oracle Java 9 manually installed via tar.gz file and update-alternatives in a location not in path but with a symbolic link in PATH -> Service does not start and shows the corresponding error message about using an incorrect java version

* Debian Stretch with Oracle Java 8 manually installed via tar.gz file and update-alternatives in a location not in path -> Service does not start with no java found error message
* Debian Stretch with Oracle Java 8 manually installed via tar.gz file and update-alternatives in a location not in path but with a symbolic link in PATH -> Service does not start and shows the corresponding error message about using an incorrect java version

Java not found error message:
```
vagrant@stretch:~$ sudo service jenkins status
● jenkins.service - LSB: Start Jenkins at boot time
   Loaded: loaded (/etc/init.d/jenkins; generated; vendor preset: enabled)
   Active: failed (Result: exit-code) since Fri 2017-07-07 15:42:03 GMT; 5s ago
     Docs: man:systemd-sysv-generator(8)
  Process: 1118 ExecStop=/etc/init.d/jenkins stop (code=exited, status=0/SUCCESS)
  Process: 1200 ExecStart=/etc/init.d/jenkins start (code=exited, status=1/FAILURE)

Jul 07 15:42:03 stretch systemd[1]: Starting LSB: Start Jenkins at boot time...
Jul 07 15:42:03 stretch jenkins[1200]: ERROR: No Java executable found in current PATH: /bin:/usr/bin:/sbin:/usr/sbin
Jul 07 15:42:03 stretch jenkins[1200]: If you actually have java installed on the system make sure the executable is in the aforementioned path and that 'which java' returns the java executable path
Jul 07 15:42:03 stretch systemd[1]: jenkins.service: Control process exited, code=exited status=1
Jul 07 15:42:03 stretch systemd[1]: Failed to start LSB: Start Jenkins at boot time.
Jul 07 15:42:03 stretch systemd[1]: jenkins.service: Unit entered failed state.
Jul 07 15:42:03 stretch systemd[1]: jenkins.service: Failed with result 'exit-code'.
```
Incorrect Java error message:
```
vagrant@stretch:~$ sudo service jenkins status
● jenkins.service - LSB: Start Jenkins at boot time
   Loaded: loaded (/etc/init.d/jenkins; generated; vendor preset: enabled)
   Active: failed (Result: exit-code) since Fri 2017-07-07 15:50:57 GMT; 5s ago
     Docs: man:systemd-sysv-generator(8)
  Process: 1369 ExecStop=/etc/init.d/jenkins stop (code=exited, status=0/SUCCESS)
  Process: 1481 ExecStart=/etc/init.d/jenkins start (code=exited, status=1/FAILURE)

Jul 07 15:50:57 stretch jenkins[1481]: Found an incorrect Java version
Jul 07 15:50:57 stretch jenkins[1481]: Java version found:
Jul 07 15:50:57 stretch jenkins[1481]: java version "9"
Jul 07 15:50:57 stretch jenkins[1481]: Java(TM) SE Runtime Environment (build 9+176)
Jul 07 15:50:57 stretch jenkins[1481]: Java HotSpot(TM) 64-Bit Server VM (build 9+176, mixed mode)
Jul 07 15:50:57 stretch jenkins[1481]: Aborting
Jul 07 15:50:57 stretch systemd[1]: jenkins.service: Control process exited, code=exited status=1
Jul 07 15:50:57 stretch systemd[1]: Failed to start LSB: Start Jenkins at boot time.
Jul 07 15:50:57 stretch systemd[1]: jenkins.service: Unit entered failed state.
Jul 07 15:50:57 stretch systemd[1]: jenkins.service: Failed with result 'exit-code'.
```

@reviewbybees specially @daniel-beck (as the issue reporter) and @svanoort 