### PR TITLE
[JENKINS-52284,JENKINS-55988,JENKINS-55989,JENKINS-55990,JENKINS-55991] - Update Unix and MacOS installers

### DIFF
--- a/deb/publish/gen.rb
+++ b/deb/publish/gen.rb
@@ -34,10 +34,10 @@ deb #{url} binary/
 </p>
 
 <p>
-You will need to explicitly install a Java runtime environment, <b>because Jenkins does not support all Java versions</b>, this is the safest way to
+You will need to explicitly install a Java Runtime Environment, <b>because Jenkins does not support all Java versions</b>, this is the safest way to
 ensure your system ends properly configured. Adding an explicit dependency requirement on Java could force installation
-of undesired versions of the JVM. Check <a href="https://jenkins.io/doc/administration/requirements/java/">this page</a>
-for more details about Java requirements in Jenkins.
+of undesired versions of the JVM. Check <a href="https://jenkins.io/doc/administration/requirements/java/">Java requirements in Jenkins</a>
+for more details.
 </p>
 
 <p>

--- a/deb/publish/gen.rb
+++ b/deb/publish/gen.rb
@@ -34,7 +34,7 @@ deb #{url} binary/
 </p>
 
 <p>
-You will need to explicitly install a Java Runtime Environment, <b>because Jenkins does not support all Java versions</b>, this is the safest way to
+You will need to explicitly install Java, <b>because Jenkins does not support all Java versions</b>, this is the safest way to
 ensure your system ends properly configured. Adding an explicit dependency requirement on Java could force installation
 of undesired versions of the JVM. Check <a href="https://jenkins.io/doc/administration/requirements/java/">Java requirements in Jenkins</a>
 for more details.

--- a/deb/publish/gen.rb
+++ b/deb/publish/gen.rb
@@ -34,14 +34,15 @@ deb #{url} binary/
 </p>
 
 <p>
-You will need to explicitly install a Java runtime environment, <b>because Jenkins does not work with Java 9</b>, this is the safest way to
+You will need to explicitly install a Java runtime environment, <b>because Jenkins does not support all Java versions</b>, this is the safest way to
 ensure your system ends properly configured. Adding an explicit dependency requirement on Java could force installation
-of undesired versions of the JVM. Check <a href="https://issues.jenkins-ci.org/browse/JENKINS-40689">JENKINS-40689</a>
-for more details about Jenkins and Java 9 compatibility.
+of undesired versions of the JVM. Check <a href="https://jenkins.io/doc/administration/requirements/java/">this page</a>
+for more details about Java requirements in Jenkins.
 </p>
 
 <p>
 <ul>
+  <li>2.164 (2019-02) and newer: Java 8 or Java 11</li>
   <li>2.54 (2017-04) and newer: Java 8</li>
   <li>1.612 (2015-05) and newer: Java 7</li>
 </ul>

--- a/osx/JenkinsInstaller.pmdoc/index.xml
+++ b/osx/JenkinsInstaller.pmdoc/index.xml
@@ -41,7 +41,7 @@
     <requirement id="file" operator="eq" value="true">
       <file>/System/Library/Frameworks/JavaVM.framework/Versions/A/Commands/java</file>
       <message-title>Java Runtime Not Found</message-title>
-      <message>You need Java runtime to run @@PRODUCTNAME@@. Open /Applications/Utilities/Java Preferences, install Java and then run this installer again.</message>
+      <message>You need Java runtime to run @@PRODUCTNAME@@. Open /Applications/Utilities/Java Preferences, install Java and then run this installer again. See https://jenkins.io/doc/administration/requirements/java/ for Java requirements</message>
     </requirement>
   </requirements>
   <flags/>

--- a/rpm/build/SOURCES/jenkins.init.in
+++ b/rpm/build/SOURCES/jenkins.init.in
@@ -77,6 +77,9 @@ candidates="
 /usr/lib/jvm/jre-1.8.0/bin/java
 /usr/lib/jvm/java-1.7.0/bin/java
 /usr/lib/jvm/jre-1.7.0/bin/java
+/usr/lib/jvm/java-11.0/bin/java
+/usr/lib/jvm/jre-11.0/bin/java
+/usr/lib/jvm/java-11-openjdk-amd64
 /usr/bin/java
 "
 for candidate in $candidates

--- a/rpm/build/SPECS/jenkins.spec
+++ b/rpm/build/SPECS/jenkins.spec
@@ -19,6 +19,7 @@ BuildRoot:	%{_tmppath}/build-%{name}-%{version}
 # Unfortunately the Oracle Java RPMs do not register as providing anything (including "java" or "jdk")
 # So either we make a hard requirement on the OpenJDK or none at all
 # Only workaround would be to use a java virtual package, see https://github.com/keystep/virtual-java-rpm
+# TODO: If re-enable, fix the matcher for Java 11
 # Requires: java >= 1:1.8.0
 Requires: procps
 Obsoletes: hudson

--- a/rpm/publish/gen.rb
+++ b/rpm/publish/gen.rb
@@ -36,6 +36,7 @@ Thus, adding an explicit dependency requirement on Java would force installation
 <p>
 
 <ul>
+  <li>2.164 (2019-02) and newer: Java 8 or Java 11</li>
   <li>2.54 (2017-04) and newer: Java 8</li>
   <li>1.612 (2015-05) and newer: Java 7</li>
 </ul>

--- a/suse/build/SPECS/jenkins.spec
+++ b/suse/build/SPECS/jenkins.spec
@@ -20,6 +20,7 @@ BuildRoot:	%{_tmppath}/build-%{name}-%{version}
 # Unfortunately the Oracle Java RPMs do not register as providing anything (including "java" or "jdk")
 # So either we make a hard requirement on the OpenJDK or none at all
 # Only workaround would be to use a java virtual package, see https://github.com/keystep/virtual-java-rpm
+# TODO: Fix the query for Java 11 if it is reenabled
 # Requires: java >= 1:1.8.0
 Requires:	procps
 Obsoletes:  hudson

--- a/suse/publish/gen.rb
+++ b/suse/publish/gen.rb
@@ -28,6 +28,7 @@ You will need to explicitly install a Java runtime environment, because Oracle's
 Thus, adding an explicit dependency requirement on Java would force installation of the OpenJDK JVM.
 
 <ul>
+  <li>2.164 (2019-02) and newer: Java 8 or Java 11</li>
   <li>2.54 (2017-04) and newer: Java 8</li>
   <li>1.612 (2015-05) and newer: Java 7</li>
 </ul>

--- a/test/base/fedora-20.sh
+++ b/test/base/fedora-20.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 yum check-update
+# TODO: Java baseline is not fixed here
 yum -y install java

--- a/test/provision/rpm.sh
+++ b/test/provision/rpm.sh
@@ -5,6 +5,7 @@ wget -q -O /etc/yum.repos.d/@@ARTIFACTNAME@@.repo @@RPM_URL@@/@@ARTIFACTNAME@@.r
 rpm --import @@RPM_URL@@/@@ORGANIZATION@@.key
 
 yum check-update || true
+#TODO Java baseline is not fixed
 yum -y install java @@ARTIFACTNAME@@
 
 systemctl start @@ARTIFACTNAME@@


### PR DESCRIPTION
It should fix all non-Windows installers, there is no critical patches. Just docs & Co

CC @jenkinsci/java11-support 
