### PR TITLE
[JENKINS-64053] - Escape SERVICE_USERNAME when configuring directory permissions in the MSI installer

### DIFF
--- a/msi/build/jenkins.wxs
+++ b/msi/build/jenkins.wxs
@@ -164,7 +164,7 @@
         Id="SetDirectoryPermissionsServiceAccount"
         Before="SetDirectoryPermissionsServiceAccount"
         Sequence="execute"
-        Value ="&quot;[System64Folder]icacls.exe&quot; &quot;[JENKINSDIR_STRIPPED]&quot; /inheritance:r /grant *S-1-5-32-544:(OI)(CI)(F) /grant [SERVICE_USERNAME]:(OI)(CI)(F)" />
+        Value ="&quot;[System64Folder]icacls.exe&quot; &quot;[JENKINSDIR_STRIPPED]&quot; /inheritance:r /grant *S-1-5-32-544:(OI)(CI)(F) /grant &quot;[SERVICE_USERNAME]&quot;:(OI)(CI)(F)" />
 
     <CustomAction
         Id="SetDirectoryPermissionsServiceAccount"


### PR DESCRIPTION
Fixes https://issues.jenkins-ci.org/browse/JENKINS-64053
I do not have a user to test it, but it should be quite straightforward