### PR TITLE
[INFRA-2763] Use correct file name in Windows installer link

### DIFF
--- a/msi/publish/publish.sh
+++ b/msi/publish/publish.sh
@@ -98,7 +98,7 @@ function uploadPackage(){
   # Don't need VERSION directory or MSI locally, just the unresolved symlink.
   # The jenkins.io page downloads http://mirrors.jenkins-ci.org/windows/latest
   # and assumes it points to the most recent MSI file.
-  ln -s ${VERSION}/jenkins.msi latest
+  ln -s ${VERSION}/"$(basename "$MSI")" latest
 
   # Copy the symlink to PKGSERVER in the root of MSIDIR
   # Overwrites the existing symlink on the destination

--- a/msi/publish/publish.sh
+++ b/msi/publish/publish.sh
@@ -96,9 +96,9 @@ function uploadPackage(){
 
   # Create a local symlink pointing to the MSI file in the VERSION directory.
   # Don't need VERSION directory or MSI locally, just the unresolved symlink.
-  # The downloads page downloads http://mirrors.jenkins-ci.org/windows/latest
+  # The jenkins.io page downloads http://mirrors.jenkins-ci.org/windows/latest
   # and assumes it points to the most recent MSI file.
-  ln -s ${VERSION}/windows.msi latest
+  ln -s ${VERSION}/jenkins.msi latest
 
   # Copy the symlink to PKGSERVER in the root of MSIDIR
   # Overwrites the existing symlink on the destination


### PR DESCRIPTION
## [INFRA-2763](https://issues.jenkins-ci.org/browse/INFRA-2673) and [3514](https://github.com/jenkins-infra/jenkins.io/issues/3514) - Use correct file name in Windows installer link

The Windows installer for Jenkins is named 'jenkins.msi', not 'windows.msi'.  Create the symbolic link to point to 'jenkins.msi'.  Verified by performing the same operation on the local file system of pkg.jenkins.io.

Updated link is visible at http://mirrors.jenkins.io/windows/