### PR TITLE
Fix MSI file extension in publish.sh

### DIFF
--- a/msi/publish/publish.sh
+++ b/msi/publish/publish.sh
@@ -31,15 +31,18 @@ function init(){
 
 function uploadPackage(){
 
-  sha256sum "${MSI}" | sed "s, .*, ${ARTIFACTNAME}.war," > "${MSI_SHASUM}"
+  cp ${ARTIFACTNAME}.msi ${MSI}
+
+  sha256sum "${MSI}" > "${MSI_SHASUM}"
+
   cat "${MSI_SHASUM}"
 
   # Local
-  rsync -avz "${MSI}" "${MSIDIR}/${VERSION}/${ARTIFACTNAME}.war"
+  rsync -avz "${MSI}" "${MSIDIR}/${VERSION}/"
   rsync -avz "${MSI_SHASUM}" "${MSIDIR}/${VERSION}/"
 
   # Remote
-  rsync -avz -e "ssh ${SSH_OPTS[*]}" "${MSI}" "$PKGSERVER:${MSIDIR}/${VERSION}/${ARTIFACTNAME}.war"
+  rsync -avz -e "ssh ${SSH_OPTS[*]}" "${MSI}" "$PKGSERVER:${MSIDIR}/${VERSION}/"
   rsync -avz -e "ssh ${SSH_OPTS[*]}" "${MSI_SHASUM}" "$PKGSERVER:${MSIDIR}/${VERSION}/"
 }
 


### PR DESCRIPTION
This pull request fixes multiple issues in the MSI publish.sh script
* Create MSI file by copying jenkins-VERSION.msi to jenkins.msi
* Upload to version/jenkins.msi instead of version/jenkins.version.msi (redundant information)
* Don't use WAR file extension
* Don't sed sha256 file name as it already contains the correct file information