### PR TITLE
Deb init kill more explicitely

### DIFF
--- a/deb/build/debian/jenkins.init
+++ b/deb/build/debian/jenkins.init
@@ -160,14 +160,14 @@ do_start()
 #
 get_running()
 {
-    return `ps -U $JENKINS_USER --no-headers -f | egrep -e '(java)' | grep -v defunct | grep -c . `
+    return `ps -U $JENKINS_USER --no-headers -f | egrep -e '(java)' | egrep -e '(@@ARTIFACTNAME@@\.war)' | grep -v defunct | grep -c . `
 }
 
 force_stop()
 {
     get_running
     if [ $? -ne 0 ]; then
-	killall -u $JENKINS_USER java daemon || return 3
+        pkill -u "${JENKINS_USER}" -f '@@ARTIFACTNAME@@.war' || return 3
     fi
 }
 


### PR DESCRIPTION
The current implementation will kill all java or daemon processes run by the jenkins-user. With my current change it will only kill either java or daemon processes that are actually running the jenkins.war (= master server daemon process):

```bash
$ pgrep -a -u jenkins -f 'jenkins.war'
7035 /usr/bin/daemon --name=jenkins --inherit --env=JENKINS_HOME=/var/lib/jenkins --output=/var/log/jenkins/jenkins.log --pidfile=/var/run/jenkins/jenkins.pid -- /usr/bin/java -Djava.awt.headless=true -Xms1976m -Xmx1976m -Djenkins.install.runSetupWizard=false -jar /usr/share/jenkins/jenkins.war --webroot=/var/cache/jenkins/war --httpPort=8080 --httpListenAddress=0.0.0.0
7036 /usr/bin/java -Djava.awt.headless=true -Xms1976m -Xmx1976m -Djenkins.install.runSetupWizard=false -jar /usr/share/jenkins/jenkins.war --webroot=/var/cache/jenkins/war --httpPort=8080 --httpListenAddress=0.0.0.0
```

Obviously this will not be needed anymore once the project switches to systemd.