### PR TITLE
Cleanup on aisle Python

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,6 +23,7 @@ podTemplate(yaml: readTrusted('KubernetesPod.yaml'), workingDir: '/home/jenkins/
         }
         stage('Build') {
           sh 'make package'
+          sh 'python3 -m unittest discover -s bin'
         }
         archiveArtifacts 'target/debian/*.deb, target/rpm/*.rpm, target/suse/*.rpm'
       }

--- a/bin/branding.py
+++ b/bin/branding.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import re

--- a/bin/branding.py
+++ b/bin/branding.py
@@ -47,9 +47,8 @@ def read_file_content(value_path_dictionary):
 	output = dict()
 	filtered = filter(lambda x: x[1] is not None and len(x[1].strip()) > 0, value_path_dictionary.items())
 	for variable, path in filtered:
-		f = open(path, 'r')
-		output[variable] = f.read()
-		f.close()
+		with open(path, 'r') as f:
+			output[variable] = f.read()
 	return output
 
 def read_branding_variables(base_path, env_variables_list, file_variables_list):
@@ -68,12 +67,11 @@ def apply_templating_to_file(path, branding_map):
 	""" Do IN-PLACE search and replace using string templating for a each file
 		Throws Exceptions if I/O fails or substitution is missing vars (safety check)
 	"""
-	f = open(path, "r+")
-	f_content = apply_template(f.read(), branding_map)
-	f.seek(0)
-	f.write(f_content)
-	f.truncate()  # This removes any original content beyond the end of templated content
-	f.close()
+	with open(path, "r+") as f:
+		f_content = apply_template(f.read(), branding_map)
+		f.seek(0)
+		f.write(f_content)
+		f.truncate()  # This removes any original content beyond the end of templated content
 
 def apply_templating_to_folder(path, branding_map):
 	""" Walks through all contents of folder recursively, and applies templating """	

--- a/bin/branding.py
+++ b/bin/branding.py
@@ -9,92 +9,113 @@ import sys
 # Usage is 'python branding.py {file or folder}'
 # Env variables to use are given in BRANDING_ENV_VARIABLE_LIST
 # Env variables giving *paths* to read content for templating are given in BRANDING_ENV_PATH_LIST
-# Author Sam Van Oort <samvanoort@gmail.com> 
+# Author Sam Van Oort <samvanoort@gmail.com>
 
-BRANDING_ENV_VARIABLE_LIST = 'branding.list'
-BRANDING_ENV_PATH_LIST = 'branding-files.list'
+BRANDING_ENV_VARIABLE_LIST = "branding.list"
+BRANDING_ENV_PATH_LIST = "branding-files.list"
+
 
 class CustomTemplate(string.Template):
-	delimiter = '@@'
-	pattern = r""" %(delim)s(?:
+    delimiter = "@@"
+    pattern = r""" %(delim)s(?:
       (?P<escaped>) |   # Nope, taken care of by the delimiter not being a valid id character
       (?P<named>%(id)s)      |   # delimiter and a Python identifier
       (?P<braced>%(id)s)   |   # we don't support braced identifiers, since it's surrounded by delimiters
       (?P<invalid>)            # no matches
-    )%(delim)s """ % dict(delim=re.escape('@@'), id=string.Template.idpattern)
+    )%(delim)s """ % dict(
+        delim=re.escape("@@"), id=string.Template.idpattern
+    )
+
 
 def clean_text_lines(textcontent):
-	""" Splits file content by line boundaries, strips leading/trailing whitespace, 
-	    and removes comments with # and -- prefixes and whitespace lines """
-	lines = map(lambda x: x.strip(), textcontent.splitlines())
-	lines = filter(lambda x: x and not x.startswith('#') and not x.startswith('--'), lines)
-	return lines
+    """Splits file content by line boundaries, strips leading/trailing whitespace,
+    and removes comments with # and -- prefixes and whitespace lines"""
+    lines = map(lambda x: x.strip(), textcontent.splitlines())
+    lines = filter(
+        lambda x: x and not x.startswith("#") and not x.startswith("--"), lines
+    )
+    return lines
+
 
 def read_env_variable_list(path):
