### PR TITLE
Run Molecule tests in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,14 +38,16 @@ nodeWithTimeout('docker') {
     checkout scm
     unstash 'results'
     infra.withDockerCredentials {
-      sh '''
-          sudo apt-get update && sudo apt-get install -y python3-docker python3-pip python3-venv
-          python3 -m venv venv
-          . venv/bin/activate
-          pip install -r requirements.txt
-          molecule test
-          deactivate
-          '''.stripIndent()
+      ansiColor('xterm') {
+        sh '''
+            sudo apt-get update && sudo apt-get install -y python3-docker python3-pip python3-venv
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install -r requirements.txt
+            ANSIBLE_FORCE_COLOR=true molecule test
+            deactivate
+        '''.stripIndent()
+      }
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,9 +38,9 @@ nodeWithTimeout('azure && docker') {
     checkout scm
     unstash 'results'
     infra.withDockerCredentials {
+      sh 'sudo apt-get update && sudo apt-get install -y python3-docker python3-pip python3-venv python3-wheel' // TODO https://github.com/jenkins-infra/packer-images/pull/167
       ansiColor('xterm') {
         sh '''
-            sudo apt-get update && sudo apt-get install -y python3-docker python3-pip python3-venv
             python3 -m venv venv
             . venv/bin/activate
             pip install -r requirements.txt

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,7 +41,7 @@ nodeWithTimeout('docker') {
       sh '''
           sudo apt-get update && sudo apt-get install -y python3-docker python3-pip python3-venv
           python3 -m venv venv
-          source venv/bin/activate
+          . venv/bin/activate
           pip install -r requirements.txt
           molecule test
           deactivate

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,7 @@ nodeWithTimeout('azure && docker') {
         sh '''
             python3 -m venv venv
             . venv/bin/activate
-            pip install -U pip
+            pip install -U pip wheel
             pip install -r requirements.txt
             ANSIBLE_FORCE_COLOR=true molecule test
             deactivate

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ podTemplate(yaml: readTrusted('KubernetesPod.yaml'), workingDir: '/home/jenkins/
   }
 }
 
-nodeWithTimeout('docker') {
+nodeWithTimeout('azure && docker') {
   stage('Test') {
     checkout scm
     unstash 'results'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,6 +39,7 @@ nodeWithTimeout('docker') {
     unstash 'results'
     infra.withDockerCredentials {
       sh '''
+          sudo apt-get update && sudo apt-get install -y python3-docker python3-pip python3-venv
           python3 -m venv venv
           source venv/bin/activate
           pip install -r requirements.txt

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,6 +43,7 @@ nodeWithTimeout('azure && docker') {
         sh '''
             python3 -m venv venv
             . venv/bin/activate
+            pip install -U pip
             pip install -r requirements.txt
             ANSIBLE_FORCE_COLOR=true molecule test
             deactivate

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,32 +1,58 @@
 properties([
-  buildDiscarder(logRotator(numToKeepStr: '15', artifactNumToKeepStr: '5')),
+  buildDiscarder(logRotator(numToKeepStr: '50', artifactNumToKeepStr: '5')),
   disableConcurrentBuilds(abortPrevious: true)
 ])
+
 podTemplate(yaml: readTrusted('KubernetesPod.yaml'), workingDir: '/home/jenkins/agent') {
-  node(POD_LABEL) {
-    timeout(time: 1, unit: 'HOURS') {
-      withEnv([
-        "BUILDENV=${WORKSPACE}/env/test.mk",
-        "BRANDING_DIR=${WORKSPACE}/branding",
-        "BRAND=${WORKSPACE}/branding/test.mk",
-        "GPG_FILE=${WORKSPACE}/credentials/sandbox.gpg",
-        "GPG_KEYNAME=Bogus Test",
-        "GPG_PASSPHRASE=s3cr3t",
-        "GPG_PASSPHRASE_FILE=${WORKSPACE}/credentials/test.gpg.password.txt",
-        "WAR=${WORKSPACE}/jenkins.war",
-        "MSI=${WORKSPACE}/jenkins.msi",
-        "RELEASELINE=-experimental",
-      ]) {
-        stage('Prep') {
-          checkout scm
-          sh './prep.sh'
-        }
-        stage('Build') {
-          sh 'make package'
-          sh 'python3 -m unittest discover -s bin'
-        }
-        archiveArtifacts 'target/debian/*.deb, target/rpm/*.rpm, target/suse/*.rpm'
+  nodeWithTimeout(POD_LABEL) {
+    withEnv([
+      "BUILDENV=${WORKSPACE}/env/test.mk",
+      "BRANDING_DIR=${WORKSPACE}/branding",
+      "BRAND=${WORKSPACE}/branding/test.mk",
+      "GPG_FILE=${WORKSPACE}/credentials/sandbox.gpg",
+      "GPG_KEYNAME=Bogus Test",
+      "GPG_PASSPHRASE=s3cr3t",
+      "GPG_PASSPHRASE_FILE=${WORKSPACE}/credentials/test.gpg.password.txt",
+      "WAR=${WORKSPACE}/jenkins.war",
+      "MSI=${WORKSPACE}/jenkins.msi",
+      "RELEASELINE=-experimental",
+    ]) {
+      stage('Preparation') {
+        checkout scm
+        sh './prep.sh'
       }
+
+      stage('Build') {
+        sh 'make package'
+        sh 'python3 -m unittest discover -s bin'
+        def results = '*.war, target/debian/*.deb, target/rpm/*.rpm, target/suse/*.rpm'
+        stash includes: results, name: 'results'
+        archiveArtifacts results
+      }
+    }
+  }
+}
+
+nodeWithTimeout('docker') {
+  stage('Test') {
+    checkout scm
+    unstash 'results'
+    infra.withDockerCredentials {
+      sh '''
+          python3 -m venv venv
+          source venv/bin/activate
+          pip install -r requirements.txt
+          molecule test
+          deactivate
+          '''.stripIndent()
+    }
+  }
+}
+
+void nodeWithTimeout(String label, Closure body) {
+  node(label) {
+    timeout(time: 1, unit: 'HOURS') {
+      body()
     }
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ ansible
 docker
 jinja2
 molecule[docker]
-wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ ansible
 docker
 jinja2
 molecule[docker]
+wheel


### PR DESCRIPTION
Builds on #239 by applying @dduportal's suggestion to run this workload on the VM agents available on `ci.jenkins.io` by using the `docker` label.