### PR TITLE
Use SHA256 for MSI file digest in signtool

### DIFF
--- a/msi/build/build.ps1
+++ b/msi/build/build.ps1
@@ -98,7 +98,7 @@ Get-ChildItem .\bin\Release -Filter *.msi -Recurse |
                 # Pop first entry from timestamp server array, use it as timestamp server for this attempt
                 $timestamp, $timestampservers = $timestampservers
                 # Submit SHA256 digest to RFC 3161 timestamp server
-                $p = Start-Process -Wait -PassThru -NoNewWindow -FilePath "signtool.exe" -ArgumentList "sign /v /f `"${env:PKCS12_FILE}`" /p ${env:SIGN_STOREPASS} /tr $timestamp /td SHA256 /d `"Jenkins Automation Server ${JenkinsVersion}`" /du `"https://jenkins.io`" $($_.FullName)"
+                $p = Start-Process -Wait -PassThru -NoNewWindow -FilePath "signtool.exe" -ArgumentList "sign /v /f `"${env:PKCS12_FILE}`" /p ${env:SIGN_STOREPASS} /tr $timestamp /td SHA256 /fd SHA256 /d `"Jenkins Automation Server ${JenkinsVersion}`" /du `"https://jenkins.io`" $($_.FullName)"
                 $p.WaitForExit()
                 # we will retry up to $retries times until we get a good exit code
                 if($p.ExitCode -eq 0) {


### PR DESCRIPTION
The previous change to this file used SHA256 for the timestamp digest algorithm but failed to specify the file digest algorithm.

The signtool program defaults to use SHA1 when a file digest is not specified.  The Microsoft documentation recommends SHA256 rather than SHA1 for the file digest algorithm.  This change uses SHA256 for the file digest algorithm as recommended by Microsoft documentation.

https://docs.microsoft.com/en-us/dotnet/framework/tools/signtool-exe says:

> The Windows 10 SDK, Windows 10 HLK, Windows 10 WDK and Windows 10 ADK builds 20236 and later require specifying the digest  algorithm. The SignTool sign command requires the /fd file digest  algorithm and the /td timestamp digest algorithm option to be  specified during signing and timestamping, respectively. A warning  (error code 0, initially) will be thrown if /fd is not specified  during signing and if /td is not specified during timestamping. In  later versions of SignTool, the warning will become an error. SHA256  is recommended and considered to be more secure than SHA1 by the  industry.
