### PR TITLE
Package OS X last

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,9 @@ clean:
 setup:
 	bash -ex -c 'for f in */setup.sh; do $$f; done'
 
-package: war msi osx deb rpm suse
+package: war msi deb rpm suse osx
 
-publish: war.publish msi.publish osx.publish deb.publish rpm.publish suse.publish
+publish: war.publish msi.publish deb.publish rpm.publish suse.publish osx.publish
 
 test: deb.test rpm.test suse.test
 


### PR DESCRIPTION
According to @kohsuke, OS X sometimes leads to trouble -- as this week, when a forced restart caused packaging to hang -- so do this last, in the hopes that all others will finish and be available even in the case of problems with OS X.