-	""" Read a list of environment variables from a file (one per line) and get a dict of var:value """
-	with open(path, 'r') as env_file:
-		lines = clean_text_lines(env_file.read())
-		return {x: os.environ.get(x) for x in lines}
+    """Read a list of environment variables from a file (one per line) and get a dict of var:value"""
+    with open(path, "r") as env_file:
+        lines = clean_text_lines(env_file.read())
+        return {x: os.environ.get(x) for x in lines}
+
 
 def read_file_content(value_path_dictionary):
-	""" For a {variable_name:file_path} dictionary, read each file and 
-	    return a dictionary of {variable:file_content}
+    """For a {variable_name:file_path} dictionary, read each file and
+    return a dictionary of {variable:file_content}
 
-	    If paths are null/empty, they are not read to result. """
-	output = dict()
-	filtered = filter(lambda x: x[1] and x[1].strip(), value_path_dictionary.items())
-	for variable, path in filtered:
-		with open(path, 'r') as f:
-			output[variable] = f.read()
-	return output
+    If paths are null/empty, they are not read to result."""
+    output = {}
+    filtered = filter(lambda x: x[1] and x[1].strip(), value_path_dictionary.items())
+    for variable, path in filtered:
+        with open(path, "r") as f:
+            output[variable] = f.read()
+    return output
+
 
 def read_branding_variables(base_path, env_variables_list, file_variables_list):
-	""" Read branding variables from files/environment and return result """
+    """Read branding variables from files/environment and return result"""
 
-	raw_variables = read_env_variable_list(os.path.join(base_path, env_variables_list))
-	file_variables = read_env_variable_list(os.path.join(base_path, file_variables_list))
-	raw_variables.update(read_file_content(file_variables))  # Add file content variables
-	return raw_variables
+    raw_variables = read_env_variable_list(os.path.join(base_path, env_variables_list))
+    file_variables = read_env_variable_list(
+        os.path.join(base_path, file_variables_list)
+    )
+    raw_variables.update(
+        read_file_content(file_variables)
+    )  # Add file content variables
+    return raw_variables
+
 
 def apply_template(input_string, branding_map):
-	""" Applies templating in a back-compatible fashion """
-	return CustomTemplate(input_string).substitute(branding_map)
+    """Applies templating in a back-compatible fashion"""
+    return CustomTemplate(input_string).substitute(branding_map)
+
 
 def apply_templating_to_file(path, branding_map):
-	""" Do IN-PLACE search and replace using string templating for a each file
-		Throws Exceptions if I/O fails or substitution is missing vars (safety check)
-	"""
-	with open(path, "r+") as f:
-		f_content = apply_template(f.read(), branding_map)
-		f.seek(0)
-		f.write(f_content)
-		f.truncate()  # This removes any original content beyond the end of templated content
+    """Do IN-PLACE search and replace using string templating for a each file
+    Throws Exceptions if I/O fails or substitution is missing vars (safety check)
+    """
+    with open(path, "r+") as f:
+        f_content = apply_template(f.read(), branding_map)
+        f.seek(0)
+        f.write(f_content)
+        f.truncate()  # This removes any original content beyond the end of templated content
+
 
 def apply_templating_to_folder(path, branding_map):
-	""" Walks through all contents of folder recursively, and applies templating """	
-	for root, dirnames, filenames in os.walk(path):
-		for filename in filenames:
-			apply_templating_to_file(os.path.join(root, filename), branding_map)
+    """Walks through all contents of folder recursively, and applies templating"""
+    for root, dirnames, filenames in os.walk(path):
+        for filename in filenames:
+            apply_templating_to_file(os.path.join(root, filename), branding_map)
+
 
 # Importable as a library without executing it
-if(__name__ == '__main__'):
-	if (len(sys.argv) != 2):
-		raise Exception("Usage: branding.py [file or folder name]")
-	path = sys.argv[1]
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        raise Exception("Usage: branding.py [file or folder name]")
+    path = sys.argv[1]
 
-	mypath = os.path.dirname(os.path.realpath(__file__))
-	branding_values = read_branding_variables(mypath, BRANDING_ENV_VARIABLE_LIST, BRANDING_ENV_PATH_LIST)
+    mypath = os.path.dirname(os.path.realpath(__file__))
+    branding_values = read_branding_variables(
+        mypath, BRANDING_ENV_VARIABLE_LIST, BRANDING_ENV_PATH_LIST
+    )
 
