### PR TITLE
Trade our global dependency on Akuma for an RPM-specific dependency on daemonize

### DIFF
--- a/rpm/build/SOURCES/jenkins.init.in
+++ b/rpm/build/SOURCES/jenkins.init.in
@@ -87,7 +87,7 @@ do
 done
 
 JAVA_CMD="$JENKINS_JAVA_CMD $JENKINS_JAVA_OPTIONS -DJENKINS_HOME=$JENKINS_HOME -jar $JENKINS_WAR"
-PARAMS="--logfile=/var/log/@@ARTIFACTNAME@@/@@ARTIFACTNAME@@.log --webroot=/var/cache/@@ARTIFACTNAME@@/war --daemon"
+PARAMS="--logfile=/var/log/@@ARTIFACTNAME@@/@@ARTIFACTNAME@@.log --webroot=/var/cache/@@ARTIFACTNAME@@/war"
 [ -n "$JENKINS_PORT" ] && PARAMS="$PARAMS --httpPort=$JENKINS_PORT"
 [ -n "$JENKINS_LISTEN_ADDRESS" ] && PARAMS="$PARAMS --httpListenAddress=$JENKINS_LISTEN_ADDRESS"
 [ -n "$JENKINS_HTTPS_PORT" ] && PARAMS="$PARAMS --httpsPort=$JENKINS_HTTPS_PORT"
@@ -112,7 +112,7 @@ RETVAL=0
 case "$1" in
     start)
 	echo -n "Starting @@PRODUCTNAME@@ "
-	daemon --user "$JENKINS_USER" --pidfile "$JENKINS_PID_FILE" "$JAVA_CMD" $PARAMS > /dev/null
+	daemonize -u "$JENKINS_USER" -p "$JENKINS_PID_FILE" $JAVA_CMD $PARAMS
 	RETVAL=$?
 	if [ $RETVAL = 0 ]; then
 	    success

--- a/rpm/build/SPECS/jenkins.spec
+++ b/rpm/build/SPECS/jenkins.spec
@@ -21,7 +21,7 @@ BuildRoot:	%{_tmppath}/build-%{name}-%{version}
 # Only workaround would be to use a java virtual package, see https://github.com/keystep/virtual-java-rpm
 # TODO: If re-enable, fix the matcher for Java 11
 # Requires: java >= 1:1.8.0
-Requires: procps
+Requires: daemonize procps
 Obsoletes: hudson
 Conflicts: hudson
 PreReq: /usr/sbin/groupadd /usr/sbin/useradd


### PR DESCRIPTION
Jenkins core and `extras-executable-war` implement a `--daemon` option via Akuma, a Java library once maintained by Kohsuke to do daemonization. Akuma uses JNA and has a lot of complicated platform-specific Java code that is a bit of a maintenance burden on core. I'd like to get rid of Akuma from `extras-executable-war` and Jenkins core to simplify maintenance. That would mean getting rid of the `--daemon` option. But can it be safely removed?

Not at the moment, because it's still used in the initialization script for the RPM. You might wonder why it's necessary. After all both the Debian and RPM versions start Jenkins with `daemon […]`. So why does the RPM version need to pass `--daemon` compared to the Debian version which does not? The answer is that the Debian version uses `/usr/bin/daemon`, which can background the process. The `daemon` function in the RPM script isn't `/usr/bin/daemon` (which doesn't exist on Fedora) but rather just a very primitive function in `/etc/init.d/functions` that runs `ulimit`, `nice`, and `runuser`. Nothing fancy like `/usr/bin/daemon` on Debian-based systems. It can't background the process. Hence to background the process we need to use `--daemon` with the WAR, which pulls in all the complicated Akuma Java process management code that I'd like to delete.

This all seems a bit unnecessary to me. Why not just trade our dependency on Akuma (which is a maintenance burden on all platforms, including Docker where daemonization is totally unnecessary) for an RPM-specific dependency on `daemonize(1)` instead? Unlike the primitive `daemon` function in `/etc/init.d/functions`, `daemonize(1)` is a full-featured program and can handle backgrounding the process. Yes it's one more package that the user has to install, but this seems like a reasonable trade-off to me.

I tested this on a real Fedora system and verified that I could build the package with these changes and install it and start Jenkins. The RPM wouldn't install unless I first installed `daemonize`. Once the RPM was installed I verified that Jenkins started normally (without the Akuma system property) and was running in the background. `systemctl status jenkinstest.service` looked normal as well.