### PR TITLE
jenkins.init: Use pgrep to match jenkins.war instead of all java processes.

### DIFF
--- a/deb/build/debian/jenkins.init
+++ b/deb/build/debian/jenkins.init
@@ -165,7 +165,7 @@ do_start()
 #
 get_running()
 {
-    return `ps -U $JENKINS_USER --no-headers -f | egrep -e '(java)' | grep -v defunct | grep -c . `
+    return `pgrep -U $JENKINS_USER -f jenkins.war | grep -c .`
 }
 
 #

--- a/rpm/build/SOURCES/jenkins.init.in
+++ b/rpm/build/SOURCES/jenkins.init.in
@@ -112,7 +112,7 @@ RETVAL=0
 case "$1" in
     start)
 	echo -n "Starting @@PRODUCTNAME@@ "
-	daemon --user "$JENKINS_USER" --pidfile "$JENKINS_PID_FILE" $JAVA_CMD $PARAMS > /dev/null
+	daemon --user "$JENKINS_USER" --pidfile "$JENKINS_PID_FILE" "$JAVA_CMD" $PARAMS > /dev/null
 	RETVAL=$?
 	if [ $RETVAL = 0 ]; then
 	    success


### PR DESCRIPTION
This should improve some cornercases where other java processes might be
running as the same $JENKINS_USER.