### PR TITLE
Avoid killing jenkins on logrotate

### DIFF
--- a/suse/build/SOURCES/jenkins.logrotate
+++ b/suse/build/SOURCES/jenkins.logrotate
@@ -7,11 +7,5 @@
     notifempty
     missingok
     create 644
-    postrotate
-        [ -r /etc/sysconfig/@@ARTIFACTNAME@@ ] && source /etc/sysconfig/@@ARTIFACTNAME@@
-        if [ -s /var/run/@@ARTIFACTNAME@@.pid ]; then
-            JPID=`cat /var/run/@@ARTIFACTNAME@@.pid`
-            test -n "`find /proc/$JPID -maxdepth 0 -user ${JENKINS_USER:-@@ARTIFACTNAME@@} 2>/dev/null`" && kill -s ALRM $JPID || :
-        fi
-    endscript
+    copytruncate
 }


### PR DESCRIPTION
copied from the `rpm` version

In my tests, SIGALRM terminated jenkins and caused long-running jobs to fail