### PR TITLE
Fix bash arrays when items need to be retrieved as separated word

### DIFF
--- a/deb/publish/publish.sh
+++ b/deb/publish/publish.sh
@@ -74,7 +74,7 @@ function init(){
   mkdir -p "$DEB_WEBDIR"
   ## On remote serve
   # shellcheck disable=SC2029
-  ssh "$PKGSERVER" "${SSH_OPTS[*]}" mkdir -p "$DEBDIR/"
+  ssh "${SSH_OPTS[@]}" "$PKGSERVER" mkdir -p "$DEBDIR/"
 }
 
 function uploadPackage(){
@@ -101,7 +101,7 @@ function show(){
   echo "DEB: $DEB"
   echo "DEBDIR: $DEBDIR"
   echo "DEB_WEBDIR: $DEB_WEBDIR"
-  echo "SSH_OPTS: $SSH_OPTS"
+  echo "SSH_OPTS: ${SSH_OPTS[*]}"
   echo "PKGSERVER: $PKGSERVER"
   echo "GPG_KEYNAME: $GPG_KEYNAME"
   echo "---"

--- a/rpm/publish/publish.sh
+++ b/rpm/publish/publish.sh
@@ -43,7 +43,7 @@ EOF
   createrepo --update -o "$RPM_WEBDIR" "$RPMDIR/"
   # on the server
   # shellcheck disable=SC2029
-  ssh "$PKGSERVER" "${SSH_OPTS[*]}" createrepo --update -o "'$RPM_WEBDIR'" "'$RPMDIR/'"
+  ssh "${SSH_OPTS[@]}" "$PKGSERVER"  createrepo --update -o "'$RPM_WEBDIR'" "'$RPMDIR/'"
 
 }
 
@@ -53,7 +53,7 @@ function init(){
   mkdir -p "$RPMDIR/"
   # mkdir -p "$RPM_WEBDIR/" # May not be necessary
   # shellcheck disable=SC2029
-  ssh "$PKGSERVER" "${SSH_OPTS[*]}" mkdir -p "'$RPMDIR/'"
+  ssh "${SSH_OPTS[@]}" "$PKGSERVER"  mkdir -p "'$RPMDIR/'"
 }
 
 

--- a/suse/publish/publish.sh
+++ b/suse/publish/publish.sh
@@ -38,7 +38,7 @@ function init(){
   mkdir -p "$SUSEDIR/" # Local
 
   # shellcheck disable=SC2029
-  ssh "$PKGSERVER" "${SSH_OPTS[*]}" mkdir -p "'$SUSEDIR/'" # Remote
+  ssh "${SSH_OPTS[@]}" "$PKGSERVER"  mkdir -p "'$SUSEDIR/'" # Remote
 
   # where to put repository index and other web contents
   mkdir -p "$SUSE_WEBDIR"
@@ -74,9 +74,9 @@ function uploadSite(){
     # server needs 'createrepo' pacakge
     createrepo --update -o "$SUSE_WEBDIR" "$SUSEDIR/" #Local
     # shellcheck disable=SC2029
-    ssh "$PKGSERVER"  "${SSH_OPTS[*]}" createrepo --update -o "'$SUSE_WEBDIR'" "'$SUSEDIR/'" # Remote
+    ssh "${SSH_OPTS[@]}" "$PKGSERVER"   createrepo --update -o "'$SUSE_WEBDIR'" "'$SUSEDIR/'" # Remote
 
-    scp "${SCP_OPTS[*]}" "$PKGSERVER:${SUSE_WEBDIR// /\\ }/repodata/repomd.xml" repodata/ # Remote
+    scp "${SCP_OPTS[@]}" "$PKGSERVER:${SUSE_WEBDIR// /\\ }/repodata/repomd.xml" repodata/ # Remote
     cp "${SUSE_WEBDIR// /\\ }/repodata/repomd.xml" repodata/ # Local
 
     gpg \
@@ -89,7 +89,7 @@ function uploadSite(){
       --yes \
       repodata/repomd.xml
 
-     scp "${SCP_OPTS[*]}" repodata/repomd.xml.asc "$PKGSERVER:${SUSE_WEBDIR// /\\ }/repodata/"
+     scp "${SCP_OPTS[@]}" repodata/repomd.xml.asc "$PKGSERVER:${SUSE_WEBDIR// /\\ }/repodata/"
      cp repodata/repomd.xml.asc "${SUSE_WEBDIR// /\\ }/repodata/"
     
   popd


### PR DESCRIPTION
${array[*]}, returns every items as a single string where ${array[@]} return every items as separated components. 