### PR TITLE
Remove Java 7 check from rpm init script

### DIFF
--- a/rpm/build/SOURCES/jenkins.init.in
+++ b/rpm/build/SOURCES/jenkins.init.in
@@ -75,8 +75,6 @@ candidates="
 /etc/alternatives/java
 /usr/lib/jvm/java-1.8.0/bin/java
 /usr/lib/jvm/jre-1.8.0/bin/java
-/usr/lib/jvm/java-1.7.0/bin/java
-/usr/lib/jvm/jre-1.7.0/bin/java
 /usr/lib/jvm/java-11.0/bin/java
 /usr/lib/jvm/jre-11.0/bin/java
 /usr/lib/jvm/java-11-openjdk-amd64


### PR DESCRIPTION
Java 7 has not been supported [since Jenkins 2.54](https://www.jenkins.io/blog/2017/04/10/jenkins-has-upgraded-to-java-8/)