### PR TITLE
Adding gpg key details (including fingerprints) to the RPM/Debian pages.

### DIFF
--- a/bin/indexGenerator.py
+++ b/bin/indexGenerator.py
@@ -159,9 +159,8 @@ class IndexGenerator:
         if (self.gpg_pub_key_info_file != "."):
             gpg_pub_key = Path(self.gpg_pub_key_info_file)
             if (gpg_pub_key.is_file()): 
-                gpg_pub_key = open(self.gpg_pub_key_info_file, "r")
-                pub_key_info = gpg_pub_key.read()
-                gpg_pub_key.close()
+                with open(self.gpg_pub_key_info_file, "r") as gpg_pub_key:
+                    pub_key_info = gpg_pub_key.read()
         
         return pub_key_info
 

--- a/bin/indexGenerator.py
+++ b/bin/indexGenerator.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 
 from jinja2 import Environment, FileSystemLoader
+from pathlib import Path
 
 import getopt
 import os
 import sys
-
 
 def basename(path):
     return os.path.basename(path)
@@ -68,12 +68,14 @@ class IndexGenerator:
         self.organization = os.getenv('ORGANIZATION', 'jenkins.io')
         self.product_name = os.getenv('PRODUCTNAME', 'Jenkins')
         self.distribution = os.getenv('OS_FAMILY', 'debian')
+        self.gpg_pub_key_info_file = os.getenv('GPGPUBKEYINFO', '.')
         self.target_directory = './target/' + self.distribution
+
         try:
             opts, args = getopt.getopt(
                 argv,
                 "hd:o:",
-                ["targetDir=", "distribution="]
+                ["targetDir=", "distribution=", "gpg-key-info-file="]
             )
         except getopt.GetoptError:
             print(self.HELP_MESSAGE)
@@ -85,6 +87,8 @@ class IndexGenerator:
             elif opt in ("-d", "--distribution"):
                 self.distribution = arg
                 self.target_directory = './target/' + self.distribution
+            elif opt in ("-g", "--gpg-key-info-file"):
+                self.gpg_pub_key_info_file = arg
             elif opt in ("-o", "--targetDir"):
                 self.target_directory = arg
                 self.targetFile = self.target_directory + "/HEADER.html"
@@ -112,6 +116,7 @@ class IndexGenerator:
         print('Repository footer generated: ' + self.footer)
         print('Root header generated: ' + self.root_header)
         print('Root footer generated: ' + self.root_footer)
+        print("GPG Key Info File: " + self.gpg_pub_key_info_file)
 
     def generate_root_header(self):
 
@@ -148,6 +153,18 @@ class IndexGenerator:
         with open(self.footer, "w") as f:
             f.write(template.render(contexts))
 
+    def fetch_pubkeyinfo(self):
+        pub_key_info = ""
+
+        if (self.gpg_pub_key_info_file != "."):
+            gpg_pub_key = Path(self.gpg_pub_key_info_file)
+            if (gpg_pub_key.is_file()): 
+                gpg_pub_key = open(self.gpg_pub_key_info_file, "r")
+                pub_key_info = gpg_pub_key.read()
+                gpg_pub_key.close()
+        
+        return pub_key_info
+
     def generate_repository_header(self):
         contexts = {
             'product_name': self.product_name,
@@ -157,8 +174,10 @@ class IndexGenerator:
             'os_family': self.distribution,
             'packages': self.packages,
             'releaseline': self.releaseline,
-            'web_url': self.web_url
+            'web_url': self.web_url,
+            'pub_key_info': self.fetch_pubkeyinfo()
         }
+
         env = Environment(loader=FileSystemLoader(self.template_directory))
         env.filters['basename'] = basename
         template = env.get_template(self.template_file)
@@ -176,8 +195,10 @@ class IndexGenerator:
             'os_family': self.distribution,
             'packages': self.packages,
             'releaseline': self.releaseline,
-            'web_url': self.web_url
+            'web_url': self.web_url,
+            'pub_key_info': self.fetch_pubkeyinfo()
         }
+
         env = Environment(loader=FileSystemLoader(self.template_directory))
         env.filters['basename'] = basename
         templateIndex = env.get_template('index.html')

