### PR TITLE
Add a Release Drafter configuration

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,17 @@
+    
+# https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
+_extends: .github
+# We are using 3-digit LTS versioning here
+version-template: $MAJOR.$MINOR.$PATCH
+tag-template: v$NEXT_PATCH_VERSION
+name-template: Jenkins Installers v$NEXT_PATCH_VERSION
+template: |
+  <!-- Optional: add a release summary here -->
+  ## 📦 Jenkins Core updates  
+  
+  * Update to Jenkins $NEXT_PATCH_VERSION ([changelog](https://jenkins.io/changelog-stable/#v$NEXT_PATCH_VERSION)) 
+  
+  $CHANGES
+  
+  **NOTE:** This is an experimental changelog. See [this page](https://github.com/jenkinsci/docker/blob/master/CHANGELOG.md) for status and versioning scheme
+    


### PR DESCRIPTION
This change reimplements Docker release notes from: https://github.com/jenkinsci/docker/releases .
I believe it might be helpful to have some kind of changelogs in this repo as well.

CC @jenkinsci/sig-platform @slide 
