### PR TITLE
use IP intead of dns record for PKGSERVER 

### DIFF
--- a/env/release.mk
+++ b/env/release.mk
@@ -6,7 +6,7 @@
 export JENKINS_URL=https://cloudbees.ci.cloudbees.com/
 
 # the host to publish bits to
-export PKGSERVER=mirrorbrain@pkg.jenkins.io
+export PKGSERVER=mirrorbrain@52.202.51.185
 export SSH_OPTS=-p 22
 export SCP_OPTS=-P 22
 

--- a/env/release.mk
+++ b/env/release.mk
@@ -6,7 +6,7 @@
 export JENKINS_URL=https://cloudbees.ci.cloudbees.com/
 
 # the host to publish bits to
-export PKGSERVER=mirrorbrain@52.202.51.185
+export PKGSERVER=mirrorbrain@pkg.origin.jenkins.io
 export SSH_OPTS=-p 22
 export SCP_OPTS=-P 22
 


### PR DESCRIPTION
We are correctly experimenting Fastly for pkg.jenkins.io so we had to change the dns recored while we can still download from pkg.jenkins.io as we did, we cannot anymore push packages through that domain