### PR TITLE
[INFRA-1416] inconcistent package listing for Contents and Packages

### DIFF
--- a/deb/publish/publish.sh
+++ b/deb/publish/publish.sh
@@ -39,7 +39,7 @@ rm $D/binary/Release.gpg || true
 gpg --batch --no-use-agent --no-default-keyring --digest-algo=sha256 --keyring "$GPG_KEYRING" --secret-keyring="$GPG_SECRET_KEYRING" --passphrase-file "$GPG_PASSPHRASE_FILE" \
   -abs -o $D/binary/Release.gpg $D/binary/Release
 
-cp $D/binary/Packages.* $D/binary/Release $D/binary/Release.gpg $D/binary/Contents.gz $D/contents/binary
+cp $D/binary/Packages* $D/binary/Release $D/binary/Release.gpg $D/binary/Contents* $D/contents/binary
 
 rsync -avz -e "ssh $SSH_OPTS" $D/contents/ "$PKGSERVER:$(echo $DEB_WEBDIR | sed 's/ /\\ /g')"
 


### PR DESCRIPTION
Publish `Contents` and `Packages` as well, not just their compressed counterparts. As can be seen in the ls output below, those files haven't been rsynced properly since mid 2017, leading to [INFRA-1416](https://issues.jenkins-ci.org/browse/INFRA-1416).

```
kohsuke@pkg.jenkins.io:/var/www/pkg.jenkins.io/debian-stable/binary$ ls -la
total 136
drwxrwxr-x 2 mirrorbrain mirrorbrain  4096 Feb 16 18:45 .
drwxrwxr-x 3 mirrorbrain mirrorbrain  4096 Feb 16 18:45 ..
-rw-rw-r-- 1 mirrorbrain mirrorbrain   357 Jun 27  2017 Contents
-rw-rw-r-- 1 mirrorbrain mirrorbrain   115 Feb 15 16:14 Contents.gz
-rw-rw-r-- 1 mirrorbrain mirrorbrain    17 Nov 28  2016 .htaccess
-rw-rw-r-- 1 mirrorbrain mirrorbrain 58796 Jun 27  2017 Packages
-rw-rw-r-- 1 mirrorbrain mirrorbrain 14393 Feb 15 16:14 Packages.bz2
-rw-rw-r-- 1 mirrorbrain mirrorbrain 15900 Feb 15 16:14 Packages.gz
-rw-rw-r-- 1 mirrorbrain mirrorbrain 13450 Feb 15 16:14 Packages.lzma
-rw-rw-r-- 1 mirrorbrain mirrorbrain  2042 Feb 15 16:14 Release
-rw-rw-r-- 1 mirrorbrain mirrorbrain   181 Feb 15 16:14 Release.gpg
```