### PR TITLE
Improve test coverage

### DIFF
--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -14,10 +14,10 @@ ENV {{ var }} {{ value }}
 {% endfor %}
 {% endif %}
 
-RUN if [ $(command -v apt-get) ] && [ $(command -v systemctl) ]  && [ ! -f /sbin/init ]; then export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -y python3 sudo bash ca-certificates iproute2 python3-apt aptitude systemd-sysv && apt-get clean && rm -rf /var/lib/apt/lists/*; \
-    elif [ $(command -v apt-get) ]; then export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -y python3 sudo bash ca-certificates iproute2 python3-apt aptitude && apt-get clean && rm -rf /var/lib/apt/lists/*; \
-    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install /usr/bin/python3 /usr/bin/python3-config /usr/bin/dnf-3 sudo bash iproute && dnf clean all; \
-    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y /usr/bin/python /usr/bin/python2-config sudo yum-plugin-ovl bash iproute && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
-    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python3 sudo bash iproute2 && zypper clean -a; \
+RUN if [ $(command -v apt-get) ] && [ $(command -v systemctl) ]  && [ ! -f /sbin/init ]; then export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -y python3 sudo bash ca-certificates iproute2 python3-apt python3-psutil aptitude systemd-sysv && apt-get clean && rm -rf /var/lib/apt/lists/*; \
+    elif [ $(command -v apt-get) ]; then export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -y python3 sudo bash ca-certificates iproute2 python3-apt python3-psutil aptitude && apt-get clean && rm -rf /var/lib/apt/lists/*; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install /usr/bin/python3 /usr/bin/python3-config /usr/bin/dnf-3 python3-psutil sudo bash iproute && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y /usr/bin/python /usr/bin/python2-config sudo yum-plugin-ovl python-psutil bash iproute && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python3 python3-psutil sudo bash iproute2 && zypper clean -a; \
     elif [ $(command -v apk) ]; then apk update && apk add --no-cache python3 sudo bash ca-certificates; \
     elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python3 sudo bash ca-certificates iproute2 && xbps-remove -O; fi

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,8 +1,20 @@
 ---
 - name: Verify
   hosts: all
-  gather_facts: false
   tasks:
+  - stat:
+      path: "{{ '/var/run/jenkinstest/jenkinstest.pid' if ansible_os_family == 'Debian' else '/var/run/jenkinstest.pid' }}"
+    register: pid_file
+  - assert:
+      that:
+        - not pid_file.stat.exists
+  - pids:
+      name: "{{ 'daemon' if ansible_os_family == 'Debian' else 'java' }}"
+    register: service_pids
+  - assert:
+      that:
+        - (service_pids.pids | length) == 0
+      fail_msg: "{{ service_pids.pids|join(',') }}"
   - service:
       name: jenkinstest
       state: started
@@ -11,8 +23,41 @@
       status_code: 403
     register: result
     until: result.status == 403
-    retries: 60
-    delay: 1
+    retries: 20
+    delay: 5
+  - stat:
+      path: "{{ '/var/run/jenkinstest/jenkinstest.pid' if ansible_os_family == 'Debian' else '/var/run/jenkinstest.pid' }}"
+    register: pid_file
+  - assert:
+      that:
+        - pid_file.stat.exists
+  - pids:
+      name: "{{ 'daemon' if ansible_os_family == 'Debian' else 'java' }}"
+    register: service_pids
+  - assert:
+      that:
+        - (service_pids.pids | length) == 1
+      fail_msg: "{{ service_pids.pids | join(',') }}"
+  - slurp:
+      src: "{{ '/var/run/jenkinstest/jenkinstest.pid' if ansible_os_family == 'Debian' else '/var/run/jenkinstest.pid' }}"
+    register: pid_file_contents
+  - assert:
+      that:
+        - service_pids.pids[0] == (pid_file_contents['content'] | b64decode | trim | int)
+      fail_msg: "Service PID {{ service_pids.pids[0] }} does not match PID file {{ pid_file_contents['content'] | b64decode | trim | int }}"
   - service:
       name: jenkinstest
       state: stopped
+  - stat:
+      path: "{{ '/var/run/jenkinstest/jenkinstest.pid' if ansible_os_family == 'Debian' else '/var/run/jenkinstest.pid' }}"
+    register: pid_file
+  - assert:
+      that:
+        - not pid_file.stat.exists
+  - pids:
+      name: "{{ 'daemon' if ansible_os_family == 'Debian' else 'java' }}"
+    register: service_pids
+  - assert:
+      that:
+        - (service_pids.pids | length) == 0
+      fail_msg: "{{ service_pids.pids | join(',') }}"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -54,6 +54,10 @@
   - assert:
       that:
         - not pid_file.stat.exists
+    # SUSE's killproc only waits 60 milliseconds for the process to die
+    # before giving up on removing the PID file. Our test systems are
+    # slower than that, so skip this test on SUSE.
+    when: ansible_os_family != 'Suse'
   - pids:
       name: "{{ 'daemon' if ansible_os_family == 'Debian' else 'java' }}"
     register: service_pids

--- a/suse/build/SOURCES/jenkins.init.in
+++ b/suse/build/SOURCES/jenkins.init.in
@@ -93,6 +93,16 @@ fi
         if [ "$1" = "stop" ]; then exit 0;
         else exit 6; fi; }
 
+is_running() {
+	JPROC=$(pgrep java -U "$JENKINS_USER")
+	if [ -n "$JPROC" ]; then
+		echo "$JPROC" >"$JENKINS_PID_FILE"
+		return 0
+	else
+		return 1
+	fi
+}
+
 case "$1" in
     start)
 	echo -n "Starting @@PRODUCTNAME@@ "
@@ -101,13 +111,21 @@ case "$1" in
         if [ $CHECK -eq 7 ]; then
                 rm -f "$JENKINS_PID_FILE"
                 if [ -x "$JENKINS_INIT_SHELL" ]; then
-                       startproc -n $JENKINS_NICE -s -e -l /var/log/@@ARTIFACTNAME@@.rc -p "$JENKINS_PID_FILE" -t 1 /bin/su -l -s "$JENKINS_INIT_SHELL" -c "$JAVA_CMD $PARAMS &" "$JENKINS_USER"
+                       startproc -n $JENKINS_NICE -s -e -l /var/log/@@ARTIFACTNAME@@.rc -p "$JENKINS_PID_FILE" /bin/su -l -s "$JENKINS_INIT_SHELL" -c "$JAVA_CMD $PARAMS &" "$JENKINS_USER"
                 else
                        HOME=$JENKINS_HOME startproc -n $JENKINS_NICE -s -e -l /var/log/@@ARTIFACTNAME@@.rc -u "$JENKINS_USER" -p "$JENKINS_PID_FILE" $JAVA_CMD $PARAMS
                 fi
-                JPROC=$( pgrep java -U $JENKINS_USER )
-                if [ -n "$JPROC" ]; then
-                        echo "$JPROC" >"$JENKINS_PID_FILE"
+                attempt=1
+                is_started=false
+                while [ $attempt -le 30 ]; do
+                        if is_running; then
+                                is_started=true
+                                break
+                        fi
+                        sleep 1
+                        attempt=$((attempt + 1))
+                done
+                if $is_started; then
                         rc_status -v
                 else
                         rc_failed


### PR DESCRIPTION
Improves test coverage to verify that:

- No PID file exists and no service process is running prior to starting the service
- Once the service has been started, a PID file exists matching the process ID of the running service process
- The PID file is deleted and no service process is running after stopping the service

I tested this locally on the entire platform matrix with `molecule test`.