### PR TITLE
chore: Cleanup checks for signing info in build.ps1 for MSI

### DIFF
--- a/msi/build/build.ps1
+++ b/msi/build/build.ps1
@@ -79,14 +79,8 @@ msbuild "jenkins.wixproj" /p:Stable="${isLts}" /p:WAR="${War}" /p:Configuration=
 
 Get-ChildItem .\bin\Release -Filter *.msi -Recurse |
     Foreach-Object {
-        Write-Host "Signing installer: $($_.FullName)"
-        # sign the file
-        
-        Test-Path $env:PKCS12_FILE
-        [System.String]::IsNullOrWhiteSpace($env:SIGN_STOREPASS)
-
-        if((Test-Path $env:PKCS12_FILE) -and (-not [System.String]::IsNullOrWhiteSpace($env:SIGN_STOREPASS))) {
-            Write-Host "Signing installer"
+        if((-not ([System.String]::IsNullOrWhiteSpace($env:PKCS12_FILE)) -and (Test-Path $env:PKCS12_FILE)) -and (-not [System.String]::IsNullOrWhiteSpace($env:SIGN_STOREPASS))) {
+            Write-Host "Signing installer: $($_.FullName)"
             # always disable tracing here
             Set-PSDebug -Trace 0
             $retries = 10


### PR DESCRIPTION
This will only try and sign the files if the PKCS12_FILE variable is not null and exists.  Previously if the environment variable was not set, there is an exception thrown. This just makes it cleaner for building in a development flow because you don't get false errors.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did