### PR TITLE
Make sure jenkins is really stopped before start in debian init script

### DIFF
--- a/deb/build/debian/jenkins.init
+++ b/deb/build/debian/jenkins.init
@@ -135,6 +135,9 @@ do_start()
     #   2 if daemon could not be started
     $DAEMON $DAEMON_ARGS --running && return 1
 
+    # Verify if there is a jenkins process already running without a daemon
+    get_running || return 2
+
     # Verify that the jenkins port is not already in use, winstone does not exit
     # even for BindException
     check_tcp_port "http" "$HTTP_PORT" "@@PORT@@" "$HTTP_HOST" "0.0.0.0" || return 2
@@ -159,18 +162,26 @@ do_start()
 
 #
 # Verify that all jenkins processes have been shutdown
-# and if not, then do killall for them
 #
 get_running()
 {
     return `ps -U $JENKINS_USER --no-headers -f | egrep -e '(java)' | grep -v defunct | grep -c . `
 }
 
+#
+# killall jenkins processes that have not been shutdown
+#
 force_stop()
 {
     get_running
     if [ $? -ne 0 ]; then
 	killall -u $JENKINS_USER java daemon || return 3
+         # wait for the process to really terminate
+         for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+             sleep 1
+             get_running && return 0
+         done
+         return 2
     fi
 }
 
@@ -201,11 +212,11 @@ do_stop()
             $DAEMON $DAEMON_ARGS --running || break
         done
         if get_daemon_status; then
-	        force_stop || return 3
+	        force_stop || return "$?"
         fi
 	    ;;
 	*)
-	    force_stop || return 3
+	    force_stop || return "$?"
 	    ;;
     esac
 
@@ -242,7 +253,7 @@ case "$1" in
     do_stop
     case "$?" in
         0|1) log_end_msg 0 ;;
-        2) log_end_msg 1 ; exit 100 ;;
+        2|3) log_end_msg 1 ; exit 100 ;;
     esac
     ;;
   restart|force-reload)


### PR DESCRIPTION
This should prevent running multiple Jenkins processes at once.

The problem was that killall doesn't check if the process was really stopped.
In case Jenkins process is stuck, daemon can get killed leaving Jenkins java process behind.
Upon startup the stuck process could be ignored, since it doesn't have to have a daemon process running and it doesn't need to listen on @@PORT@@ any more thus leading to two Jenkins java processes running

Still, following code might lead to an unexpected situation with systemd. Systemctl runs init script invoked with `restart` as two invoked with `stop` followed by `start`. When stop times out, it would exit with failure, but systemctl would still run the init script with `start` regardless of that failure.
Start would exit with success in case daemon process is still be running (hence restart would be successful), but:
* Jenkins could be just finishing the shutdown, or
* no Jenkins processes were really stopped and Jenkins is still running.
I think this would still be better to end up with that, instead of ending up with two of them, which might lead to an unexpected behaviour.