### PR TITLE
Consistency with `docker-compose.yaml`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,7 @@ pipeline {
   options {
     disableConcurrentBuilds(abortPrevious: true)
     buildDiscarder logRotator(numToKeepStr: '5') // Retain only last 5 builds to reduce space requirements
+    timeout(time: 1, unit: 'HOURS')
   }
 
   environment {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,6 @@
 pipeline {
   agent {
     kubernetes {
-      label 'package-linux'
       yamlFile 'KubernetesPod.yaml'
       workingDir '/home/jenkins/agent'
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,12 +13,9 @@ pipeline {
   }
 
   environment {
-    JENKINS_VERSION = 'latest'
-    JENKINS_DOWNLOAD_URL= 'https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/'
-    WAR = "${WORKSPACE}/target/war/jenkins.war"
-    MSI = "${WORKSPACE}/target/msi/jenkins.msi"
-    BRAND = "${WORKSPACE}/branding/common"
-    ORGANIZATION = 'example.org'
+    WAR = "${WORKSPACE}/jenkins.war"
+    MSI = "${WORKSPACE}/jenkins.msi"
+    BRAND = "${WORKSPACE}/branding/test.mk"
     BUILDENV = "${WORKSPACE}/env/test.mk"
     CREDENTIAL = "${WORKSPACE}/credentials/test.mk"
     GPG_KEYNAME = 'test'
@@ -39,7 +36,7 @@ pipeline {
       }
       post {
         success {
-          archiveArtifacts 'target/war/*.war, target/debian/*.deb, target/rpm/*.rpm, target/suse/*.rpm'
+          archiveArtifacts 'target/debian/*.deb, target/rpm/*.rpm, target/suse/*.rpm'
         }
       }
     }

--- a/prep.sh
+++ b/prep.sh
@@ -9,7 +9,6 @@ cd "$(dirname "$0")"
 # jenkins-infra/release should be refactored to consume the new functionality.
 
 if [[ ! -f $WAR ]]; then
-	mkdir -p "$(dirname "${WAR}")"
 	jv download
 fi
 

--- a/prep.sh
+++ b/prep.sh
@@ -17,5 +17,5 @@ if ! gpg --fingerprint "${GPG_KEYNAME}"; then
 	gpg --import --batch "${GPG_KEYRING}" "${GPG_SECRET_KEYRING}"
 fi
 
-# produces: target/war/jenkins.war
+# produces: jenkins.war
 exit 0


### PR DESCRIPTION
Makes the Jenkins build more consistent with `docker-compose.yaml` in two ways:

- Removes the unneeded `JENKINS_VERSION` and `JENKINS_DOWNLOAD_URL` variables, which don't need to be set.
- Changes the values of `WAR`, `MSI`, and `BRAND` to be the same as those in `docker-compose.yaml`.