### PR TITLE
Prevent glob expansion on JAVA_CMD

### DIFF
--- a/rpm/build/SOURCES/jenkins.init.in
+++ b/rpm/build/SOURCES/jenkins.init.in
@@ -111,7 +111,7 @@ RETVAL=0
 case "$1" in
     start)
 	echo -n "Starting @@PRODUCTNAME@@ "
-	daemon --user "$JENKINS_USER" --pidfile "$JENKINS_PID_FILE" $JAVA_CMD $PARAMS > /dev/null
+	daemon --user "$JENKINS_USER" --pidfile "$JENKINS_PID_FILE" "$JAVA_CMD" $PARAMS > /dev/null
 	RETVAL=$?
 	if [ $RETVAL = 0 ]; then
 	    success


### PR DESCRIPTION
`JENKINS_JAVA_OPTIONS` may contain CSP arguments such as:
```-Dhudson.model.DirectoryBrowserSupport.CSP=\"style-src * 'unsafe-inline';\"```
To avoid globbing and word-splitting, this change double quote wraps `JAVA_CMD` where it is used.
This may be a breaking change for other unusual use cases, where users rely on the glob expansion of this variable.
If so, an additional variable can be introduced purely for arguments that must avoid glob expansion.