### PR TITLE
Update Windows 'latest' symlink after uploading new msi

### DIFF
--- a/msi/publish/publish.sh
+++ b/msi/publish/publish.sh
@@ -94,9 +94,11 @@ function uploadPackage(){
   # This is a safety measure just in case something was left there previously
   rm -rf latest
 
-  # Create a local symlink pointing to the VERSION directory
-  # Don't need VERSION directory locally, just the unresolved symlink
-  ln -s ${VERSION} latest
+  # Create a local symlink pointing to the MSI file in the VERSION directory.
+  # Don't need VERSION directory or MSI locally, just the unresolved symlink.
+  # The downloads page downloads http://mirrors.jenkins-ci.org/windows/latest
+  # and assumes it points to the most recent MSI file.
+  ln -s ${VERSION}/windows.msi latest
 
   # Copy the symlink to PKGSERVER in the root of MSIDIR
   # Overwrites the existing symlink on the destination

--- a/msi/publish/publish.sh
+++ b/msi/publish/publish.sh
@@ -87,6 +87,28 @@ function uploadPackage(){
     --progress \
     -e "ssh ${SSH_OPTS[*]}" \
     "${MSI_SHASUM}" "$PKGSERVER:${MSIDIR}/${VERSION}/"
+
+  # Update the symlink to point to most recent Windows build
+  #
+  # Remove anything in current directory named 'latest'
+  # This is a safety measure just in case something was left there previously
+  rm -rf latest
+
+  # Create a local symlink pointing to the VERSION directory
+  # Don't need VERSION directory locally, just the unresolved symlink
+  ln -s ${VERSION} latest
+
+  # Copy the symlink to PKGSERVER in the root of MSIDIR
+  # Overwrites the existing symlink on the destination
+  rsync \
+    --archive \
+    --links \
+    --verbose \
+    -e "ssh ${SSH_OPTS[*]}" \
+    latest "$PKGSERVER:${MSIDIR}/"
+
+  # Remove the local symlink
+  rm latest
 }
 
 # The site need to be located in the binary directory


### PR DESCRIPTION
## Update Windows 'latest' symlink after uploading new msi

The 'latest' symlink allows the Download page on jenkins.io to have a constant URL that points to http://mirrors.jenkins.io/windows/latest .  It relies on the production build process to update the symlink to point to the most recent build.

Step 1 to fix https://issues.jenkins-ci.org/browse/WEBSITE-758 and https://github.com/jenkins-infra/jenkins.io/issues/3476 .

The script creates the necessary symlink locally, uploads it with rsync, then removes the local symlink.

It seems like this should be able to use a pattern similar to the technique used to update the symbolic link to the war file parent directory in http://mirrors.jenkins.io/war/ .  It is not exactly the same, since this symbolic link needs to point to the MSI file, not to the parent directory of the MSI file.

Unfortunately, I was unable to find the location where the symlink is created for the parent directory of the war file.  @olblak or @slide can you point me to that location so that I can compare the techniques?