-	# List of branding values that are allowed to be blank
-	allowed_blank = ['RELEASELINE']
-	# Remove branding values with nothing set so we fail early if they are used in a template
-	# except for values where blank is explicitly allows
-	branding_values = {k: v for k, v in branding_values.items() if k in allowed_blank or v}
+    # List of branding values that are allowed to be blank
+    allowed_blank = ["RELEASELINE"]
+    # Remove branding values with nothing set so we fail early if they are used in a template
+    # except for values where blank is explicitly allows
+    branding_values = {
+        k: v for k, v in branding_values.items() if k in allowed_blank or v
+    }
 
-	# Apply templating to files or content of folder
-	if os.path.isfile(path):
-		apply_templating_to_file(path, branding_values)
-	elif os.path.isdir(path):
-		apply_templating_to_folder(path, branding_values)
-	else:
-		raise Exception("Supplied path must be file or directory")
+    # Apply templating to files or content of folder
+    if os.path.isfile(path):
+        apply_templating_to_file(path, branding_values)
+    elif os.path.isdir(path):
+        apply_templating_to_folder(path, branding_values)
+    else:
+        raise Exception("Supplied path must be file or directory")

--- a/bin/branding.py
+++ b/bin/branding.py
@@ -45,7 +45,7 @@ def read_file_content(value_path_dictionary):
 
 	    If paths are null/empty, they are not read to result. """
 	output = dict()
-	filtered = filter(lambda x: x[1] is not None and len(x[1].strip()) > 0, value_path_dictionary.items())
+	filtered = filter(lambda x: x[1] and x[1].strip(), value_path_dictionary.items())
 	for variable, path in filtered:
 		with open(path, 'r') as f:
 			output[variable] = f.read()

--- a/bin/branding.py
+++ b/bin/branding.py
@@ -2,10 +2,8 @@
 
 import os
 from string import Template
-import fnmatch
 import sys
 import re
-from optparse import OptionParser
 
 # Applies branding to files/folders with simple templating
 # Usage is 'python branding.py {file or folder}'

--- a/bin/branding.py
+++ b/bin/branding.py
@@ -78,8 +78,8 @@ def apply_templating_to_file(path, branding_map):
 def apply_templating_to_folder(path, branding_map):
 	""" Walks through all contents of folder recursively, and applies templating """	
 	for root, dirnames, filenames in os.walk(path):
-		func = lambda x: apply_templating_to_file(os.path.join(root, x), branding_map)
-		map(func, filenames)
+		for filename in filenames:
+			apply_templating_to_file(os.path.join(root, filename), branding_map)
 
 # Importable as a library without executing it
 if(__name__ == '__main__'):

--- a/bin/branding.py
+++ b/bin/branding.py
@@ -34,8 +34,7 @@ def read_env_variable_list(path):
 	""" Read a list of environment variables from a file (one per line) and get a dict of var:value """
 	with open(path, 'r') as env_file:
 		lines = clean_text_lines(env_file.read())
-		branding_values = {x:os.environ.get(x) for x in lines}
-	return branding_values
+		return {x: os.environ.get(x) for x in lines}
 
 def read_file_content(value_path_dictionary):
 	""" For a {variable_name:file_path} dictionary, read each file and 
@@ -90,7 +89,7 @@ if(__name__ == '__main__'):
 	allowed_blank = ['RELEASELINE']
 	# Remove branding values with nothing set so we fail early if they are used in a template
 	# except for values where blank is explicitly allows
-	branding_values = dict(filter (lambda x: x[0] in allowed_blank or x[1], branding_values.items()))
+	branding_values = {k: v for k, v in branding_values.items() if k in allowed_blank or v}
 
 	# Apply templating to files or content of folder
 	if os.path.isfile(path):

--- a/bin/branding.py
+++ b/bin/branding.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
 import os
-from string import Template
-import sys
 import re
+import string
+import sys
 
 # Applies branding to files/folders with simple templating
 # Usage is 'python branding.py {file or folder}'
@@ -14,14 +14,14 @@ import re
 BRANDING_ENV_VARIABLE_LIST = 'branding.list'
 BRANDING_ENV_PATH_LIST = 'branding-files.list'
 
