### PR TITLE
FIX - Updated the regex on JAVA_VERSION

### DIFF
--- a/deb/build/debian/jenkins.init
+++ b/deb/build/debian/jenkins.init
@@ -57,7 +57,7 @@ fi
 # Which Java versions can be used to run Jenkins
 JAVA_ALLOWED_VERSIONS=( "18" "110" )
 # Work out the JAVA version we are working with:
-JAVA_VERSION=$($JAVA -version 2>&1 | sed -n ';s/.* version "\(.*\)\.\(.*\)\..*".*/\1\2/p;')
+JAVA_VERSION=$($JAVA -version 2>&1 | sed -n ';s/.* version "\([0-9]\{1,2\}\)\.\([0-9]\{1,2\}\)\..*".*/\1\2/p;')
 
 if [[ ${JAVA_ALLOWED_VERSIONS[*]} =~ "$JAVA_VERSION" ]]; then
     echo "Correct java version found" >&2


### PR DESCRIPTION
On Ubuntu 18.04 LTS, an updated version of openjdk-11 (11.0.9.1+1-0ubuntu1~18.04)
prevent Jenkins LTS 2.249.3 from restarting. The regex didn't match the new way of
displaying the version.

> $ java -version
openjdk version "11.0.9.1" 2020-11-04
OpenJDK Runtime Environment (build 11.0.9.1+1-Ubuntu-0ubuntu1.18.04)
OpenJDK 64-Bit Server VM (build 11.0.9.1+1-Ubuntu-0ubuntu1.18.04, mixed mode, sharing)

> $ apt show jenkins
Package: jenkins
Version: 2.249.3
[...]

So check this: https://regex101.com/r/EXnrrx/1

With my fix, it seems to work on my server: https://regex101.com/r/kuRRto/1