### PR TITLE
Drop support for migrating from Hudson

### DIFF
--- a/deb/build/debian/control
+++ b/deb/build/debian/control
@@ -9,6 +9,4 @@ Homepage: @@HOMEPAGE@@
 Package: @@ARTIFACTNAME@@
 Architecture: all
 Depends: ${misc:Depends}, daemon, adduser, procps, psmisc, net-tools
-Conflicts: hudson
-Replaces: hudson
 Description: @@DESCRIPTION_FILE@@

--- a/deb/build/debian/jenkins.postinst
+++ b/deb/build/debian/jenkins.postinst
@@ -37,17 +37,6 @@ case "$1" in
                 "$JENKINS_USER"
         fi
 
-        # If we have an old hudson install, rename it to jenkins
-        if test -d /var/lib/hudson -a \! \( -e /var/lib/hudson/.for-jenkins \) ; then
-            # leave a marker to indicate this came from Hudson.
-            # could be useful down the road
-            # This also ensures that the .??* wildcard matches something
-            touch /var/lib/hudson/.from-hudson
-            mv -f /var/lib/hudson/* /var/lib/hudson/.??* /var/lib/@@ARTIFACTNAME@@
-            rmdir /var/lib/hudson
-            find /var/lib/@@ARTIFACTNAME@@ -user hudson -exec chown $JENKINS_USER {} + || true
-        fi
-
         # directories needed for jenkins
         # we don't do -R because it can take a long time on big installation
         chown $JENKINS_USER:$JENKINS_GROUP /var/lib/@@ARTIFACTNAME@@ /var/log/@@ARTIFACTNAME@@

--- a/rpm/build/SPECS/jenkins.spec
+++ b/rpm/build/SPECS/jenkins.spec
@@ -22,8 +22,6 @@ BuildRoot:	%{_tmppath}/build-%{name}-%{version}
 # TODO: If re-enable, fix the matcher for Java 11
 # Requires: java >= 1:1.8.0
 Requires: daemonize procps
-Obsoletes: hudson
-Conflicts: hudson
 PreReq: /usr/sbin/groupadd /usr/sbin/useradd
 BuildArch: noarch
 

--- a/suse/build/SPECS/jenkins.spec
+++ b/suse/build/SPECS/jenkins.spec
@@ -23,7 +23,6 @@ BuildRoot:	%{_tmppath}/build-%{name}-%{version}
 # TODO: Fix the query for Java 11 if it is reenabled
 # Requires: java >= 1:1.8.0
 Requires:	procps
-Obsoletes:  hudson
 PreReq:		/usr/sbin/groupadd /usr/sbin/useradd
 #PreReq:		%{fillup_prereq}
 BuildArch:	noarch
@@ -71,21 +70,6 @@ rm -rf "%{buildroot}"
 
 %post
 [ $1 -eq 1 ] && /sbin/chkconfig --add %{name}
-
-# If we have an old hudson install, rename it to jenkins
-if test -d /var/lib/hudson; then
-    # leave a marker to indicate this came from Hudson.
-    # could be useful down the road
-    # This also ensures that the .??* wildcard matches something
-    touch /var/lib/hudson/.moving-hudson
-    mv -f /var/lib/hudson/* /var/lib/hudson/.??* /var/lib/%{name}
-    rmdir /var/lib/hudson
-    find /var/lib/%{name} -user hudson -exec chown %{name} {} + || true
-fi
-if test -d /var/run/hudson; then
-    mv -f /var/run/hudson/* /var/run/%{name}
-    rmdir /var/run/hudson
-fi
 
 %preun
 if [ "$1" = 0 ] ; then


### PR DESCRIPTION
I don't feel too strongly about this PR, but anything that removes cruft in this repository and makes these long and complex scripts shorter is a good thing in my book. The final release of Hudson took place on February 15, 2016, and I doubt anyone will be upgrading from Hudson to Jenkins in 2022.