### PR TITLE
[JENKINS-18870] JENKINS_ENABLE_ACCESS_LOG for Debian

### DIFF
--- a/deb/build/debian/jenkins.default
+++ b/deb/build/debian/jenkins.default
@@ -34,6 +34,10 @@ RUN_STANDALONE=true
 JENKINS_LOG=/var/log/$NAME/$NAME.log
 #JENKINS_LOG=daemon.info
 
+# Whether to enable web access logging or not.
+# Set to "yes" to enable logging to /var/log/$NAME/access_log
+JENKINS_ENABLE_ACCESS_LOG="no"
+
 # OS LIMITS SETUP
 #   comment this out to observe /etc/security/limits.conf
 #   this is on by default because http://github.com/jenkinsci/jenkins/commit/2fb288474e980d0e7ff9c4a3b768874835a3e92e

--- a/deb/build/debian/jenkins.init
+++ b/deb/build/debian/jenkins.init
@@ -31,6 +31,9 @@ JAVA_ALLOWED_VERSION="18"
 if [ -n "$UMASK" ]; then
     DAEMON_ARGS="$DAEMON_ARGS --umask=$UMASK"
 fi
+if [ "$JENKINS_ENABLE_ACCESS_LOG" = "yes" ]; then
+    DAEMON_ARGS="$DAEMON_ARGS --accessLoggerClassName=winstone.accesslog.SimpleAccessLogger --simpleAccessLogger.format=combined --simpleAccessLogger.file=/var/log/$NAME/access_log"
+fi
 
 SU=/bin/su
 

--- a/deb/build/debian/jenkins.logrotate
+++ b/deb/build/debian/jenkins.logrotate
@@ -1,4 +1,4 @@
-/var/log/@@ARTIFACTNAME@@/@@ARTIFACTNAME@@.log {
+/var/log/@@ARTIFACTNAME@@/@@ARTIFACTNAME@@.log /var/log/@@ARTIFACTNAME@@/access_log {
         weekly
         copytruncate
         missingok


### PR DESCRIPTION
The rpm provide JENKINS_ENABLE_ACCESS_LOG which enable Jenkins to write
down some access log.  It is missing from the debian package.

1) add JENKINS_ENABLE_ACCESS_LOG (default: "no") to
   debian/jenkins.default.
1) add JENKINS_ENABLE_ACCESS_LOG support in debian/jenkins.init based on
   what is done for rpm/suse.
3) update the logrotate script.

Signed-off-by: Antoine Musso <hashar@free.fr>