### PR TITLE
RELEASELINE is used in the MSI package name

### DIFF
--- a/msi/publish/publish.sh
+++ b/msi/publish/publish.sh
@@ -46,7 +46,7 @@ function skipIfAlreadyPublished(){
 
 function uploadPackage(){
 
-  cp "${ARTIFACTNAME}-${VERSION}.msi" "${MSI}"
+  cp "${ARTIFACTNAME}-${VERSION}${RELEASELINE}.msi" "${MSI}"
 
   sha256sum "${MSI}" > "${MSI_SHASUM}"
 


### PR DESCRIPTION
This [job](https://release.ci.jenkins.io/blue/organizations/jenkins/core%2Fpackage/detail/stable-2.235/4/artifacts) is failing because we are referencing a MSI package that doesn't contain the RELEASELINE. We weren't affected until now because weekly releases uses an empty releaseline