### PR TITLE
Don't update debian repository metadata if not needed

### DIFF
--- a/deb/publish/publish.sh
+++ b/deb/publish/publish.sh
@@ -187,6 +187,6 @@ init
 generateSite
 signSite
 uploadPackage
-uploadPackagSite
+uploadPackageSite
 uploadHtmlSite
 clean

--- a/deb/publish/publish.sh
+++ b/deb/publish/publish.sh
@@ -80,15 +80,17 @@ function skipIfAlreadyPublished(){
 
   if ssh "${SSH_OPTS[@]}" "$PKGSERVER" test -e "${DEBDIR}/$(basename "$DEB")"; then
     echo "File already published, nothing else todo"
-    exit 0
-
+    return 0
   fi
+  return 1
 
 }
 
 # Upload Debian Package
 function uploadPackage(){
-  skipIfAlreadyPublished
+  if skipIfAlreadyPublished; then
+    return
+  fi
 
   rsync \
     -avz \
@@ -105,7 +107,9 @@ function uploadPackage(){
 }
 
 function uploadPackageSite(){
-  skipIfAlreadyPublished
+  if skipIfAlreadyPublished; then
+    return
+  fi
 
   cp \
     "$D"/binary/Packages* \

--- a/deb/publish/publish.sh
+++ b/deb/publish/publish.sh
@@ -86,8 +86,10 @@ function skipIfAlreadyPublished(){
 
 }
 
+# Upload Debian Package
 function uploadPackage(){
-  # Upload Debian Package
+  skipIfAlreadyPublished
+
   rsync \
     -avz \
     --ignore-existing \
@@ -102,7 +104,8 @@ function uploadPackage(){
     "${DEB}" "$PKGSERVER:${DEBDIR// /\\ }"
 }
 
-function uploadSite(){
+function uploadPackageSite(){
+  skipIfAlreadyPublished
 
   cp \
     "$D"/binary/Packages* \
@@ -121,6 +124,9 @@ function uploadSite(){
     -e "ssh ${SSH_OPTS[*]}" \
     --progress \
     "$D/contents/" "$PKGSERVER:${DEB_WEBDIR// /\\ }/"
+}
+
+function uploadHtmlSite(){
 
   # Html file need to be located in the binary directory
   rsync \
@@ -181,5 +187,6 @@ init
 generateSite
 signSite
 uploadPackage
-uploadSite
+uploadPackagSite
+uploadHtmlSite
 clean


### PR DESCRIPTION
We can't update Debian repository metadata if we don't also update .deb otherwise pkg.jenkins.io return a slightly different version of what's available from the binary repostiroy 

```
Err:4 https://pkg.jenkins.io/debian binary/ jenkins 2.232
  File has unexpected size (64603200 != 64603192). Mirror sync in progress? [IP: 52.167.88.112 443]
  Hashes of expected file:
   - SHA512:f9ff86dede90e59203eacac29e6a2c7e35de905648f60a5ce7a6d03d0c4bf8fc8d95d8f3b02e7efb09f4bd3a9b6ebee67c32d6bf346a516e5effb15f7671aee3
   - SHA256:6f75101f5714a6945f34105ecc572a31d32de4590cf960ab03d39ad8ea557e52
   - SHA1:fbb8cb7cb9ce232b6ae91989f057c12eb8903302 [weak]
   - MD5Sum:ab4e44722fcacfa4d1f4b00f3a109fb3 [weak]
   - Filesize:64603192 [weak]
Fetched 346 kB in 5s (72.6 kB/s)
E: Failed to fetch https://prodjenkinsreleases.blob.core.windows.net/debian/jenkins_2.232_all.deb  File has unexpected size (64603200 != 64603192). Mirror sync in progress? [IP: 52.167.88.112 443]
   Hashes of expected file:
    - SHA512:f9ff86dede90e59203eacac29e6a2c7e35de905648f60a5ce7a6d03d0c4bf8fc8d95d8f3b02e7efb09f4bd3a9b6ebee67c32d6bf346a516e5effb15f7671aee3
    - SHA256:6f75101f5714a6945f34105ecc572a31d32de4590cf960ab03d39ad8ea557e52
    - SHA1:fbb8cb7cb9ce232b6ae91989f057c12eb8903302 [weak]
    - MD5Sum:ab4e44722fcacfa4d1f4b00f3a109fb3 [weak]
    - Filesize:64603192 [weak]
```