### PR TITLE
Disable -a rsync parameter when locally

### DIFF
--- a/deb/publish/publish.sh
+++ b/deb/publish/publish.sh
@@ -89,14 +89,17 @@ function skipIfAlreadyPublished(){
 # Upload Debian Package
 function uploadPackage(){
   rsync \
-    -avz \
+    --verbose \
+    --recursive \
+    --compress \
     --ignore-existing \
-    -O --no-o --no-g --no-perms \
     --progress \
     "$DEB" "$DEBDIR/"
 
   rsync \
-    -avz \
+    --archive \
+    --verbose \
+    --compress \
     --ignore-existing \
     --progress \
     -e "ssh ${SSH_OPTS[*]}" \
@@ -113,15 +116,18 @@ function uploadPackageSite(){
     "$D"/contents/binary
 
   rsync \
-    -avz \
+    --verbose \
+    --recursive \
+    --compress \
     --progress \
-    -O --no-o --no-g --no-perms \
     "$D/contents/" "$DEB_WEBDIR/"
 
   rsync \
-    -avz \
-    -e "ssh ${SSH_OPTS[*]}" \
+    --archive \
+    --compress \
     --progress \
+    --verbose \
+    -e "ssh ${SSH_OPTS[*]}" \
     "$D/contents/" "$PKGSERVER:${DEB_WEBDIR// /\\ }/"
 }
 
@@ -129,25 +135,27 @@ function uploadHtmlSite(){
 
   # Html file need to be located in the binary directory
   rsync \
-    -avz \
+    --compress \
+    --recursive \
     --progress \
-    -O --no-o --no-g --no-perms \
+    --recursive \
+    --verbose \
     "$D/html/" "$DEBDIR/"
 
   rsync \
-    -avz \
-    -e "ssh ${SSH_OPTS[*]}" \
-    -O \
-    --no-o --no-g --no-perms \
+    --archive \
+    --compress \
     --progress \
+    --verbose \
+    -e "ssh ${SSH_OPTS[*]}" \
     "$D/html/" "$PKGSERVER:${DEB_WEBDIR// /\\ }/"
 
   rsync \
-    -rlpgoDvz \
-    -e "ssh ${SSH_OPTS[*]}" \
-    -O \
-    --no-o --no-g --no-perms \
+    --archive \
+    --compress \
     --progress \
+    --verbose \
+    -e "ssh ${SSH_OPTS[*]}" \
     "$D/html/" "$PKGSERVER:${DEBDIR// /\\ }/"
 }
 

--- a/deb/publish/publish.sh
+++ b/deb/publish/publish.sh
@@ -138,7 +138,6 @@ function uploadHtmlSite(){
     --compress \
     --recursive \
     --progress \
-    --recursive \
     --verbose \
     "$D/html/" "$DEBDIR/"
 

--- a/msi/publish/publish.sh
+++ b/msi/publish/publish.sh
@@ -54,29 +54,35 @@ function uploadPackage(){
 
   # Local
   rsync \
-    -avz \
+    --compress \
+    --verbose \
+    --recursive \
     --ignore-existing \
     --progress \
-    -O --no-o --no-g --no-perms \
     "${MSI}" "${MSIDIR}/${VERSION}/"
 
   rsync \
-    -avz \
+    --compress \
     --ignore-existing \
-    -O --no-o --no-g --no-perms \
+    --recursive \
     --progress \
+    --verbose \
     "${MSI_SHASUM}" "${MSIDIR}/${VERSION}/"
 
   # Remote
   rsync \
-    -avz \
+    --archive \
+    --compress \
+    --verbose \
     --ignore-existing \
     --progress \
     -e "ssh ${SSH_OPTS[*]}" \
     "${MSI}" "$PKGSERVER:${MSIDIR}/${VERSION}/"
 
   rsync \
-    -avz \
+    --archive \
+    --compress \
+    --verbose \
     --ignore-existing \
     --progress \
     -e "ssh ${SSH_OPTS[*]}" \
@@ -86,17 +92,20 @@ function uploadPackage(){
 # The site need to be located in the binary directory
 function uploadSite(){
   rsync \
-    -avz \
+    --compress \
+    --verbose \
+    --recursive \
+    --progress \
+    -e "ssh ${SSH_OPTS[*]}" \
+    "${D}/" "${MSIDIR// /\\ }/"
+
+  rsync \
+    --archive \
+    --compress \
+    --verbose \
     --progress \
     -e "ssh ${SSH_OPTS[*]}" \
     "${D}/" "$PKGSERVER:${MSIDIR// /\\ }/"
-
-  rsync \
-    -avz \
-    --progress \
-    -O --no-o --no-g --no-perms \
-    -e "ssh ${SSH_OPTS[*]}" \
-    "${D}/" "${MSIDIR// /\\ }/"
 }
 
 function show(){

--- a/rpm/publish/publish.sh
+++ b/rpm/publish/publish.sh
@@ -68,15 +68,18 @@ function init(){
 function uploadPackage(){
   # Local
   rsync \
-    -avz \
+    --verbose \
+    --compress \
     --ignore-existing \
-    -O --no-o --no-g --no-perms \
+    --recursive \
     --progress \
     "$RPM" "$RPMDIR/"
 
   # Remote 
   rsync \
-    -avz \
+    --archive \
+    --verbose \
+    --compress \
     -e "ssh ${SSH_OPTS[*]}" \
     --ignore-existing \
     --progress \
@@ -97,16 +100,19 @@ function show(){
 function uploadSite(){
   pushd "$D"
     rsync \
-      -avz \
+      --compress \
+      --recursive \
+      --verbose \
       --exclude RPMS \
       --exclude "HEADER.html" \
       --exclude "FOOTER.html" \
-      -O --no-o --no-g --no-perms \
       --progress \
       . "$RPM_WEBDIR/"
 
     rsync \
-      -avz \
+      --archive \
+      --compress \
+      --verbose \
       -e "ssh ${SSH_OPTS[*]}" \
       --exclude RPMS \
       --exclude "HEADER.html" \
@@ -116,22 +122,23 @@ function uploadSite(){
 
     # Following html need to be located inside the binary directory
     rsync \
-      -avz \
+      --compress \
+      --verbose \
+      --recursive \
       --include "HEADER.html" \
       --include "FOOTER.html" \
-      -O --no-o --no-g --no-perms \
       --exclude "*" \
       --progress \
       . "$RPMDIR/"
 
     rsync \
-      -rlpgoDvz \
+      --archive \
+      --compress \
+      --verbose \
       -e "ssh ${SSH_OPTS[*]}" \
       --include "HEADER.html" \
       --include "FOOTER.html" \
       --exclude "*" \
-      -O \
-      --no-o --no-g --no-perms \
       --progress \
       . "$PKGSERVER:${RPMDIR// /\\ }/"
   popd

--- a/suse/publish/publish.sh
+++ b/suse/publish/publish.sh
@@ -68,14 +68,17 @@ function show(){
 
 function uploadPackage(){
   rsync \
-    -avz \
+    --recursive \
+    --verbose \
+    --compress \
     --ignore-existing \
     --progress \
-    -O --no-o --no-g --no-perms \
     "$SUSE" "$SUSEDIR/" # Local
 
   rsync \
-    -avz \
+    --archive \
+    --verbose \
+    --compress \
     --ignore-existing \
     --progress \
     -e "ssh ${SSH_OPTS[*]}" \
@@ -86,17 +89,20 @@ function uploadSite(){
 
   pushd $D
     rsync \
-      -avz \
+      --recursive \
+      --verbose \
+      --compress \
       --progress \
       --exclude RPMS \
       --exclude "HEADER.html" \
       --exclude "FOOTER.html" \
-      -O --no-o --no-g --no-perms \
       . "$SUSE_WEBDIR/" #Local
 
     # shellcheck disable=SC2029
     rsync \
-      -avz \
+      --archive \
+      --verbose \
+      --compress \
       --progress \
       -e "ssh ${SSH_OPTS[*]}" \
       --exclude RPMS \
@@ -136,22 +142,23 @@ function uploadSite(){
 
     # Following html need to be located inside the binary directory
     rsync \
-      -avz \
+      --compress \
+      --verbose \
+      --recursive \
       --include "HEADER.html" \
       --include "FOOTER.html" \
       --exclude "*" \
-      -O --no-o --no-g --no-perms \
       --progress \
       . "$SUSEDIR/"
 
     rsync \
-      -rlpgoDvz \
+      --archive \
+      --compress \
+      --verbose \
       -e "ssh ${SSH_OPTS[*]}" \
       --include "HEADER.html" \
       --include "FOOTER.html" \
       --exclude "*" \
-      -O \
-      --no-o --no-g --no-perms \
       --progress \
       . "$PKGSERVER:${SUSEDIR// /\\ }/"
     

--- a/war/publish/publish.sh
+++ b/war/publish/publish.sh
@@ -52,29 +52,35 @@ function uploadPackage(){
 
   # Local
   rsync \
-    -avz \
+    --compress \
+    --recursive \
+    --verbose \
     --ignore-existing \
     --progress \
-    -O --no-o --no-g --no-perms \
     "${WAR}" "${WARDIR}/${VERSION}/${ARTIFACTNAME}.war"
 
   rsync \
-    -avz \
+    --compress \
+    --recursive \
+    --verbose \
     --ignore-existing \
     --progress \
-    -O --no-o --no-g --no-perms \
     "${WAR_SHASUM}" "${WARDIR}/${VERSION}/"
 
   # Remote
   rsync \
-    -avz \
+    --archive \
+    --compress \
+    --verbose \
     -e "ssh ${SSH_OPTS[*]}" \
     --ignore-existing \
     --progress \
     "${WAR}" "$PKGSERVER:${WARDIR}/${VERSION}/${ARTIFACTNAME}.war"
 
   rsync \
-    -avz \
+    --archive \
+    --compress \
+    --verbose \
     -e "ssh ${SSH_OPTS[*]}" \
     --ignore-existing \
     --progress \
@@ -84,17 +90,20 @@ function uploadPackage(){
 # Site html need to be located in the binary directory
 function uploadSite(){
   rsync \
-    -avz \
+    --compress \
+    --recursive \
+    --verbose \
+    --progress \
+    -e "ssh ${SSH_OPTS[*]}" \
+    "${D}/" "${WARDIR// /\\ }/"
+
+  rsync \
+    --archive \
+    --compress \
+    --verbose \
     --progress \
     -e "ssh ${SSH_OPTS[*]}" \
     "${D}/" "$PKGSERVER:${WARDIR// /\\ }/"
-
-  rsync \
-    -avz \
-    --progress \
-    -e "ssh ${SSH_OPTS[*]}" \
-    -O --no-o --no-g --no-perms \
-    "${D}/" "${WARDIR// /\\ }/"
 }
 
 function show(){


### PR DESCRIPTION
As suggested by @daniel-beck , I switched rsync parameter to long name to improve visiblity and disabled --archives when using rsync on local  directories as it relies on CIFS volumes.