### PR TITLE
Fixed 'daemon: unrecognized option'

### DIFF
--- a/deb/build/debian/jenkins.init
+++ b/deb/build/debian/jenkins.init
@@ -32,7 +32,7 @@ if [ -n "$UMASK" ]; then
     DAEMON_ARGS="$DAEMON_ARGS --umask=$UMASK"
 fi
 if [ "$JENKINS_ENABLE_ACCESS_LOG" = "yes" ]; then
-    DAEMON_ARGS="$DAEMON_ARGS --accessLoggerClassName=winstone.accesslog.SimpleAccessLogger --simpleAccessLogger.format=combined --simpleAccessLogger.file=/var/log/$NAME/access_log"
+    JENKINS_ARGS="$JENKINS_ARGS --accessLoggerClassName=winstone.accesslog.SimpleAccessLogger --simpleAccessLogger.format=combined --simpleAccessLogger.file=/var/log/$NAME/access_log"
 fi
 
 SU=/bin/su


### PR DESCRIPTION
In case of JENKINS_ENABLE_ACCESS_LOG="yes" options should be added into JENKINS_ARGS instead of DAEMON_ARGS. Otherwise 'daemon: unrecognized option' error occurs