### PR TITLE
Add Fedora 34

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -53,6 +53,13 @@ platforms:
       - ${MOLECULE_PROJECT_DIRECTORY}/target:/var/tmp/target
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
+  - name: fedora-34
+    image: dokken/fedora-34:latest
+    command: /sbin/init
+    volumes:
+      - ${MOLECULE_PROJECT_DIRECTORY}/target:/var/tmp/target
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
   - name: fedora-35
     image: dokken/fedora-35:latest
     command: /sbin/init


### PR DESCRIPTION
Not adding Fedora 33 because it is listed as [End of Life](https://docs.fedoraproject.org/en-US/releases/eol/).