### PR TITLE
[FIXES JENKINS-51888] Fixed PID mix up bug in init script

### DIFF
--- a/rpm/build/SOURCES/jenkins.init.in
+++ b/rpm/build/SOURCES/jenkins.init.in
@@ -114,13 +114,7 @@ case "$1" in
                 # [ "$sess" = "$MY_SESSION_ID" ] || continue
 	       	echo "$cmd" | grep $JENKINS_WAR > /dev/null
 		[ $? = 0 ] || continue
-                echo "$cmd" | grep -e "$JENKINS_PORT" > /dev/null
-                [ $? = 0 ] || continue
-                echo "$cmd" | grep -F "$JENKINS_LISTEN_ADDRESS" > /dev/null
-                [ $? = 0 ] || continue
-                echo "$cmd" | grep -e "$JENKINS_HTTPS_PORT" > /dev/null
-                [ $? = 0 ] || continue
-                echo "$cmd" | grep -F "$JENKINS_HTTPS_LISTEN_ADDRESS" > /dev/null
+                echo "$cmd" | grep -e "$JENKINS_HOME" > /dev/null
                 [ $? = 0 ] || continue
 		# found a PID
 		echo $pid > "$JENKINS_PID_FILE"

--- a/rpm/build/SOURCES/jenkins.init.in
+++ b/rpm/build/SOURCES/jenkins.init.in
@@ -114,6 +114,14 @@ case "$1" in
                 # [ "$sess" = "$MY_SESSION_ID" ] || continue
 	       	echo "$cmd" | grep $JENKINS_WAR > /dev/null
 		[ $? = 0 ] || continue
+                echo "$cmd" | grep -e "$JENKINS_PORT" > /dev/null
+                [ $? = 0 ] || continue
+                echo "$cmd" | grep -F "$JENKINS_LISTEN_ADDRESS" > /dev/null
+                [ $? = 0 ] || continue
+                echo "$cmd" | grep -e "$JENKINS_HTTPS_PORT" > /dev/null
+                [ $? = 0 ] || continue
+                echo "$cmd" | grep -F "$JENKINS_HTTPS_LISTEN_ADDRESS" > /dev/null
+                [ $? = 0 ] || continue
 		# found a PID
 		echo $pid > "$JENKINS_PID_FILE"
 	    done
@@ -124,7 +132,7 @@ case "$1" in
 	;;
     stop)
 	echo -n "Shutting down @@PRODUCTNAME@@ "
-	killproc @@ARTIFACTNAME@@
+	killproc -p $JENKINS_PID_FILE @@ARTIFACTNAME@@
 	RETVAL=$?
 	echo
 	;;
@@ -151,7 +159,7 @@ case "$1" in
     	$0 restart
 	;;
     status)
-    	status @@ARTIFACTNAME@@
+    	status -p $JENKINS_PID_FILE @@ARTIFACTNAME@@
 	RETVAL=$?
 	;;
     probe)


### PR DESCRIPTION
Improved PID handling in RedHat/CentOS init script to fix bug:
https://issues.jenkins-ci.org/browse/JENKINS-51888