### PR TITLE
[INFRA-2488] Add `CODEOWNERS` to `jenkinsci/packaging`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @jenkinsci/core


### PR DESCRIPTION
Fixes jenkins-infra/helpdesk#2090