### PR TITLE
Fixing a failure in rpm-sign

### DIFF
--- a/rpm/build/build.sh
+++ b/rpm/build/build.sh
@@ -15,7 +15,7 @@ pushd $D
 
   # sign the results
   for rpm in $(find RPMS -name '*.rpm'); do
-    "$BASE/bin/rpm-sign" "${rpm}"
+    "$BASE/bin/rpm-sign.bin" "${rpm}"
   done
 popd
 

--- a/suse/build/build.sh
+++ b/suse/build/build.sh
@@ -15,7 +15,7 @@ pushd $D
 
   # sign the results
   for rpm in $(find RPMS -name '*.rpm'); do
-    "$BASE/bin/rpm-sign" $rpm
+    "$BASE/bin/rpm-sign.bin" $rpm
   done
 popd
 


### PR DESCRIPTION
After updating my home OS to Ubuntu 18.04.3 LTS from 16.04 LTS, I encountered the following release failure.
It appears that gpg is now honoring the --gpg-passphrase-file option, and thus there's no need of expect.
IOW, the failure is because gpg successfully terminates, which is not what expect is expecting.

The relevant log that shows a failue below:

```
Thu Jan  2 18:17:58 PST 2020: RPMS/noarch/jenkins-2.211-1.1.noarch.rpm:
Thu Jan  2 18:17:58 PST 2020: gpg: WARNING: unsafe permissions on homedir '/home/kohsuke/.gnupg'
Thu Jan  2 18:17:58 PST 2020: gpg: WARNING: "--no-use-agent" is an obsolete option - it has no effect
Thu Jan  2 18:17:58 PST 2020: gpg: using "D50582E6!" as default secret key for signing
Thu Jan  2 18:17:59 PST 2020: gpg: WARNING: unsafe permissions on homedir '/home/kohsuke/.gnupg'
Thu Jan  2 18:17:59 PST 2020: gpg: WARNING: "--no-use-agent" is an obsolete option - it has no effect
Thu Jan  2 18:17:59 PST 2020: gpg: using "D50582E6!" as default secret key for signing
Thu Jan  2 18:17:59 PST 2020: send: spawn id exp4 not open
Thu Jan  2 18:17:59 PST 2020: while executing
Thu Jan  2 18:17:59 PST 2020: "send -- "r""
Thu Jan  2 18:17:59 PST 2020: (file "/home/kohsuke/ws/jenkins/packaging/bin/rpm-sign" line 10)
Thu Jan  2 18:17:59 PST 2020: Makefile:76: recipe for target 'target/rpm/jenkins-2.211-1.1.noarch.rpm' failed
Thu Jan  2 18:17:59 PST 2020: make: *** [target/rpm/jenkins-2.211-1.1.noarch.rpm] Error 1
```