### PR TITLE
[INFRA-1363][WIP] Rpm repository can generate metadata from staging and production packages directory 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ generated
 .iml
 .idea/
 *.orig
+credentials/ssh/known_hosts

--- a/deb/publish/publish.sh
+++ b/deb/publish/publish.sh
@@ -79,8 +79,13 @@ function init(){
 function skipIfAlreadyPublished(){
 
   if ssh "${SSH_OPTS[@]}" "$PKGSERVER" test -e "${DEBDIR}/$(basename "$DEB")"; then
-    echo "File already published, nothing else todo"
+    echo "File already published $PKGSERVER:$PROD_DEBDIR, nothing else todo"
     return 0
+  fi
+
+  if ssh "${SSH_OPTS[@]}" "$PKGSERVER" test -e "${PROD_DEBDIR}/$(basename "$DEB")"; then
+    echo "File already published on $PKGSERVER:$PROD_DEBDIR, nothing else todo"
+    exit 0
   fi
   return 1
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-# docker exec -i -t packaging_packaging_1 gpg --import --batch credentials/sandbox.gpg
 version: '3'
 volumes:
   sshd:
@@ -41,3 +40,14 @@ services:
     volumes:
       - "./pkgConfig/httpd.conf:/usr/local/apache2/conf/httpd.conf"
       - "./target:/usr/local/apache2/htdocs"
+
+## Howto
+# docker exec -i -t packaging_packaging_1 gpg --import --batch credentials/sandbox.gpg
+#
+# Delete .ssh/known_hosts
+# docker exec -i -t packaging_packaging_1 rm .ssh/known_hosts
+# docker exec -i -t packaging_packaging_1 ssh jenkins@remote
+# docker exec -i -t packaging_packaging_1 make rpm rpm.publish
+# docker exec -i -t packaging_packaging_1 make deb deb.publish
+# docker exec -i -t packaging_packaging_1 make suse suse.publish
+# docker exec -i -t packaging_packaging_1 make war war.publish

--- a/env/release.mk
+++ b/env/release.mk
@@ -11,12 +11,16 @@ export SSH_OPTS=-p 22
 export SCP_OPTS=-P 22
 
 # where to put binary files
-export WARDIR=/srv/releases/jenkins/war${RELEASELINE}
-export MSIDIR=/srv/releases/jenkins/windows${RELEASELINE}
-export OSXDIR=/srv/releases/jenkins/osx${RELEASELINE}
-export DEBDIR=/srv/releases/jenkins/debian${RELEASELINE}
-export RPMDIR=/srv/releases/jenkins/redhat${RELEASELINE}
-export SUSEDIR=/srv/releases/jenkins/opensuse${RELEASELINE}
+export WARDIR=/srv/releases/jenkins.staging/war${RELEASELINE}
+export MSIDIR=/srv/releases/jenkins.staging/windows${RELEASELINE}
+export OSXDIR=/srv/releases/jenkins.staging/osx${RELEASELINE}
+export DEBDIR=/srv/releases/jenkins.staging/debian${RELEASELINE}
+export RPMDIR=/srv/releases/jenkins.staging/redhat${RELEASELINE}
+export SUSEDIR=/srv/releases/jenkins.staging/opensuse${RELEASELINE}
+
+# Where to fetch production packages used to generate pkg website
+export RPMDIR=/srv/releases/jenkins.staging/redhat${RELEASELINE}
+export SUSEDIR=/srv/releases/jenkins.staging/opensuse${RELEASELINE}
 
 # where to put repository index and other web contents
 export  RPM_WEBDIR=/var/www/pkg.jenkins.io.staging/redhat${RELEASELINE}

--- a/env/release.mk
+++ b/env/release.mk
@@ -19,8 +19,8 @@ export RPMDIR=/srv/releases/jenkins.staging/redhat${RELEASELINE}
 export SUSEDIR=/srv/releases/jenkins.staging/opensuse${RELEASELINE}
 
 # Where to fetch production packages used to generate pkg website
-export RPMDIR=/srv/releases/jenkins.staging/redhat${RELEASELINE}
-export SUSEDIR=/srv/releases/jenkins.staging/opensuse${RELEASELINE}
+export RPMDIR=/srv/releases/jenkins/redhat${RELEASELINE}
+export SUSEDIR=/srv/releases/jenkins/opensuse${RELEASELINE}
 
 # where to put repository index and other web contents
 export  RPM_WEBDIR=/var/www/pkg.jenkins.io.staging/redhat${RELEASELINE}

--- a/env/test.mk
+++ b/env/test.mk
@@ -14,7 +14,7 @@ export SSH_OPTS=-p 22 -o StrictHostKeyChecking=no
 export SCP_OPTS=-P 22 -o StrictHostKeyChecking=no
 
 # where to put binary files
-export TESTDIR=$(realpath .)/pkg.jenkins.io
+export TESTDIR=/src/releases/jenkins
 export WARDIR=${TESTDIR}.staging/war${RELEASELINE}
 export MSIDIR=${TESTDIR}.staging/windows${RELEASELINE}
 export OSXDIR=${TESTDIR}.staging/osx${RELEASELINE}
@@ -26,6 +26,7 @@ export PROD_RPMDIR=${TESTDIR}/redhat${RELEASELINE}
 export PROD_SUSEDIR=${TESTDIR}/opensuse${RELEASELINE}
 
 # where to put repository index and other web contents
+export TESTDIR=$(realpath .)/pkg.jenkins.io
 export  RPM_WEBDIR=${TESTDIR}.staging/redhat${RELEASELINE}
 export SUSE_WEBDIR=${TESTDIR}.staging/opensuse${RELEASELINE}
 export  DEB_WEBDIR=${TESTDIR}.staging/debian${RELEASELINE}

--- a/env/test.mk
+++ b/env/test.mk
@@ -10,24 +10,27 @@ export PKGSERVER=jenkins@remote
 # Testing both with and without SSH_OPTS
 #export SSH_OPTS=-p 22
 #export SCP_OPTS=-P 22
-export SSH_OPTS=-p 22
-export SCP_OPTS=-P 22
+export SSH_OPTS=-p 22 -o StrictHostKeyChecking=no
+export SCP_OPTS=-P 22 -o StrictHostKeyChecking=no
 
 # where to put binary files
 export TESTDIR=$(realpath .)/pkg.jenkins.io
-export WARDIR=${TESTDIR}/war${RELEASELINE}
-export MSIDIR=${TESTDIR}/windows${RELEASELINE}
-export OSXDIR=${TESTDIR}/osx${RELEASELINE}
-export DEBDIR=${TESTDIR}/debian${RELEASELINE}/binary
-export RPMDIR=${TESTDIR}/redhat${RELEASELINE}
-export SUSEDIR=${TESTDIR}/opensuse${RELEASELINE}
+export WARDIR=${TESTDIR}.staging/war${RELEASELINE}
+export MSIDIR=${TESTDIR}.staging/windows${RELEASELINE}
+export OSXDIR=${TESTDIR}.staging/osx${RELEASELINE}
+export DEBDIR=${TESTDIR}.staging/debian${RELEASELINE}/binary
+export RPMDIR=${TESTDIR}.staging/redhat${RELEASELINE}
+export SUSEDIR=${TESTDIR}.staging/opensuse${RELEASELINE}
+
+export PROD_RPMDIR=${TESTDIR}/redhat${RELEASELINE}
+export PROD_SUSEDIR=${TESTDIR}/opensuse${RELEASELINE}
 
 # where to put repository index and other web contents
-export  RPM_WEBDIR=${TESTDIR}/redhat${RELEASELINE}
-export SUSE_WEBDIR=${TESTDIR}/opensuse${RELEASELINE}
-export  DEB_WEBDIR=${TESTDIR}/debian${RELEASELINE}
-export  WAR_WEBDIR=${TESTDIR}/war${RELEASELINE}
-export  MSI_WEBDIR=${TESTDIR}/windows${RELEASELINE}
+export  RPM_WEBDIR=${TESTDIR}.staging/redhat${RELEASELINE}
+export SUSE_WEBDIR=${TESTDIR}.staging/opensuse${RELEASELINE}
+export  DEB_WEBDIR=${TESTDIR}.staging/debian${RELEASELINE}
+export  WAR_WEBDIR=${TESTDIR}.staging/war${RELEASELINE}
+export  MSI_WEBDIR=${TESTDIR}.staging/windows${RELEASELINE}
 
 # URL to the aforementioned webdir.
 WEBSERVER=pkg.jenkins.io

--- a/msi/publish/publish.sh
+++ b/msi/publish/publish.sh
@@ -38,9 +38,13 @@ function init(){
 function skipIfAlreadyPublished(){
 
   if ssh "${SSH_OPTS[@]}" "$PKGSERVER" test -e "${MSIDIR}/${VERSION}/$(basename "$MSI")"; then
-    echo "File already published, nothing else todo"
+    echo "File already published $PKGSERVER:${MSIDIR}/${VERSION}/$(basename "$MSI"), nothing else todo"
     exit 0
+  fi
 
+  if ssh "${SSH_OPTS[@]}" "$PKGSERVER" test -e "${PROD_MSIDIR}/${VERSION}/$(basename "$MSI")"; then
+    echo "File already published on $PKGSERVER:${PROD_MSIDIR}/${VERSION}/$(basename "$MSI"), nothing else todo"
+    exit 0
   fi
 }
 

--- a/rpm/publish/publish.sh
+++ b/rpm/publish/publish.sh
@@ -43,7 +43,8 @@ EOF
   # createrepo --update -o "$RPM_WEBDIR" "$RPMDIR/"
   # on the server
   # shellcheck disable=SC2029
-  ssh "${SSH_OPTS[@]}" "$PKGSERVER"  createrepo --update -o "'$RPM_WEBDIR'" "'$RPMDIR/'"
+  # --update can't be used because of https://bugs.centos.org/view.php?id=9189
+  ssh "${SSH_OPTS[@]}" "$PKGSERVER"  createrepo --outputdir "'$RPM_WEBDIR'" --split --pretty "'$PROD_RPMDIR/'" "'$RPMDIR/'"
 
 }
 

--- a/rpm/publish/publish.sh
+++ b/rpm/publish/publish.sh
@@ -44,16 +44,20 @@ EOF
   # on the server
   # shellcheck disable=SC2029
   # --update can't be used because of https://bugs.centos.org/view.php?id=9189
-  ssh "${SSH_OPTS[@]}" "$PKGSERVER"  createrepo --outputdir "'$RPM_WEBDIR'" --split --pretty "'$PROD_RPMDIR/'" "'$RPMDIR/'"
+  ssh "${SSH_OPTS[@]}" "$PKGSERVER"  createrepo --outputdir "'$RPM_WEBDIR'" --update --pretty --baseurl "'$PROD_RPMDIR/'" "'$RPMDIR/'" 
 
 }
 
 function skipIfAlreadyPublished(){
 
   if ssh "${SSH_OPTS[@]}" "$PKGSERVER" test -e "${RPMDIR}/$(basename "$RPM")"; then
-    echo "File already published, nothing else todo"
+    echo "File already published on $PKGSERVER:$RPMDIR, nothing else todo"
     exit 0
+  fi
 
+  if ssh "${SSH_OPTS[@]}" "$PKGSERVER" test -e "${PROD_RPMDIR}/$(basename "$RPM")"; then
+    echo "File already published on $PKGSERVER:$PROD_RPMDIR, nothing else todo"
+    exit 0
   fi
 }
 

--- a/suse/publish/publish.sh
+++ b/suse/publish/publish.sh
@@ -117,7 +117,8 @@ function uploadSite(){
     # cp "${SUSE_WEBDIR// /\\ }/repodata/repomd.xml" repodata/ # Local
 
     # shellcheck disable=SC2029
-    ssh "${SSH_OPTS[@]}" "$PKGSERVER"   createrepo --update -o "'$SUSE_WEBDIR'" "'$SUSEDIR/'" # Remote
+    # --update can't be used because of https://bugs.centos.org/view.php?id=9189
+    ssh "${SSH_OPTS[@]}" "$PKGSERVER"   createrepo --outputdir "'$SUSE_WEBDIR'" --pretty --split "'$PROD_SUSEDIR/'"  "'$SUSEDIR/'" # Remote
 
     scp \
       "${SCP_OPTS[@]}" \

--- a/suse/publish/publish.sh
+++ b/suse/publish/publish.sh
@@ -48,9 +48,12 @@ function init(){
 function skipIfAlreadyPublished(){
 
   if ssh "${SSH_OPTS[@]}" "$PKGSERVER" "test -e ${SUSEDIR}/$(basename $SUSE)"; then
-    echo "File already published, nothing else todo"
+    echo "File already published $PKGSERVER:${SUSEDIR}/$(basename "$SUSE"), nothing else todo"
     exit 0
-
+  fi
+  if ssh "${SSH_OPTS[@]}" "$PKGSERVER" "test -e ${PROD_SUSEDIR}/$(basename $SUSE)"; then
+    echo "File already published $PKGSERVER:${PROD_SUSEDIR}/$(basename "$SUSE"), nothing else todo"
+    exit 0
   fi
 
 }

--- a/war/publish/publish.sh
+++ b/war/publish/publish.sh
@@ -39,9 +39,12 @@ function init(){
 function skipIfAlreadyPublished(){
 
   if ssh "${SSH_OPTS[@]}" "$PKGSERVER" test -e "${WARDIR}/${VERSION}/${ARTIFACTNAME}.war"; then
-    echo "File already published, nothing else todo"
+    echo "File already published $PKGSERVER:${WARDIR}/${VERSION}/${ARTIFACTNAME}.war, nothing else todo"
     exit 0
-
+  fi
+  if ssh "${SSH_OPTS[@]}" "$PKGSERVER" test -e "${PROD_WARDIR}/${VERSION}/${ARTIFACTNAME}.war"; then
+    echo "File already published $PKGSERVER:${PROD_WARDIR}/${VERSION}/${ARTIFACTNAME}.war, nothing else todo"
+    exit 0
   fi
 }
 


### PR DESCRIPTION
This pull request is an attempt to build rpm package website from both production and staging repositories in order to have stage website that we could promote later one.

Package promotion is done from this [PR](https://github.com/jenkins-infra/release/pull/88)

In order to test this PR, you can use the docker-compose environment

**For some reason that I still ignore, when the same package is located in the two directories (staging and production), the same package appears multiple times in the repository as displayed in the following snippet.**

```
**root@067f9791f451:/tmp# gunzip  -c /tmp/test_rpm/repodata/af5f1114bd67785bd39b03edea0461423c022ac42aaa8367d1ec2ff70082f8ae-filelists.xml.gz
<?xml version="1.0" encoding="UTF-8"?>
<filelists xmlns="http://linux.duke.edu/metadata/filelists" packages="3">
<package pkgid="7c3e35d1e33ebaeb27039352d1052ad5422840b608ee81572ee800a27fbf1e71" name="jenkinstest" arch="noarch">
    <version epoch="0" ver="2.199" rel="1.1"/>

    <file>/etc/init.d/jenkinstest</file>
    <file>/etc/logrotate.d/jenkinstest</file>
    <file>/etc/sysconfig/jenkinstest</file>
    <file>/usr/lib/jenkinstest/jenkinstest.war</file>
    <file>/usr/sbin/rcjenkinstest</file>
    <file type="dir">/usr/lib/jenkinstest</file>
    <file type="dir">/var/cache/jenkinstest</file>
    <file type="dir">/var/lib/jenkinstest</file>
    <file type="dir">/var/log/jenkinstest</file>
</package>

<package pkgid="e48981c5575f8aa4f44fc8d8aa02e8abba62ab43082de235a28b588b0479f244" name="hudson" arch="noarch">
    <version epoch="0" ver="1.331" rel="1.1"/>

    <file>/etc/init.d/hudson</file>
    <file>/etc/logrotate.d/hudson</file>
    <file>/etc/sysconfig/hudson</file>
    <file>/usr/lib/hudson/hudson.war</file>
    <file>/usr/sbin/rchudson</file>
    <file type="dir">/usr/lib/hudson</file>
    <file type="dir">/var/lib/hudson</file>
    <file type="dir">/var/log/hudson</file>
</package>

<package pkgid="7c3e35d1e33ebaeb27039352d1052ad5422840b608ee81572ee800a27fbf1e71" name="jenkinstest" arch="noarch">
    <version epoch="0" ver="2.199" rel="1.1"/>

    <file>/etc/init.d/jenkinstest</file>
    <file>/etc/logrotate.d/jenkinstest</file>
    <file>/etc/sysconfig/jenkinstest</file>
    <file>/usr/lib/jenkinstest/jenkinstest.war</file>
    <file>/usr/sbin/rcjenkinstest</file>
    <file type="dir">/usr/lib/jenkinstest</file>
    <file type="dir">/var/cache/jenkinstest</file>
    <file type="dir">/var/lib/jenkinstest</file>
    <file type="dir">/var/log/jenkinstest</file>
</package>
**
```