### PR TITLE
Ignore the msi/build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ generated
 .iml
 .idea/
 *.orig
+
+msi/build


### PR DESCRIPTION
Too many files when you build it