### PR TITLE
[FIXED JENKINS-55149] deb access set in JENKINS_ARGS

### DIFF
--- a/deb/build/debian/jenkins.init
+++ b/deb/build/debian/jenkins.init
@@ -32,7 +32,7 @@ if [ -n "$UMASK" ]; then
     DAEMON_ARGS="$DAEMON_ARGS --umask=$UMASK"
 fi
 if [ "$JENKINS_ENABLE_ACCESS_LOG" = "yes" ]; then
-    DAEMON_ARGS="$DAEMON_ARGS --accessLoggerClassName=winstone.accesslog.SimpleAccessLogger --simpleAccessLogger.format=combined --simpleAccessLogger.file=/var/log/$NAME/access_log"
+    JENKINS_ARGS="$JENKINS_ARGS --accessLoggerClassName=winstone.accesslog.SimpleAccessLogger --simpleAccessLogger.format=combined --simpleAccessLogger.file=/var/log/$NAME/access_log"
 fi
 
 SU=/bin/su


### PR DESCRIPTION
The options to enable access logs were set in DAEMON_ARGS, breaking daemon startup.  Moved access log options to append to JENKINS_ARGS.