### PR TITLE
[JENKINS-66359] Include epel-release in rpm install instructions

### DIFF
--- a/bin/indexGenerator.py
+++ b/bin/indexGenerator.py
@@ -87,6 +87,7 @@ class IndexGenerator:
             elif opt in ("-d", "--distribution"):
                 self.distribution = arg
                 self.target_directory = './target/' + self.distribution
+                os.makedirs(self.target_directory, exist_ok=True)
             elif opt in ("-g", "--gpg-key-info-file"):
                 self.gpg_pub_key_info_file = arg
             elif opt in ("-o", "--targetDir"):

--- a/bin/indexGenerator.py
+++ b/bin/indexGenerator.py
@@ -109,7 +109,7 @@ class IndexGenerator:
         print("Organization: " + self.organization)
         print("Artifact Name: " + self.artifact)
         print("Distribution: " + self.distribution)
-        print("Web URL: " + self.web_url)
+        print("Web URL: " + str(self.web_url))
         print('Number of Packages found: ' + str(len(self.packages)))
         print('Template file: ' + self.template_file)
         print('Repository header generated: ' + self.targetFile)

--- a/templates/header.redhat.html
+++ b/templates/header.redhat.html
@@ -22,6 +22,8 @@
 
   <pre class="text-white bg-dark">
 
+  yum install epel-release # repository that provides 'daemonize'
+  yum install java-11-openjdk-devel
   yum install {{artifactName}}
   </pre>
 


### PR DESCRIPTION
## Include epel_release in rpm instructions

Updates the installation instructions for rpm releases to include epel-release so that the 2.306 dependency on daemonize can be satisfied.

- Install epel-release and Java 11 on CentOS
- Create target directories if they don't exist
- Don't fail when a web_url is None

See current [Fedora install instructions](https://www.jenkins.io/doc/book/installing/linux/#fedora) and current [CentOS install instructions](https://www.jenkins.io/doc/book/installing/linux/#red-hat-centos).