### PR TITLE
Use keyring instead of apt-key to register Debian signing key on stable-2.303

### DIFF
--- a/templates/header.debian.html
+++ b/templates/header.debian.html
@@ -13,14 +13,17 @@
 
   <pre class="text-white bg-dark">
     <code>
-  wget -q -O - <a href="{{web_url}}/{{organization}}.key" style="color:white">{{web_url}}/{{organization}}.key</a> | sudo apt-key add -</code>
+  curl -fsSL <a href="{{web_url}}/{{organization}}.key" style="color:white">{{web_url}}/{{organization}}.key</a> | sudo tee \
+    /usr/share/keyrings/jenkins-keyring.asc > /dev/null</code>
   </pre>
 
   Then add the following entry in your <tt>/etc/apt/sources.list</tt>:
 
   <pre class="text-white bg-dark">
-    
-  deb {{ web_url }} binary/
+    <code>
+  echo deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] \
+    {{ web_url }} binary/ | sudo tee \
+    /etc/apt/sources.list.d/jenkins.list > /dev/null</code>
   </pre>
 </p>
 
@@ -29,8 +32,9 @@ Update your local package index, then finally install {{product_name}}:
 
   <pre class="text-white bg-dark">
 
+    <code>
   sudo apt-get update
-  sudo apt-get install {{artifactName}}
+  sudo apt-get install {{artifactName}}</code>
   </pre>
 </p>
 


### PR DESCRIPTION
## Use keyring instead of apt-key for Debian install on stable-2.303

See https://github.com/jenkins-infra/jenkins.io/pull/4675 for the rationale and the links to information like:

* https://unix.stackexchange.com/a/463140/498490
* https://wiki.debian.org/DebianRepository/UseThirdParty

Include this change on the stable-2.303 branch because the next LTS branch will likely be constructed from stable-2.303.