### PR TITLE
Disable building pkg site for suse and rpm targeting on CIFS volume

### DIFF
--- a/rpm/publish/publish.sh
+++ b/rpm/publish/publish.sh
@@ -39,7 +39,8 @@ EOF
 
   # generate index 
   # locally
-  createrepo --update -o "$RPM_WEBDIR" "$RPMDIR/"
+  # disable this for now, as it's currently now used and generate errors
+  # createrepo --update -o "$RPM_WEBDIR" "$RPMDIR/"
   # on the server
   # shellcheck disable=SC2029
   ssh "${SSH_OPTS[@]}" "$PKGSERVER"  createrepo --update -o "'$RPM_WEBDIR'" "'$RPMDIR/'"
@@ -99,15 +100,16 @@ function show(){
 
 function uploadSite(){
   pushd "$D"
-    rsync \
-      --compress \
-      --recursive \
-      --verbose \
-      --exclude RPMS \
-      --exclude "HEADER.html" \
-      --exclude "FOOTER.html" \
-      --progress \
-      . "$RPM_WEBDIR/"
+    # Disable copy on local network storage
+    #rsync \
+    #  --compress \
+    #  --recursive \
+    #  --verbose \
+    #  --exclude RPMS \
+    #  --exclude "HEADER.html" \
+    #  --exclude "FOOTER.html" \
+    #  --progress \
+    #  . "$RPM_WEBDIR/"
 
     rsync \
       --archive \

--- a/suse/publish/publish.sh
+++ b/suse/publish/publish.sh
@@ -112,7 +112,10 @@ function uploadSite(){
   
     # generate index on the server
     # server needs 'createrepo' pacakge
-    createrepo --update -o "$SUSE_WEBDIR" "$SUSEDIR/" #Local
+    # Disable this for now as not critical
+    # createrepo --update -o "$SUSE_WEBDIR" "$SUSEDIR/" #Local
+    # cp "${SUSE_WEBDIR// /\\ }/repodata/repomd.xml" repodata/ # Local
+
     # shellcheck disable=SC2029
     ssh "${SSH_OPTS[@]}" "$PKGSERVER"   createrepo --update -o "'$SUSE_WEBDIR'" "'$SUSEDIR/'" # Remote
 
@@ -121,7 +124,6 @@ function uploadSite(){
       "$PKGSERVER:${SUSE_WEBDIR// /\\ }/repodata/repomd.xml" \
       repodata/ # Remote
 
-    cp "${SUSE_WEBDIR// /\\ }/repodata/repomd.xml" repodata/ # Local
 
     gpg \
       --batch \


### PR DESCRIPTION
Every generated artifacts are pushed into two locations, on pkg.jenkins.io and on a local network file storage used by for example get.jenkins.io, files generated by createrepo on the local directory are not used at the moment the priority is pkg.jenkins.io so I suggest to disable this part for now.