### PR TITLE
Adding a (fix?) for debian output error.

### DIFF
--- a/deb/publish/publish.sh
+++ b/deb/publish/publish.sh
@@ -27,11 +27,11 @@ function generateSite(){
   cp -R "$bin/contents/." "$D/contents"
   
   gpg --export -a --output "$D/contents/${ORGANIZATION}.key" "${GPG_KEYNAME}"
-  echo "$(gpg --import-options show-only --import $D/${ORGANIZATION}.key)" > "$D/${ORGANIZATION}.key.info"
+  echo "$(gpg --import-options show-only --import $D/contents/${ORGANIZATION}.key)" > "$D/contents/${ORGANIZATION}.key.info"
   
   "$BASE/bin/indexGenerator.py" \
     --distribution debian \
-    --gpg-key-info-file "${D}/${ORGANIZATION}.key.info" \
+    --gpg-key-info-file "${D}/contents/${ORGANIZATION}.key.info" \
     --targetDir "$D/html"
   
   "$BASE/bin/branding.py" "$D"


### PR DESCRIPTION
A fix for https://github.com/jenkinsci/packaging/pull/192#issuecomment-668600104

GPG keys are missing on https://pkg.jenkins.io/debian.