--- a/deb/publish/publish.sh
+++ b/deb/publish/publish.sh
@@ -31,8 +31,8 @@ function generateSite(){
   
   "$BASE/bin/indexGenerator.py" \
     --distribution debian \
-    --targetDir "$D/html" \
-    --gpg-key-info-file "${D}/${ORGANIZATION}.key.info"
+    --gpg-key-info-file "${D}/${ORGANIZATION}.key.info" \
+    --targetDir "$D/html"
   
   "$BASE/bin/branding.py" "$D"
 

--- a/deb/publish/publish.sh
+++ b/deb/publish/publish.sh
@@ -27,10 +27,12 @@ function generateSite(){
   cp -R "$bin/contents/." "$D/contents"
   
   gpg --export -a --output "$D/contents/${ORGANIZATION}.key" "${GPG_KEYNAME}"
+  echo "$(gpg --import-options show-only --import $D/${ORGANIZATION}.key)" > "$D/${ORGANIZATION}.key.info"
   
   "$BASE/bin/indexGenerator.py" \
     --distribution debian \
-    --targetDir "$D/html"
+    --targetDir "$D/html" \
+    --gpg-key-info-file "${D}/${ORGANIZATION}.key.info"
   
   "$BASE/bin/branding.py" "$D"
 

--- a/rpm/publish/publish.sh
+++ b/rpm/publish/publish.sh
@@ -20,11 +20,13 @@ function clean(){
 }
 
 function generateSite(){
+  gpg --export -a --output "$D/${ORGANIZATION}.key" "${GPG_KEYNAME}"
+  echo "$(gpg --import-options show-only --import $D/${ORGANIZATION}.key)" > "$D/${ORGANIZATION}.key.info"
+  
   "$BASE/bin/indexGenerator.py" \
     --distribution redhat \
-    --targetDir "${D}"
-  
-  gpg --export -a --output "$D/${ORGANIZATION}.key" "${GPG_KEYNAME}"
+    --targetDir "${D}" \
+    --gpg-key-info-file "${D}/${ORGANIZATION}.key.info"
   
   "$BASE/bin/branding.py" "$D"
   

--- a/rpm/publish/publish.sh
+++ b/rpm/publish/publish.sh
@@ -25,8 +25,8 @@ function generateSite(){
   
   "$BASE/bin/indexGenerator.py" \
     --distribution redhat \
-    --targetDir "${D}" \
-    --gpg-key-info-file "${D}/${ORGANIZATION}.key.info"
+    --gpg-key-info-file "${D}/${ORGANIZATION}.key.info" \
+    --targetDir "$D"
   
   "$BASE/bin/branding.py" "$D"
   

--- a/templates/header.debian.html
+++ b/templates/header.debian.html
@@ -33,6 +33,12 @@ Update your local package index, then finally install {{product_name}}:
   sudo apt-get install {{artifactName}}
   </pre>
 </p>
+
+<p>
+The apt packages were signed using this key:
+</p>
+
+<pre class="text-white bg-dark" style="box-sizing:border-box; padding:1.5rem 1rem;">{{ pub_key_info|trim }}</pre>
 {% endblock %}
 
 {% block  individual_package_instruction  %}

--- a/templates/header.redhat.html
+++ b/templates/header.redhat.html
@@ -25,6 +25,13 @@
   yum install {{artifactName}}
   </pre>
 
+  <p>
+  The rpm packages were signed using this key:
+  </p>
+
+  <pre class="text-white bg-dark" style="box-sizing:border-box; padding:1.5rem 1rem;">{{ pub_key_info|trim }}</pre>
+
+
 {% endblock %}
 
 {% block  individual_package_instruction  %}


### PR DESCRIPTION
Hello there,

I wanted to verify the GPG keys used to sign RPM packages and I couldn't find the key fingerprint anywhere.

This PR exports the public key info into a file. The content of that file gets loaded and input into the generated HEADER.html and index.html files for the Debian and RPM distributions.

The following PR is a work in progress. I've tested locally using the following commands:

```bash
mkdir -p ../jpkg-work
rm -f ../jpkg-work/*.html
DEB_URL="http://example.com" bin/indexGenerator.py --distribution debian --targetDir "$PWD/../jpkg-work" --gpg-key-info-file "$PWD/../jpkg-work/gpg.key.info"
```

AFAIK it _should_ work however it needs additional testing in a build environment which I can't do ATM.