-class CustomTemplate(Template):
+class CustomTemplate(string.Template):
 	delimiter = '@@'
 	pattern = r""" %(delim)s(?:
       (?P<escaped>) |   # Nope, taken care of by the delimiter not being a valid id character
       (?P<named>%(id)s)      |   # delimiter and a Python identifier
       (?P<braced>%(id)s)   |   # we don't support braced identifiers, since it's surrounded by delimiters
       (?P<invalid>)            # no matches
-    )%(delim)s """ % dict(delim=re.escape('@@'), id=Template.idpattern)
+    )%(delim)s """ % dict(delim=re.escape('@@'), id=string.Template.idpattern)
 
 def clean_text_lines(textcontent):
 	""" Splits file content by line boundaries, strips leading/trailing whitespace, 

--- a/bin/indexGenerator.py
+++ b/bin/indexGenerator.py
@@ -6,40 +6,37 @@ import os
 import pathlib
 import sys
 
+
 def basename(path):
     return os.path.basename(path)
 
 
 class IndexGenerator:
     DISTRIBUTIONS = {
-        'debian': {
-            'extension': '.deb',
-            'template': 'header.debian.html',
-            'web_url': os.getenv('DEB_URL')
+        "debian": {
+            "extension": ".deb",
+            "template": "header.debian.html",
+            "web_url": os.getenv("DEB_URL"),
         },
-        'redhat': {
-            'extension': '.rpm',
-            'template': 'header.redhat.html',
-            'web_url': os.getenv('RPM_URL')
+        "redhat": {
+            "extension": ".rpm",
+            "template": "header.redhat.html",
+            "web_url": os.getenv("RPM_URL"),
         },
-        'opensuse': {
-            'extension': '.rpm',
-            'template': 'header.opensuse.html',
-            'web_url': os.getenv('SUSE_URL')
+        "opensuse": {
+            "extension": ".rpm",
+            "template": "header.opensuse.html",
+            "web_url": os.getenv("SUSE_URL"),
         },
-        'war': {
-            'extension': '.war',
-            'template': 'header.war.html',
-            'web_url': 'unset'
+        "war": {"extension": ".war", "template": "header.war.html", "web_url": "unset"},
+        "windows": {
+            "extension": ".msi",
+            "template": "header.msi.html",
+            "web_url": "unset",
         },
-        'windows': {
-            'extension': '.msi',
-            'template': 'header.msi.html',
-            'web_url': 'unset'
-        }
     }
 
-    HELP_MESSAGE = '''
+    HELP_MESSAGE = """
     Generate header.html for package distribution site
     It supports debian, redhat and opensuse packages
 
@@ -51,41 +48,39 @@ class IndexGenerator:
         indexGenerator.py
             -d debian
             -o /packages/website/debian
-    '''
+    """
 
     packages = []
-    targetFile = ''
-    template_file = ''
-    template_directory = 'templates'
+    targetFile = ""
+    template_file = ""
+    template_directory = "templates"
     repositories = []
 
     def __init__(self, argv):
 
-        self.artifact = os.getenv('ARTIFACTNAME', 'jenkins')
-        self.releaseline = os.getenv('RELEASELINE', '')
-        self.download_url = os.getenv('URL', 'null')
-        self.organization = os.getenv('ORGANIZATION', 'jenkins.io')
-        self.product_name = os.getenv('PRODUCTNAME', 'Jenkins')
-        self.distribution = os.getenv('OS_FAMILY', 'debian')
-        self.gpg_pub_key_info_file = os.getenv('GPGPUBKEYINFO', '.')
-        self.target_directory = './target/' + self.distribution
+        self.artifact = os.getenv("ARTIFACTNAME", "jenkins")
+        self.releaseline = os.getenv("RELEASELINE", "")
+        self.download_url = os.getenv("URL", "null")
+        self.organization = os.getenv("ORGANIZATION", "jenkins.io")
+        self.product_name = os.getenv("PRODUCTNAME", "Jenkins")
+        self.distribution = os.getenv("OS_FAMILY", "debian")
+        self.gpg_pub_key_info_file = os.getenv("GPGPUBKEYINFO", ".")
+        self.target_directory = "./target/" + self.distribution
 
         try:
             opts, args = getopt.getopt(
-                argv,
-                "hd:o:",
-                ["targetDir=", "distribution=", "gpg-key-info-file="]
+                argv, "hd:o:", ["targetDir=", "distribution=", "gpg-key-info-file="]
             )
         except getopt.GetoptError:
             print(self.HELP_MESSAGE)
             sys.exit(2)
         for opt, arg in opts:
-            if opt == '-h':
+            if opt == "-h":
                 print(self.HELP_MESSAGE)
                 sys.exit()
             elif opt in ("-d", "--distribution"):
                 self.distribution = arg
-                self.target_directory = './target/' + self.distribution
+                self.target_directory = "./target/" + self.distribution
                 os.makedirs(self.target_directory, exist_ok=True)
             elif opt in ("-g", "--gpg-key-info-file"):
                 self.gpg_pub_key_info_file = arg
@@ -94,13 +89,13 @@ class IndexGenerator:
                 self.targetFile = self.target_directory + "/HEADER.html"
 
         self.targetFile = self.target_directory + "/HEADER.html"
-        self.footer = self.target_directory + '/FOOTER.html'
-        self.index = self.target_directory + '/index.html'
+        self.footer = self.target_directory + "/FOOTER.html"
+        self.index = self.target_directory + "/index.html"
         self.template_file = self.DISTRIBUTIONS[self.distribution]["template"]
         self.root_dir = os.path.dirname(self.target_directory[0:-1])
-        self.root_header = self.root_dir + '/HEADER.html'
-        self.root_footer = self.root_dir + '/FOOTER.html'
-        self.web_url = self.DISTRIBUTIONS[self.distribution]['web_url']
+        self.root_header = self.root_dir + "/HEADER.html"
+        self.root_footer = self.root_dir + "/FOOTER.html"
+        self.web_url = self.DISTRIBUTIONS[self.distribution]["web_url"]
 
     def show_information(self):
         print("Product Name: " + self.product_name)
@@ -109,24 +104,26 @@ class IndexGenerator:
         print("Artifact Name: " + self.artifact)
         print("Distribution: " + self.distribution)
         print("Web URL: " + str(self.web_url))
-        print('Number of Packages found: ' + str(len(self.packages)))
-        print('Template file: ' + self.template_file)
-        print('Repository header generated: ' + self.targetFile)
-        print('Repository index generated: ' + self.index)
-        print('Repository footer generated: ' + self.footer)
-        print('Root header generated: ' + self.root_header)
-        print('Root footer generated: ' + self.root_footer)
+        print("Number of Packages found: " + str(len(self.packages)))
+        print("Template file: " + self.template_file)
+        print("Repository header generated: " + self.targetFile)
+        print("Repository index generated: " + self.index)
+        print("Repository footer generated: " + self.footer)
+        print("Root header generated: " + self.root_header)
+        print("Root footer generated: " + self.root_footer)
         print("GPG Key Info File: " + self.gpg_pub_key_info_file)
 
     def generate_root_header(self):
 
         contexts = {
-            'product_name': self.product_name,
-            'repositories': self.repositories
+            "product_name": self.product_name,
+            "repositories": self.repositories,
         }
 
-        env = jinja2.Environment(loader=jinja2.FileSystemLoader(self.template_directory))
-        template = env.get_template('header.root.html')
+        env = jinja2.Environment(
+            loader=jinja2.FileSystemLoader(self.template_directory)
+        )
+        template = env.get_template("header.root.html")
 
         with open(self.root_header, "w") as f:
             f.write(template.render(contexts))
@@ -135,20 +132,22 @@ class IndexGenerator:
 
         contexts = {}
 
-        env = jinja2.Environment(loader=jinja2.FileSystemLoader(self.template_directory))
-        template = env.get_template('footer.html')
+        env = jinja2.Environment(
+            loader=jinja2.FileSystemLoader(self.template_directory)
+        )
+        template = env.get_template("footer.html")
 
         with open(self.root_footer, "w") as f:
             f.write(template.render(contexts))
 
     def generate_footer(self):
 
-        contexts = {
-            'product_name': self.product_name
-        }
+        contexts = {"product_name": self.product_name}
 
-        env = jinja2.Environment(loader=jinja2.FileSystemLoader(self.template_directory))
-        template = env.get_template('footer.html')
+        env = jinja2.Environment(
+            loader=jinja2.FileSystemLoader(self.template_directory)
+        )
+        template = env.get_template("footer.html")
 
         with open(self.footer, "w") as f:
             f.write(template.render(contexts))
@@ -156,29 +155,31 @@ class IndexGenerator:
     def fetch_pubkeyinfo(self):
         pub_key_info = ""
 
-        if (self.gpg_pub_key_info_file != "."):
+        if self.gpg_pub_key_info_file != ".":
             gpg_pub_key = pathlib.Path(self.gpg_pub_key_info_file)
-            if (gpg_pub_key.is_file()): 
+            if gpg_pub_key.is_file():
                 with open(self.gpg_pub_key_info_file, "r") as gpg_pub_key:
                     pub_key_info = gpg_pub_key.read()
-        
+
         return pub_key_info
 
     def generate_repository_header(self):
         contexts = {
-            'product_name': self.product_name,
-            'url': self.download_url,
-            'organization': self.organization,
-            'artifactName': self.artifact,
-            'os_family': self.distribution,
-            'packages': self.packages,
-            'releaseline': self.releaseline,
-            'web_url': self.web_url,
-            'pub_key_info': self.fetch_pubkeyinfo()
+            "product_name": self.product_name,
+            "url": self.download_url,
+            "organization": self.organization,
+            "artifactName": self.artifact,
+            "os_family": self.distribution,
+            "packages": self.packages,
+            "releaseline": self.releaseline,
+            "web_url": self.web_url,
+            "pub_key_info": self.fetch_pubkeyinfo(),
         }
 
-        env = jinja2.Environment(loader=jinja2.FileSystemLoader(self.template_directory))
-        env.filters['basename'] = basename
+        env = jinja2.Environment(
+            loader=jinja2.FileSystemLoader(self.template_directory)
+        )
+        env.filters["basename"] = basename
         template = env.get_template(self.template_file)
 
         with open(self.targetFile, "w") as f:
@@ -186,21 +187,23 @@ class IndexGenerator:
 
     def generate_repository_index(self):
         contexts = {
-            'header': self.template_file,
-            'product_name': self.product_name,
-            'url': self.download_url,
-            'organization': self.organization,
-            'artifactName': self.artifact,
-            'os_family': self.distribution,
-            'packages': self.packages,
-            'releaseline': self.releaseline,
-            'web_url': self.web_url,
-            'pub_key_info': self.fetch_pubkeyinfo()
+            "header": self.template_file,
+            "product_name": self.product_name,
+            "url": self.download_url,
+            "organization": self.organization,
+            "artifactName": self.artifact,
+            "os_family": self.distribution,
+            "packages": self.packages,
+            "releaseline": self.releaseline,
+            "web_url": self.web_url,
+            "pub_key_info": self.fetch_pubkeyinfo(),
         }
 
-        env = jinja2.Environment(loader=jinja2.FileSystemLoader(self.template_directory))
-        env.filters['basename'] = basename
-        templateIndex = env.get_template('index.html')
+        env = jinja2.Environment(
+            loader=jinja2.FileSystemLoader(self.template_directory)
+        )
+        env.filters["basename"] = basename
+        templateIndex = env.get_template("index.html")
 
         with open(self.index, "w") as f:
             f.write(templateIndex.render(contexts))

--- a/bin/indexGenerator.py
+++ b/bin/indexGenerator.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
 
-from jinja2 import Environment, FileSystemLoader
-from pathlib import Path
-
 import getopt
+import jinja2
 import os
+import pathlib
 import sys
 
 def basename(path):
@@ -126,7 +125,7 @@ class IndexGenerator:
             'repositories': self.repositories
         }
 
-        env = Environment(loader=FileSystemLoader(self.template_directory))
+        env = jinja2.Environment(loader=jinja2.FileSystemLoader(self.template_directory))
         template = env.get_template('header.root.html')
 
         with open(self.root_header, "w") as f:
@@ -136,7 +135,7 @@ class IndexGenerator:
 
         contexts = {}
 
-        env = Environment(loader=FileSystemLoader(self.template_directory))
+        env = jinja2.Environment(loader=jinja2.FileSystemLoader(self.template_directory))
         template = env.get_template('footer.html')
 
         with open(self.root_footer, "w") as f:
@@ -148,7 +147,7 @@ class IndexGenerator:
             'product_name': self.product_name
         }
 
-        env = Environment(loader=FileSystemLoader(self.template_directory))
+        env = jinja2.Environment(loader=jinja2.FileSystemLoader(self.template_directory))
         template = env.get_template('footer.html')
 
         with open(self.footer, "w") as f:
@@ -158,7 +157,7 @@ class IndexGenerator:
         pub_key_info = ""
 
         if (self.gpg_pub_key_info_file != "."):
-            gpg_pub_key = Path(self.gpg_pub_key_info_file)
+            gpg_pub_key = pathlib.Path(self.gpg_pub_key_info_file)
             if (gpg_pub_key.is_file()): 
                 with open(self.gpg_pub_key_info_file, "r") as gpg_pub_key:
                     pub_key_info = gpg_pub_key.read()
@@ -178,7 +177,7 @@ class IndexGenerator:
             'pub_key_info': self.fetch_pubkeyinfo()
         }
 
-        env = Environment(loader=FileSystemLoader(self.template_directory))
+        env = jinja2.Environment(loader=jinja2.FileSystemLoader(self.template_directory))
         env.filters['basename'] = basename
         template = env.get_template(self.template_file)
 
@@ -199,7 +198,7 @@ class IndexGenerator:
             'pub_key_info': self.fetch_pubkeyinfo()
         }
 
-        env = Environment(loader=FileSystemLoader(self.template_directory))
+        env = jinja2.Environment(loader=jinja2.FileSystemLoader(self.template_directory))
         env.filters['basename'] = basename
         templateIndex = env.get_template('index.html')
 

--- a/bin/test_branding.py
+++ b/bin/test_branding.py
@@ -16,7 +16,7 @@ SUMMARY
 AUTHOR
 # Not here
 LICENSE
- HOMEPAGE  
+ HOMEPAGE
 CHANGELOG_PAGE
 ----------------------------------
 
@@ -31,21 +31,34 @@ SHORT_VARS = """
 TESTVAR
 """
 
-# NOMATCH is a section that should *not* be treated as a variable for substitution to 
+# NOMATCH is a section that should *not* be treated as a variable for substitution to
 # Avoid issues with curly braces
-TEMPLATED_CONTENT = "My @@VAR@@ is @@FILECONTENT@@ and I have @@@@ESCAPES@@ and @@{NOMATCH}@@ stuff"
-TEMPLATE_VARS = {'VAR': 'SPECIAL', 'FILECONTENT': 'gooooooober'}
+TEMPLATED_CONTENT = (
+    "My @@VAR@@ is @@FILECONTENT@@ and I have @@@@ESCAPES@@ and @@{NOMATCH}@@ stuff"
+)
+TEMPLATE_VARS = {"VAR": "SPECIAL", "FILECONTENT": "gooooooober"}
 
 # Shows that substitutions were performed, and NOMATCH does not get handled as a substitution variable
-TEMPLATE_EXPECTED = 'My SPECIAL is gooooooober and I have @@ESCAPES@@ and @@{NOMATCH}@@ stuff'
+TEMPLATE_EXPECTED = (
+    "My SPECIAL is gooooooober and I have @@ESCAPES@@ and @@{NOMATCH}@@ stuff"
+)
+
 
 class TestBranding(unittest.TestCase):
-
     def test_clean_lines(self):
         cleaned = set(branding.clean_text_lines(RAW_CONTENT))
-        expected = {'PRODUCTNAME', 'ARTIFACTNAME', 'SUMMARY', 
-          'PORT', 'AUTHOR', 'LICENSE', 'HOMEPAGE', 'CHANGELOG_PAGE', 
-          'SUSE_URL', 'DEB_URL', 'LICENSE_TEXT'
+        expected = {
+            "PRODUCTNAME",
+            "ARTIFACTNAME",
+            "SUMMARY",
+            "PORT",
+            "AUTHOR",
+            "LICENSE",
+            "HOMEPAGE",
+            "CHANGELOG_PAGE",
+            "SUSE_URL",
+            "DEB_URL",
+            "LICENSE_TEXT",
         }
         invalid_results = cleaned ^ expected  # Items in one set but not the other
         self.assertFalse(invalid_results)
@@ -54,30 +67,32 @@ class TestBranding(unittest.TestCase):
         temp = tempfile.NamedTemporaryFile()
         temp.write(SHORT_VARS.encode())
         temp.seek(0)
-        os.environ['TESTVAR']='testvalue'
+        os.environ["TESTVAR"] = "testvalue"
         vals = branding.read_env_variable_list(temp.name)
         self.assertEqual(1, len(vals))
-        self.assertEqual('testvalue', vals['TESTVAR'])
-    
+        self.assertEqual("testvalue", vals["TESTVAR"])
+
     def test_read_file_content(self):
-        """ Write file and then read, using path from env """
+        """Write file and then read, using path from env"""
         temp = tempfile.NamedTemporaryFile()
         temp.write(RAW_CONTENT.encode())
         temp.seek(0)
 
-        os.environ['FILEPATH']=temp.name
-        vals = branding.read_file_content({'FILEPATH': temp.name})
-        self.assertEqual(RAW_CONTENT, vals['FILEPATH'])
+        os.environ["FILEPATH"] = temp.name
+        vals = branding.read_file_content({"FILEPATH": temp.name})
+        self.assertEqual(RAW_CONTENT, vals["FILEPATH"])
 
     def test_templating(self):
         output = branding.apply_template(TEMPLATED_CONTENT, TEMPLATE_VARS)
         self.assertEqual(TEMPLATE_EXPECTED, output)
 
     def test_missing_variable(self):
-        """ Prove branding will fail if branding variable is undefined """
+        """Prove branding will fail if branding variable is undefined"""
 
         try:
-            output = branding.apply_template('My @@UNDEFINED_VALUE@@ is going to fail', {'going': 'to fail'})
+            output = branding.apply_template(
+                "My @@UNDEFINED_VALUE@@ is going to fail", {"going": "to fail"}
+            )
             self.fail("Should throw KeyError")
         except KeyError:
             pass
@@ -91,5 +106,5 @@ class TestBranding(unittest.TestCase):
         self.assertEqual(TEMPLATE_EXPECTED, temp.read().decode())
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/bin/test_branding.py
+++ b/bin/test_branding.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 
-import unittest
 import branding
-import tempfile
 import os
 import string
+import tempfile
+import unittest
 
 RAW_CONTENT = """
 PRODUCTNAME

--- a/bin/test_branding.py
+++ b/bin/test_branding.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import branding
 import os

--- a/bin/test_branding.py
+++ b/bin/test_branding.py
@@ -52,7 +52,7 @@ class TestBranding(unittest.TestCase):
 
     def test_read_env_list(self):
         temp = tempfile.NamedTemporaryFile()
-        temp.write(SHORT_VARS)
+        temp.write(SHORT_VARS.encode())
         temp.seek(0)
         os.environ['TESTVAR']='testvalue'
         vals = branding.read_env_variable_list(temp.name)
@@ -62,7 +62,7 @@ class TestBranding(unittest.TestCase):
     def test_read_file_content(self):
         """ Write file and then read, using path from env """
         temp = tempfile.NamedTemporaryFile()
-        temp.write(RAW_CONTENT)
+        temp.write(RAW_CONTENT.encode())
         temp.seek(0)
 
         os.environ['FILEPATH']=temp.name
@@ -84,11 +84,11 @@ class TestBranding(unittest.TestCase):
 
     def test_in_place_templating(self):
         temp = tempfile.NamedTemporaryFile()
-        temp.write(TEMPLATED_CONTENT)
+        temp.write(TEMPLATED_CONTENT.encode())
         temp.seek(0)
         branding.apply_templating_to_file(temp.name, TEMPLATE_VARS)
         temp.seek(0)
-        self.assertEqual(TEMPLATE_EXPECTED, temp.read())
+        self.assertEqual(TEMPLATE_EXPECTED, temp.read().decode())
 
 
 if __name__ == '__main__':

--- a/branding/description-file
+++ b/branding/description-file
@@ -1,4 +1,4 @@
-Jenkins is an open source automation server which enables developers around the world to reliably automate  their development lifecycle processes of all kinds, including build, document, test, package, stage, deployment, static analysis and many more.
+Jenkins is an open source automation server which enables developers around the world to reliably automate  their development lifecycle processes of all kinds, including build, document, test, package, stage, deployment, static analysis and many more.
 
 Jenkins is being widely used in areas of Continous Integration, Continuous Delivery, DevOps, and other areas. And it is not only about software, the same automation techniques can be applied in other areas like Hardware Engineering, Embedded Systems, BioTech, etc. 
 


### PR DESCRIPTION
Extracts some useful commits from #224 and adds some additional Python cleanup and testing:

- Move to Python 3
- Organize imports
- Format Python files with Black

I tested this by running the unit tests in Python 3 as well as running `make publish` (which caught a weird encoding problem with a non-breaking space, fixed).

CC @MarkEWaite @timja