### PR TITLE
Link from Debian changelog to project changelog

### DIFF
--- a/deb/build/build.sh
+++ b/deb/build/build.sh
@@ -22,17 +22,10 @@ sed -i.bak -e 's/^\s*$/./' -e 's/^/ /' $DESCRIPTION_FILE
 # Rewrite the file
 mv "$DESCRIPTION_FILE.bak" "$DESCRIPTION_FILE"
 
-# Define changelog link for weekly releases
-CHANGELOG_LINK=https://jenkins.io/changelog/#v${VERSION}
-if [[ $VERSION =~ [0-9]+[.][0-9]+[.][0-9]+ ]]; then
-  # Link the LTS version to the LTS changelog
-  CHANGELOG_LINK=https://jenkins.io/changelog-stable/#v${VERSION}
-fi
-
 cat > $D/debian/changelog << EOF
 ${ARTIFACTNAME} ($VERSION${DEB_REVISION}) unstable; urgency=low
 
-  * Packaged ${VERSION} ${CHANGELOG_LINK}
+  * Packaged ${VERSION} https://jenkins.io/changelog${RELEASELINE}/#v${VERSION}
 
  -- ${AUTHOR}  $(date -R)
 

--- a/deb/build/build.sh
+++ b/deb/build/build.sh
@@ -22,10 +22,17 @@ sed -i.bak -e 's/^\s*$/./' -e 's/^/ /' $DESCRIPTION_FILE
 # Rewrite the file
 mv "$DESCRIPTION_FILE.bak" "$DESCRIPTION_FILE"
 
+# Define changelog link for weekly releases
+CHANGELOG_LINK=https://jenkins.io/changelog/#v${VERSION}
+if [[ $VERSION =~ [0-9]+[.][0-9]+[.][0-9]+ ]]; then
+  # Link the LTS version to the LTS changelog
+  CHANGELOG_LINK=https://jenkins.io/changelog-stable/#v${VERSION}
+fi
+
 cat > $D/debian/changelog << EOF
 ${ARTIFACTNAME} ($VERSION${DEB_REVISION}) unstable; urgency=low
 
-  * Packaged ${VERSION}
+  * Packaged ${VERSION} ${CHANGELOG_LINK}
 
  -- ${AUTHOR}  $(date -R)
 


### PR DESCRIPTION
The current Debian changelog only provides the version number and user name of the account that ran the publishing script.  Let's link to the online changelog for those users that read the Debian changelog.

I've reviewed the [Debian changelog requirements](https://www.debian.org/doc/manuals/maint-guide/dreq.en.html#changelog) and the [Debian policy](https://www.debian.org/doc/debian-policy/ch-source.html#s-dpkgchangelog) and believe this change complies with the requirements and the policy.

@daniel-beck and @oleg-nenashev may also want to comment if this is a reasonable addition.

## Before:

```
jenkins (2.222.1) unstable; urgency=low

  * Packaged 2.222.1

 -- Kohsuke Kawaguchi <kk@kohsuke.org>  Wed, 25 Mar 2020 07:12:05 -0700

```
## After:

```
jenkins (2.222.1) unstable; urgency=low

  * Packaged 2.222.1 https://jenkins.io/changelog-stable/#v2.222.1

 -- Kohsuke Kawaguchi <kk@kohsuke.org>  Wed, 25 Mar 2020 07:12:05 -0700

```