### PR TITLE
Remove .FullName from msi build artifact

### DIFF
--- a/msi/build/build.ps1
+++ b/msi/build/build.ps1
@@ -83,7 +83,7 @@ Get-Location
 
 Get-ChildItem .\bin\Release -Filter *.msi -Recurse |
     Foreach-Object {
-        Write-Host "Signing installer: " + $_.FullName
+        Write-Host "Signing installer: " + $_
         # sign the file
         
         Test-Path $env:PKCS12_FILE
@@ -96,7 +96,7 @@ Get-ChildItem .\bin\Release -Filter *.msi -Recurse |
             $retries = 10
             $i = $retries
             for(; $i -gt 0; $i--) {
-                $p = Start-Process -Wait -PassThru -NoNewWindow -FilePath "signtool.exe" -ArgumentList "sign /v /f `"${env:PKCS12_FILE}`" /p ${env:SIGN_STOREPASS} /t http://timestamp.verisign.com/scripts/timestamp.dll /d `"Jenkins Automation Server ${JenkinsVersion}`" /du `"https://jenkins.io`" $_.FullName"
+                $p = Start-Process -Wait -PassThru -NoNewWindow -FilePath "signtool.exe" -ArgumentList "sign /v /f `"${env:PKCS12_FILE}`" /p ${env:SIGN_STOREPASS} /t http://timestamp.verisign.com/scripts/timestamp.dll /d `"Jenkins Automation Server ${JenkinsVersion}`" /du `"https://jenkins.io`" $_"
                 $p.WaitForExit()
                 # we will retry up to $retries times until we get a good exit code
                 if($p.ExitCode -eq 0) {
@@ -115,11 +115,11 @@ Get-ChildItem .\bin\Release -Filter *.msi -Recurse |
 
             Write-Host "Checking the signature"
             # It will print the entire certificate chain with details
-            signtool verify /v /pa /all $_.FullName
+            signtool verify /v /pa /all $_
         }
 
-    $sha256 = (Get-FileHash -Algorithm SHA256 -Path $_.FullName).Hash.ToString().ToLower()
-    Set-Content -Path "$($_.FullName).sha256" -Value "$sha256 $($_.Name)" -Force
+    $sha256 = (Get-FileHash -Algorithm SHA256 -Path $_).Hash.ToString().ToLower()
+    Set-Content -Path "$($_).sha256" -Value "$sha256 $($_.Name)" -Force
     $env:MSI_SHA256 = $sha256
 }
 


### PR DESCRIPTION
Signed-off-by: Olivier Vernin <olivier@vernin.me>

Based on this error [logs](https://release.ci.jenkins.io/blue/organizations/jenkins/core%2Fpackage/detail/master/21/pipeline/100), the windows build process try to sign the file `C:\home\jenkins\agent\workspace\core_package_master\release\msi\build\bin\Release\en-US\jenkins-2.241.msi
` then try to verify the signature of the file `jenkins-2.241.msi.FullName`.

After checking in the container, the file `C:\home\jenkins\agent\workspace\core_package_master\release\msi\build\bin\Release\en-US\jenkins-2.241.msi` is correctly generated.