### PR TITLE
Update jenkins.sysconfig.in to mention /var/cache/jenkins

### DIFF
--- a/suse/build/SOURCES/jenkins.sysconfig.in
+++ b/suse/build/SOURCES/jenkins.sysconfig.in
@@ -38,7 +38,9 @@ JENKINS_JAVA_HOME=""
 #
 # Unix user account that runs the Jenkins daemon
 # Be careful when you change this, as you need to update
-# permissions of $JENKINS_HOME and /var/log/@@ARTIFACTNAME@@.
+# permissions of $JENKINS_HOME and /var/log/@@ARTIFACTNAME@@,
+# and if you have already run Jenkins, potentially other
+# directories such as /var/cache/@@ARTIFACTNAME@@ .
 #
 JENKINS_USER="@@ARTIFACTNAME@@"
 


### PR DESCRIPTION
Updated jenkins.sysconfig.in to mention /var/cache/jenkins to add the remaining gotcha directory if running from `jenkins.war` and having run already, changed `JENKINS_USER`