### PR TITLE
[JENKINS-57096] Allow using Java 11 and Java 8 to run Jenkins on Debian / Ubuntu

### DIFF
--- a/deb/build/debian/jenkins.init
+++ b/deb/build/debian/jenkins.init
@@ -26,8 +26,6 @@ DAEMON=/usr/bin/daemon
 DAEMON_ARGS="--name=$NAME --inherit --env=JENKINS_HOME=$JENKINS_HOME --output=$JENKINS_LOG --pidfile=$PIDFILE"
 JAVA=`type -p java`
 
-JAVA_ALLOWED_VERSION="110"
-
 if [ -n "$UMASK" ]; then
     DAEMON_ARGS="$DAEMON_ARGS --umask=$UMASK"
 fi
@@ -56,10 +54,12 @@ if [ -z "$JAVA" ]; then
     exit 1
 fi
 
+# Which Java versions can be used to run Jenkins
+JAVA_ALLOWED_VERSIONS=( "18" "110" )
 # Work out the JAVA version we are working with:
 JAVA_VERSION=$($JAVA -version 2>&1 | sed -n ';s/.* version "\(.*\)\.\(.*\)\..*".*/\1\2/p;')
 
-if [ "$JAVA_VERSION" = "$JAVA_ALLOWED_VERSION" ]; then
+if [[ ${JAVA_ALLOWED_VERSIONS[*]} =~ "$JAVA_VERSION" ]]; then
     echo "Correct java version found" >&2
 else
     echo "Found an incorrect Java version" >&2

--- a/deb/build/debian/jenkins.init
+++ b/deb/build/debian/jenkins.init
@@ -26,7 +26,7 @@ DAEMON=/usr/bin/daemon
 DAEMON_ARGS="--name=$NAME --inherit --env=JENKINS_HOME=$JENKINS_HOME --output=$JENKINS_LOG --pidfile=$PIDFILE"
 JAVA=`type -p java`
 
-JAVA_ALLOWED_VERSION="18"
+JAVA_ALLOWED_VERSION="110"
 
 if [ -n "$UMASK" ]; then
     DAEMON_ARGS="$DAEMON_ARGS --umask=$UMASK"
@@ -57,7 +57,7 @@ if [ -z "$JAVA" ]; then
 fi
 
 # Work out the JAVA version we are working with:
-JAVA_VERSION=$($JAVA -version 2>&1 | sed -n ';s/.* version "\(.*\)\.\(.*\)\..*"/\1\2/p;')
+JAVA_VERSION=$($JAVA -version 2>&1 | sed -n ';s/.* version "\(.*\)\.\(.*\)\..*".*/\1\2/p;')
 
 if [ "$JAVA_VERSION" = "$JAVA_ALLOWED_VERSION" ]; then
     echo "Correct java version found" >&2


### PR DESCRIPTION
issue: [JENKINS-57096](https://issues.jenkins-ci.org/browse/JENKINS-57096)

This PR offers a way for Debian / Ubuntu users to run Jenkins on Java 11 or on Java 8.

I tested the script modification on a fresh Ubuntu Server VM by installing `openjdk-11-jdk` and `jenkins`. Jenkins couldn't start, then I updated the `/etc/init.d/jenkins` file according to my changeset and then it worked.

cc @jenkinsci/java11-support 