### PR TITLE
Make keys consistent with `docker-compose.yaml`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,9 +18,8 @@ pipeline {
     BRAND = "${WORKSPACE}/branding/test.mk"
     BUILDENV = "${WORKSPACE}/env/test.mk"
     CREDENTIAL = "${WORKSPACE}/credentials/test.mk"
-    GPG_KEYNAME = 'test'
-    GPG_KEYRING = "${WORKSPACE}/credentials/${GPG_KEYNAME}.gpg"
-    GPG_SECRET_KEYRING = "${WORKSPACE}/credentials/${GPG_KEYNAME}.secret.gpg"
+    GPG_KEYNAME = 'Bogus Test'
+    GPG_FILE = "${WORKSPACE}/credentials/sandbox.gpg"
   }
 
   stages {

--- a/prep.sh
+++ b/prep.sh
@@ -13,7 +13,7 @@ if [[ ! -f $WAR ]]; then
 fi
 
 if ! gpg --fingerprint "${GPG_KEYNAME}"; then
-	gpg --import --batch "${GPG_KEYRING}" "${GPG_SECRET_KEYRING}"
+	gpg --import --batch "${GPG_FILE}"
 fi
 
 # produces: jenkins.war


### PR DESCRIPTION
Makes the environment variables used in the `Jenkinsfile` for keys consistent with those in `docker-compose.yaml`