### PR TITLE
Format scripts with `shfmt(1)`

### DIFF
--- a/bin/branding.sh
+++ b/bin/branding.sh
@@ -8,31 +8,28 @@
 ARGS=()
 
 # Read branding files to environment variables and convert to search and replace args
-for t in $(cat $(dirname "$0")/branding-files.list);
-do
-  # Keep going if file is not set, otherwise it'll hang on 'cat' command
-  if [ -n "$t" ]
-  then
-  	v=""
-  else
-  	v="$(eval cat \$${t})"	
-  fi
-  # Escape the @ signs in the variable as they will do bad things in Perl
-  v="$(echo $v | sed 's#\@#\\\@#g' )"
-  ARGS+=("-e" "s%\@\@${t}\@\@%${v}%g;")
+for t in $(cat $(dirname "$0")/branding-files.list); do
+	# Keep going if file is not set, otherwise it'll hang on 'cat' command
+	if [ -n "$t" ]; then
+		v=""
+	else
+		v="$(eval cat \$${t})"
+	fi
+	# Escape the @ signs in the variable as they will do bad things in Perl
+	v="$(echo $v | sed 's#\@#\\\@#g')"
+	ARGS+=("-e" "s%\@\@${t}\@\@%${v}%g;")
 done
 
 # Convert variables to search and replace arguments
-for t in $(cat $(dirname "$0")/branding.list);
-do
-  v="$(eval echo \$${t})"
-  # Escape the @ signs in the variable as they will do bad things in Perl
-  v="$(echo $v | sed 's#\@#\\\@#g' )"
-  ARGS+=("-e" "s%\@\@${t}\@\@%${v}%g;")
+for t in $(cat $(dirname "$0")/branding.list); do
+	v="$(eval echo \$${t})"
+	# Escape the @ signs in the variable as they will do bad things in Perl
+	v="$(echo $v | sed 's#\@#\\\@#g')"
+	ARGS+=("-e" "s%\@\@${t}\@\@%${v}%g;")
 done
 
 if [ -f "$1" ]; then
-  perl -pi -w "${ARGS[@]}" "$1"
+	perl -pi -w "${ARGS[@]}" "$1"
 else
-  find "$1" -type f -print0 | xargs -0 -t perl -pi -w "${ARGS[@]}"
+	find "$1" -type f -print0 | xargs -0 -t perl -pi -w "${ARGS[@]}"
 fi

--- a/deb/build/build.sh
+++ b/deb/build/build.sh
@@ -22,7 +22,7 @@ sed -i.bak -e 's/^\s*$/./' -e 's/^/ /' $DESCRIPTION_FILE
 # Rewrite the file
 mv "$DESCRIPTION_FILE.bak" "$DESCRIPTION_FILE"
 
-cat > $D/debian/changelog << EOF
+cat >$D/debian/changelog <<EOF
 ${ARTIFACTNAME} ($VERSION${DEB_REVISION}) unstable; urgency=low
 
   * Packaged ${VERSION} https://jenkins.io/changelog${RELEASELINE}/#v${VERSION}
@@ -34,14 +34,14 @@ EOF
 # build the debian package
 cp "${WAR}" $D/${ARTIFACTNAME}.war
 pushd $D
-  pushd debian
-    # rename jenkins.* to artifact.*
-    for f in jenkins.*; do
-      mv $f ${f}_
-      mv ${f}_ ${ARTIFACTNAME}$(echo $f | cut -b8-)
-    done
-  popd
-  debuild -Zgzip -A
+pushd debian
+# rename jenkins.* to artifact.*
+for f in jenkins.*; do
+	mv $f ${f}_
+	mv ${f}_ ${ARTIFACTNAME}$(echo $f | cut -b8-)
+done
+popd
+debuild -Zgzip -A
 popd
 
 mkdir -p "$(dirname "${DEB}")" || true

--- a/deb/build/debian/jenkins.init
+++ b/deb/build/debian/jenkins.init
@@ -24,58 +24,58 @@ SCRIPTNAME=/etc/init.d/$NAME
 #DAEMON=$JENKINS_SH
 DAEMON=/usr/bin/daemon
 DAEMON_ARGS="--name=$NAME --inherit --env=JENKINS_HOME=$JENKINS_HOME --output=$JENKINS_LOG --pidfile=$PIDFILE"
-JAVA=`type -p java`
+JAVA=$(type -p java)
 
 if [ -n "$UMASK" ]; then
-    DAEMON_ARGS="$DAEMON_ARGS --umask=$UMASK"
+	DAEMON_ARGS="$DAEMON_ARGS --umask=$UMASK"
 fi
 if [ "$JENKINS_ENABLE_ACCESS_LOG" = "yes" ]; then
-    JENKINS_ARGS="$JENKINS_ARGS --accessLoggerClassName=winstone.accesslog.SimpleAccessLogger --simpleAccessLogger.format=combined --simpleAccessLogger.file=/var/log/$NAME/access_log"
+	JENKINS_ARGS="$JENKINS_ARGS --accessLoggerClassName=winstone.accesslog.SimpleAccessLogger --simpleAccessLogger.format=combined --simpleAccessLogger.file=/var/log/$NAME/access_log"
 fi
 
 SU=/bin/su
 
 # Exit if the package is not installed
 if [ ! -x "$DAEMON" ]; then
-    echo "daemon package not installed" >&2
-    exit 1
+	echo "daemon package not installed" >&2
+	exit 1
 fi
 
 # Exit if not supposed to run standalone
 if [ "$RUN_STANDALONE" = "false" ]; then
-    echo "Not configured to run standalone" >&2
-    exit 1
+	echo "Not configured to run standalone" >&2
+	exit 1
 fi
 
 # Make sure there exists a java executable, it may not be always the case
 if [ -z "$JAVA" ]; then
-    echo "ERROR: No Java executable found in current PATH: $PATH" >&2
-    echo "If you actually have java installed on the system make sure the executable is in the aforementioned path and that 'type -p java' returns the java executable path" >&2
-    exit 1
+	echo "ERROR: No Java executable found in current PATH: $PATH" >&2
+	echo "If you actually have java installed on the system make sure the executable is in the aforementioned path and that 'type -p java' returns the java executable path" >&2
+	exit 1
 fi
 
 # Which Java versions can be used to run Jenkins
-JAVA_ALLOWED_VERSIONS=( "1.8" "11" )
+JAVA_ALLOWED_VERSIONS=("1.8" "11")
 # Work out the JAVA version we are working with:
 JAVA_VERSION=$($JAVA -version 2>&1 | sed -n ';s/.* version "\([0-9]\{2,\}\|[0-9]\.[0-9]\)\..*".*/\1/p;')
 
-if [[ ${JAVA_ALLOWED_VERSIONS[*]} =~ "$JAVA_VERSION" ]]; then
-    echo "Correct java version found" >&2
+if [[ ${JAVA_ALLOWED_VERSIONS[*]} =~ $JAVA_VERSION ]]; then
+	echo "Correct java version found" >&2
 else
-    echo "Found an incorrect Java version" >&2
-    echo "Java version found:" >&2
-    echo $($JAVA -version) >&2
-    echo "Aborting" >&2
-    exit 1
+	echo "Found an incorrect Java version" >&2
+	echo "Java version found:" >&2
+	echo $($JAVA -version) >&2
+	echo "Aborting" >&2
+	exit 1
 fi
 
 # load environments
 if [ -r /etc/default/locale ]; then
-  . /etc/default/locale
-  export LANG LANGUAGE
+	. /etc/default/locale
+	export LANG LANGUAGE
 elif [ -r /etc/environment ]; then
-  . /etc/environment
-  export LANG LANGUAGE
+	. /etc/environment
+	export LANG LANGUAGE
 fi
 
 # Load the VERBOSE setting and other rcS variables
@@ -87,205 +87,211 @@ fi
 
 # Make sure we run as root, since setting the max open files through
 # ulimit requires root access
-if [ `id -u` -ne 0 ]; then
-    echo "The $NAME init script can only be run as root"
-    exit 1
+if [ $(id -u) -ne 0 ]; then
+	echo "The $NAME init script can only be run as root"
+	exit 1
 fi
 
-
 check_tcp_port() {
-    local service=$1
-    local assigned=$2
-    local default=$3
-    local assigned_address=$4
-    local default_address=$5
+	local service=$1
+	local assigned=$2
+	local default=$3
+	local assigned_address=$4
+	local default_address=$5
 
-    if [ -n "$assigned" ]; then
-        port=$assigned
-    else
-        port=$default
-    fi
+	if [ -n "$assigned" ]; then
+		port=$assigned
+	else
+		port=$default
+	fi
 
-    if [ -n "$assigned_address" ]; then
-        address=$assigned_address
-    else
-        address=$default_address
-    fi
+	if [ -n "$assigned_address" ]; then
+		address=$assigned_address
+	else
+		address=$default_address
+	fi
 
-    count=`netstat --listen --numeric-ports | grep $address\:$port[[:space:]] | grep -c . `
+	count=$(netstat --listen --numeric-ports | grep $address\:$port[[:space:]] | grep -c .)
 
-    if [ $count -ne 0 ]; then
-        echo "The selected $service port ($port) on address $address seems to be in use by another program "
-        echo "Please select another address/port combination to use for $NAME"
-        return 1
-    fi
+	if [ $count -ne 0 ]; then
+		echo "The selected $service port ($port) on address $address seems to be in use by another program "
+		echo "Please select another address/port combination to use for $NAME"
+		return 1
+	fi
 }
 
 #
 # Function that starts the daemon/service
 #
-do_start()
-{
-    # the default location is /var/run/jenkins/jenkins.pid but the parent directory needs to be created
-    mkdir `dirname $PIDFILE` > /dev/null 2>&1 || true
-    chown $JENKINS_USER `dirname $PIDFILE`
-    # Return
-    #   0 if daemon has been started
-    #   1 if daemon was already running
-    #   2 if daemon could not be started
-    $DAEMON $DAEMON_ARGS --running && return 1
+do_start() {
+	# the default location is /var/run/jenkins/jenkins.pid but the parent directory needs to be created
+	mkdir $(dirname $PIDFILE) >/dev/null 2>&1 || true
+	chown $JENKINS_USER $(dirname $PIDFILE)
+	# Return
+	#   0 if daemon has been started
+	#   1 if daemon was already running
+	#   2 if daemon could not be started
+	$DAEMON $DAEMON_ARGS --running && return 1
 
-    # Verify if there is a jenkins process already running without a daemon
-    get_running || return 2
+	# Verify if there is a jenkins process already running without a daemon
+	get_running || return 2
 
-    # Verify that the jenkins port is not already in use, winstone does not exit
-    # even for BindException
-    check_tcp_port "http" "$HTTP_PORT" "@@PORT@@" "$HTTP_HOST" "0.0.0.0" || return 2
+	# Verify that the jenkins port is not already in use, winstone does not exit
+	# even for BindException
+	check_tcp_port "http" "$HTTP_PORT" "@@PORT@@" "$HTTP_HOST" "0.0.0.0" || return 2
 
-    # If the var MAXOPENFILES is enabled in /etc/default/jenkins then set the max open files to the
-    # proper value
-    if [ -n "$MAXOPENFILES" ]; then
-        [ "$VERBOSE" != no ] && echo Setting up max open files limit to $MAXOPENFILES
-        ulimit -n $MAXOPENFILES
-    fi
+	# If the var MAXOPENFILES is enabled in /etc/default/jenkins then set the max open files to the
+	# proper value
+	if [ -n "$MAXOPENFILES" ]; then
+		[ "$VERBOSE" != no ] && echo Setting up max open files limit to $MAXOPENFILES
+		ulimit -n $MAXOPENFILES
+	fi
 
-    # notify of explicit umask
-    if [ -n "$UMASK" ]; then
-        [ "$VERBOSE" != no ] && echo Setting umask to $UMASK
-    fi
+	# notify of explicit umask
+	if [ -n "$UMASK" ]; then
+		[ "$VERBOSE" != no ] && echo Setting umask to $UMASK
+	fi
 
-    # --user in daemon doesn't prepare environment variables like HOME, USER, LOGNAME or USERNAME,
-    # so we let su do so for us now
-    $SU -l $JENKINS_USER --shell=/bin/bash -c "$DAEMON $DAEMON_ARGS -- $JAVA $JAVA_ARGS -jar $JENKINS_WAR $JENKINS_ARGS" || return 2
+	# --user in daemon doesn't prepare environment variables like HOME, USER, LOGNAME or USERNAME,
+	# so we let su do so for us now
+	$SU -l $JENKINS_USER --shell=/bin/bash -c "$DAEMON $DAEMON_ARGS -- $JAVA $JAVA_ARGS -jar $JENKINS_WAR $JENKINS_ARGS" || return 2
 }
-
 
 #
 # Verify that all jenkins processes have been shutdown
 #
-get_running()
-{
-    return `pgrep -U $JENKINS_USER -f $JENKINS_WAR | grep -c .`
+get_running() {
+	return $(pgrep -U $JENKINS_USER -f $JENKINS_WAR | grep -c .)
 }
 
 #
 # killall jenkins processes that have not been shutdown
 #
-force_stop()
-{
-    get_running
-    if [ $? -ne 0 ]; then
-	killall -u $JENKINS_USER java daemon || return 3
-         # wait for the process to really terminate
-         for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
-             sleep 1
-             get_running && return 0
-         done
-         return 2
-    fi
+force_stop() {
+	get_running
+	if [ $? -ne 0 ]; then
+		killall -u $JENKINS_USER java daemon || return 3
+		# wait for the process to really terminate
+		for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+			sleep 1
+			get_running && return 0
+		done
+		return 2
+	fi
 }
 
 # Get the status of the daemon process
-get_daemon_status()
-{
-    $DAEMON $DAEMON_ARGS --running || return 1
+get_daemon_status() {
+	$DAEMON $DAEMON_ARGS --running || return 1
 }
-
 
 #
 # Function that stops the daemon/service
 #
-do_stop()
-{
-    # Return
-    #   0 if daemon has been stopped
-    #   1 if daemon was already stopped
-    #   2 if daemon could not be stopped
-    #   other if a failure occurred
-    get_daemon_status
-    case "$?" in
+do_stop() {
+	# Return
+	#   0 if daemon has been stopped
+	#   1 if daemon was already stopped
+	#   2 if daemon could not be stopped
+	#   other if a failure occurred
+	get_daemon_status
+	case "$?" in
 	0)
-	    $DAEMON $DAEMON_ARGS --stop || return 2
-        # wait for the process to really terminate
-        for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
-            sleep 1
-            $DAEMON $DAEMON_ARGS --running || break
-        done
-        if get_daemon_status; then
-	        force_stop || return "$?"
-        fi
-	    ;;
+		$DAEMON $DAEMON_ARGS --stop || return 2
+		# wait for the process to really terminate
+		for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+			sleep 1
+			$DAEMON $DAEMON_ARGS --running || break
+		done
+		if get_daemon_status; then
+			force_stop || return "$?"
+		fi
+		;;
 	*)
-	    force_stop || return "$?"
-	    ;;
-    esac
+		force_stop || return "$?"
+		;;
+	esac
 
-    # Many daemons don't delete their pidfiles when they exit.
-    rm -f $PIDFILE
-    return 0
+	# Many daemons don't delete their pidfiles when they exit.
+	rm -f $PIDFILE
+	return 0
 }
 
 # Verify the process did in fact start successfully and didn't just bomb out
 do_check_started_ok() {
-    sleep 1
-    if [ "$1" -ne "0" ]; then return $1; fi
-    get_running
-    if [ "$?" -eq "0" ]; then
-        return 2
-    else
-        return 0
-    fi
+	sleep 1
+	if [ "$1" -ne "0" ]; then
+		return $1
+	fi
+	get_running
+	if [ "$?" -eq "0" ]; then
+		return 2
+	else
+		return 0
+	fi
 }
 
 case "$1" in
-  start)
-    log_daemon_msg "Starting $DESC" "$NAME"
-    do_start
-    START_STATUS="$?"
-    do_check_started_ok "$START_STATUS"
-    case "$?" in
-        0|1) log_end_msg 0 ;;
-        2) log_end_msg 1 ; exit 7 ;;
-    esac
-    ;;
-  stop)
-    log_daemon_msg "Stopping $DESC" "$NAME"
-    do_stop
-    case "$?" in
-        0|1) log_end_msg 0 ;;
-        2|3) log_end_msg 1 ; exit 100 ;;
-    esac
-    ;;
-  restart|force-reload)
-    #
-    # If the "reload" option is implemented then remove the
-    # 'force-reload' alias
-    #
-    log_daemon_msg "Restarting $DESC" "$NAME"
-    do_stop
-    case "$?" in
-      0|1)
-        do_start
-        START_STATUS="$?"
-        sleep 1
-        do_check_started_ok "$START_STATUS"
-        case "$?" in
-          0) log_end_msg 0 ;;
-          1) log_end_msg 1 ; exit 100 ;; # Old process is still running
-          *) log_end_msg 1 ; exit 100 ;; # Failed to start
-        esac
-        ;;
-      *)
-  	# Failed to stop
-	log_end_msg 1
+start)
+	log_daemon_msg "Starting $DESC" "$NAME"
+	do_start
+	START_STATUS="$?"
+	do_check_started_ok "$START_STATUS"
+	case "$?" in
+	0 | 1) log_end_msg 0 ;;
+	2)
+		log_end_msg 1
+		exit 7
+		;;
+	esac
 	;;
-    esac
-    ;;
-  status)
+stop)
+	log_daemon_msg "Stopping $DESC" "$NAME"
+	do_stop
+	case "$?" in
+	0 | 1) log_end_msg 0 ;;
+	2 | 3)
+		log_end_msg 1
+		exit 100
+		;;
+	esac
+	;;
+restart | force-reload)
+	#
+	# If the "reload" option is implemented then remove the
+	# 'force-reload' alias
+	#
+	log_daemon_msg "Restarting $DESC" "$NAME"
+	do_stop
+	case "$?" in
+	0 | 1)
+		do_start
+		START_STATUS="$?"
+		sleep 1
+		do_check_started_ok "$START_STATUS"
+		case "$?" in
+		0) log_end_msg 0 ;;
+		1)
+			log_end_msg 1
+			exit 100
+			;; # Old process is still running
+		*)
+			log_end_msg 1
+			exit 100
+			;; # Failed to start
+		esac
+		;;
+	*)
+		# Failed to stop
+		log_end_msg 1
+		;;
+	esac
+	;;
+status)
 	get_daemon_status
 	case "$?" in
-	 0)
-		echo "$DESC is running with the pid `cat $PIDFILE`"
+	0)
+		echo "$DESC is running with the pid $(cat $PIDFILE)"
 		rc=0
 		;;
 	*)
@@ -311,10 +317,10 @@ case "$1" in
 		;;
 	esac
 	;;
-  *)
-    echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
-    exit 3
-    ;;
+*)
+	echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
+	exit 3
+	;;
 esac
 
 exit 0

--- a/deb/build/debian/jenkins.postinst
+++ b/deb/build/debian/jenkins.postinst
@@ -17,52 +17,51 @@ set -e
 # for details, see http://www.debian.org/doc/debian-policy/ or
 # the debian-policy package
 
-
 case "$1" in
-    configure)
-        [ -r /etc/default/@@ARTIFACTNAME@@ ] && . /etc/default/@@ARTIFACTNAME@@
-        : ${JENKINS_USER:=@@ARTIFACTNAME@@}
-        : ${JENKINS_GROUP:=@@ARTIFACTNAME@@}
+configure)
+	[ -r /etc/default/@@ARTIFACTNAME@@ ] && . /etc/default/@@ARTIFACTNAME@@
+	: ${JENKINS_USER:=@@ARTIFACTNAME@@}
+	: ${JENKINS_GROUP:=@@ARTIFACTNAME@@}
 
-        # Create @@ARTIFACTNAME@@ group and user if they don't exist.
-        # sometimes tools that users want Jenkins to run need a shell,
-        # so use /bin/bash. See JENKINS-4830
-        if ! getent group "$JENKINS_GROUP" > /dev/null; then
-            addgroup --system --quiet "$JENKINS_GROUP"
-        fi
-        if ! id "$JENKINS_USER" >/dev/null 2>&1 ; then
-            adduser --system --quiet --home /var/lib/@@ARTIFACTNAME@@ --no-create-home \
-                --ingroup "$JENKINS_GROUP" --disabled-password --shell /bin/bash \
-                --gecos '@@PRODUCTNAME@@' \
-                "$JENKINS_USER"
-        fi
+	# Create @@ARTIFACTNAME@@ group and user if they don't exist.
+	# sometimes tools that users want Jenkins to run need a shell,
+	# so use /bin/bash. See JENKINS-4830
+	if ! getent group "$JENKINS_GROUP" >/dev/null; then
+		addgroup --system --quiet "$JENKINS_GROUP"
+	fi
+	if ! id "$JENKINS_USER" >/dev/null 2>&1; then
+		adduser --system --quiet --home /var/lib/@@ARTIFACTNAME@@ --no-create-home \
+			--ingroup "$JENKINS_GROUP" --disabled-password --shell /bin/bash \
+			--gecos '@@PRODUCTNAME@@' \
+			"$JENKINS_USER"
+	fi
 
-        # directories needed for jenkins
-        # we don't do -R because it can take a long time on big installation
-        chown $JENKINS_USER:$JENKINS_GROUP /var/lib/@@ARTIFACTNAME@@ /var/log/@@ARTIFACTNAME@@
-        # we don't do "chmod 750" so that the user can choose the pemission for g and o on their own
-        chmod u+rwx /var/lib/@@ARTIFACTNAME@@ /var/log/@@ARTIFACTNAME@@
+	# directories needed for jenkins
+	# we don't do -R because it can take a long time on big installation
+	chown $JENKINS_USER:$JENKINS_GROUP /var/lib/@@ARTIFACTNAME@@ /var/log/@@ARTIFACTNAME@@
+	# we don't do "chmod 750" so that the user can choose the pemission for g and o on their own
+	chmod u+rwx /var/lib/@@ARTIFACTNAME@@ /var/log/@@ARTIFACTNAME@@
 
-        # make sure jenkins can delete everything in /var/cache/jenkins to
-        # re-explode war.
-        chown -R $JENKINS_USER:$JENKINS_GROUP /var/cache/@@ARTIFACTNAME@@
-        chmod -R 750                          /var/cache/@@ARTIFACTNAME@@
+	# make sure jenkins can delete everything in /var/cache/jenkins to
+	# re-explode war.
+	chown -R $JENKINS_USER:$JENKINS_GROUP /var/cache/@@ARTIFACTNAME@@
+	chmod -R 750 /var/cache/@@ARTIFACTNAME@@
 
-        # older installations may use /var/run/jenkins
-        # so make sure that they can delete too.
-        if [ -d "/var/run/@@ARTIFACTNAME@@" ]; then
-            chown -R $JENKINS_USER:$JENKINS_GROUP /var/run/@@ARTIFACTNAME@@
-            chmod -R 750                          /var/run/@@ARTIFACTNAME@@
-        fi
-    ;;
+	# older installations may use /var/run/jenkins
+	# so make sure that they can delete too.
+	if [ -d "/var/run/@@ARTIFACTNAME@@" ]; then
+		chown -R $JENKINS_USER:$JENKINS_GROUP /var/run/@@ARTIFACTNAME@@
+		chmod -R 750 /var/run/@@ARTIFACTNAME@@
+	fi
+	;;
 
-    abort-upgrade|abort-remove|abort-deconfigure)
-    ;;
+abort-upgrade | abort-remove | abort-deconfigure) ;;
 
-    *)
-        echo "postinst called with unknown argument \`$1'" >&2
-        exit 1
-    ;;
+\
+	*)
+	echo "postinst called with unknown argument \`$1'" >&2
+	exit 1
+	;;
 esac
 
 # dh_installdeb will replace this with shell code automatically
@@ -71,5 +70,3 @@ esac
 #DEBHELPER#
 
 exit 0
-
-

--- a/deb/build/debian/jenkins.postrm
+++ b/deb/build/debian/jenkins.postrm
@@ -3,20 +3,20 @@
 set -e
 
 case "$1" in
-    purge)
-        userdel @@ARTIFACTNAME@@ || true
-        groupdel @@ARTIFACTNAME@@ || true
-        rm -rf /var/lib/@@ARTIFACTNAME@@ /var/log/@@ARTIFACTNAME@@ \
-               /var/run/@@ARTIFACTNAME@@ /var/cache/@@ARTIFACTNAME@@
-    ;;
+purge)
+	userdel @@ARTIFACTNAME@@ || true
+	groupdel @@ARTIFACTNAME@@ || true
+	rm -rf /var/lib/@@ARTIFACTNAME@@ /var/log/@@ARTIFACTNAME@@ \
+		/var/run/@@ARTIFACTNAME@@ /var/cache/@@ARTIFACTNAME@@
+	;;
 
-    remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
-    ;;
+remove | upgrade | failed-upgrade | abort-install | abort-upgrade | disappear) ;;
 
-    *)
-        echo "postrm called with unknown argument \`$1'" >&2
-        exit 1
-    ;;
+\
+	*)
+	echo "postrm called with unknown argument \`$1'" >&2
+	exit 1
+	;;
 esac
 
 #DEBHELPER#

--- a/deb/publish/publish.sh
+++ b/deb/publish/publish.sh
@@ -17,183 +17,175 @@ SSH_OPTS=($SSH_OPTS)
 
 bin="$(dirname "$0")"
 
-function clean(){
-  rm -rf "$D"
+function clean() {
+	rm -rf "$D"
 }
 
 # Generate and publish site content
-function generateSite(){
+function generateSite() {
+	cp -R "$bin/contents/." "$D/contents"
 
-  cp -R "$bin/contents/." "$D/contents"
-  
-  gpg --export -a --output "$D/contents/${ORGANIZATION}.key" "${GPG_KEYNAME}"
-  echo "$(gpg --import-options show-only --import $D/contents/${ORGANIZATION}.key)" > "$D/contents/${ORGANIZATION}.key.info"
-  
-  "$BASE/bin/indexGenerator.py" \
-    --distribution debian \
-    --gpg-key-info-file "${D}/contents/${ORGANIZATION}.key.info" \
-    --targetDir "$D/html"
-  
-  "$BASE/bin/branding.py" "$D"
+	gpg --export -a --output "$D/contents/${ORGANIZATION}.key" "${GPG_KEYNAME}"
+	echo "$(gpg --import-options show-only --import $D/contents/${ORGANIZATION}.key)" >"$D/contents/${ORGANIZATION}.key.info"
 
+	"$BASE/bin/indexGenerator.py" \
+		--distribution debian \
+		--gpg-key-info-file "${D}/contents/${ORGANIZATION}.key.info" \
+		--targetDir "$D/html"
 
-  # build package index
-  # see http://wiki.debian.org/SecureApt for more details
-  cp "${DEB}" "$D/binary/"
+	"$BASE/bin/branding.py" "$D"
 
-  pushd "$D"
-    apt-ftparchive packages binary > binary/Packages
-    apt-ftparchive contents binary > binary/Contents
-  popd
+	# build package index
+	# see http://wiki.debian.org/SecureApt for more details
+	cp "${DEB}" "$D/binary/"
 
-  # Remote ftparchive-merge
-  # https://github.com/kohsuke/apt-ftparchive-merge
-  pushd $D/binary
-    mvn org.kohsuke:apt-ftparchive-merge:1.6:merge -Durl="$DEB_URL/binary/" -Dout=../merged
-  popd
+	pushd "$D"
+	apt-ftparchive packages binary >binary/Packages
+	apt-ftparchive contents binary >binary/Contents
+	popd
 
-  # Local ftparchive-merge
+	# Remote ftparchive-merge
+	# https://github.com/kohsuke/apt-ftparchive-merge
+	pushd $D/binary
+	mvn org.kohsuke:apt-ftparchive-merge:1.6:merge -Durl="$DEB_URL/binary/" -Dout=../merged
+	popd
 
-  cat $D/merged/Packages > $D/binary/Packages
-  gzip -9c "$D/merged/Packages" > "$D/binary/Packages.gz"
-  bzip2 -c "$D/merged/Packages" > "$D/binary/Packages.bz2"
-  lzma -c "$D/merged/Packages" > "$D/binary/Packages.lzma"
-  gzip -9c "$D/merged/Contents" > "$D/binary/Contents.gz"
+	# Local ftparchive-merge
 
-  apt-ftparchive -c "$bin/release.conf" release "$D/binary" > "$D/binary/Release"
+	cat $D/merged/Packages >$D/binary/Packages
+	gzip -9c "$D/merged/Packages" >"$D/binary/Packages.gz"
+	bzip2 -c "$D/merged/Packages" >"$D/binary/Packages.bz2"
+	lzma -c "$D/merged/Packages" >"$D/binary/Packages.lzma"
+	gzip -9c "$D/merged/Contents" >"$D/binary/Contents.gz"
 
+	apt-ftparchive -c "$bin/release.conf" release "$D/binary" >"$D/binary/Release"
 }
 
-function init(){
+function init() {
+	mkdir -p "$D/binary" "$D/contents" "$D/html"
 
-  mkdir -p "$D/binary" "$D/contents" "$D/html"
+	# where to put binary files
+	mkdir -p "$DEBDIR" # where to put binary files
 
-  # where to put binary files
-  mkdir -p "$DEBDIR" # where to put binary files
-
-  # where to put repository index and other web contents
-  mkdir -p "$DEB_WEBDIR"
-  ## On remote serve
-  # shellcheck disable=SC2029
-  ssh "${SSH_OPTS[@]}" "$PKGSERVER" mkdir -p "$DEBDIR/"
+	# where to put repository index and other web contents
+	mkdir -p "$DEB_WEBDIR"
+	## On remote serve
+	# shellcheck disable=SC2029
+	ssh "${SSH_OPTS[@]}" "$PKGSERVER" mkdir -p "$DEBDIR/"
 }
 
-function skipIfAlreadyPublished(){
-
-  if ssh "${SSH_OPTS[@]}" "$PKGSERVER" test -e "${DEBDIR}/$(basename "$DEB")"; then
-    echo "File already published, nothing else todo"
-    return 0
-  fi
-  return 1
-
+function skipIfAlreadyPublished() {
+	if ssh "${SSH_OPTS[@]}" "$PKGSERVER" test -e "${DEBDIR}/$(basename "$DEB")"; then
+		echo "File already published, nothing else todo"
+		return 0
+	fi
+	return 1
 }
 
 # Upload Debian Package
-function uploadPackage(){
-  rsync \
-    --verbose \
-    --recursive \
-    --compress \
-    --ignore-existing \
-    --progress \
-    "$DEB" "$DEBDIR/"
+function uploadPackage() {
+	rsync \
+		--verbose \
+		--recursive \
+		--compress \
+		--ignore-existing \
+		--progress \
+		"$DEB" "$DEBDIR/"
 
-  rsync \
-    --archive \
-    --verbose \
-    --compress \
-    --ignore-existing \
-    --progress \
-    -e "ssh ${SSH_OPTS[*]}" \
-    "${DEB}" "$PKGSERVER:${DEBDIR// /\\ }"
+	rsync \
+		--archive \
+		--verbose \
+		--compress \
+		--ignore-existing \
+		--progress \
+		-e "ssh ${SSH_OPTS[*]}" \
+		"${DEB}" "$PKGSERVER:${DEBDIR// /\\ }"
 }
 
-function uploadPackageSite(){
+function uploadPackageSite() {
+	cp \
+		"$D"/binary/Packages* \
+		"$D"/binary/Release \
+		"$D"/binary/Release.gpg \
+		"$D"/binary/Contents* \
+		"$D"/contents/binary
 
-  cp \
-    "$D"/binary/Packages* \
-    "$D"/binary/Release \
-    "$D"/binary/Release.gpg \
-    "$D"/binary/Contents* \
-    "$D"/contents/binary
+	rsync \
+		--verbose \
+		--recursive \
+		--compress \
+		--progress \
+		"$D/contents/" "$DEB_WEBDIR/"
 
-  rsync \
-    --verbose \
-    --recursive \
-    --compress \
-    --progress \
-    "$D/contents/" "$DEB_WEBDIR/"
-
-  rsync \
-    --archive \
-    --compress \
-    --progress \
-    --verbose \
-    -e "ssh ${SSH_OPTS[*]}" \
-    "$D/contents/" "$PKGSERVER:${DEB_WEBDIR// /\\ }/"
+	rsync \
+		--archive \
+		--compress \
+		--progress \
+		--verbose \
+		-e "ssh ${SSH_OPTS[*]}" \
+		"$D/contents/" "$PKGSERVER:${DEB_WEBDIR// /\\ }/"
 }
 
-function uploadHtmlSite(){
+function uploadHtmlSite() {
+	# Html file need to be located in the binary directory
+	rsync \
+		--include "HEADER.html" \
+		--include "FOOTER.html" \
+		--exclude "*" \
+		--compress \
+		--recursive \
+		--progress \
+		--verbose \
+		"$D/html/" "$DEBDIR/"
 
-  # Html file need to be located in the binary directory
-  rsync \
-    --include "HEADER.html" \
-    --include "FOOTER.html" \
-    --exclude "*" \
-    --compress \
-    --recursive \
-    --progress \
-    --verbose \
-    "$D/html/" "$DEBDIR/"
+	rsync \
+		--archive \
+		--compress \
+		--include "index.html" \
+		--exclude "*" \
+		--progress \
+		--verbose \
+		-e "ssh ${SSH_OPTS[*]}" \
+		"$D/html/" "$PKGSERVER:${DEB_WEBDIR// /\\ }/"
 
-  rsync \
-    --archive \
-    --compress \
-    --include "index.html" \
-    --exclude "*" \
-    --progress \
-    --verbose \
-    -e "ssh ${SSH_OPTS[*]}" \
-    "$D/html/" "$PKGSERVER:${DEB_WEBDIR// /\\ }/"
-
-  rsync \
-    --archive \
-    --compress \
-    --include "HEADER.html" \
-    --include "FOOTER.html" \
-    --exclude "*" \
-    --progress \
-    --verbose \
-    -e "ssh ${SSH_OPTS[*]}" \
-    "$D/html/" "$PKGSERVER:${DEBDIR// /\\ }/"
+	rsync \
+		--archive \
+		--compress \
+		--include "HEADER.html" \
+		--include "FOOTER.html" \
+		--exclude "*" \
+		--progress \
+		--verbose \
+		-e "ssh ${SSH_OPTS[*]}" \
+		"$D/html/" "$PKGSERVER:${DEBDIR// /\\ }/"
 }
 
-function show(){
-  echo "Parameters:"
-  echo "DEB: $DEB"
-  echo "DEBDIR: $DEBDIR"
-  echo "DEB_WEBDIR: $DEB_WEBDIR"
-  echo "SSH_OPTS: ${SSH_OPTS[*]}"
-  echo "PKGSERVER: $PKGSERVER"
-  echo "GPG_KEYNAME: $GPG_KEYNAME"
-  echo "---"
+function show() {
+	echo "Parameters:"
+	echo "DEB: $DEB"
+	echo "DEBDIR: $DEBDIR"
+	echo "DEB_WEBDIR: $DEB_WEBDIR"
+	echo "SSH_OPTS: ${SSH_OPTS[*]}"
+	echo "PKGSERVER: $PKGSERVER"
+	echo "GPG_KEYNAME: $GPG_KEYNAME"
+	echo "---"
 }
 
-function signSite(){
-  # sign the release file
-  if [ -f "$D/binary/Release.gpg" ]; then
-    rm "$D/binary/Release.gpg"
-  fi
+function signSite() {
+	# sign the release file
+	if [ -f "$D/binary/Release.gpg" ]; then
+		rm "$D/binary/Release.gpg"
+	fi
 
-  gpg \
-    --batch \
-    --pinentry-mode loopback \
-    --digest-algo=sha256 \
-    -u "$GPG_KEYNAME" \
-    --passphrase-file "$GPG_PASSPHRASE_FILE" \
-    -abs \
-    -o "$D/binary/Release.gpg" \
-    "$D/binary/Release"
+	gpg \
+		--batch \
+		--pinentry-mode loopback \
+		--digest-algo=sha256 \
+		-u "$GPG_KEYNAME" \
+		--passphrase-file "$GPG_PASSPHRASE_FILE" \
+		-abs \
+		-o "$D/binary/Release.gpg" \
+		"$D/binary/Release"
 }
 
 show
@@ -205,8 +197,8 @@ generateSite
 signSite
 
 if ! skipIfAlreadyPublished; then
-  uploadPackage
-  uploadPackageSite
+	uploadPackage
+	uploadPackageSite
 fi
 
 uploadHtmlSite

--- a/deb/setup.sh
+++ b/deb/setup.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
 sudo apt-get install -y devscripts apt-utils || true
-

--- a/msi/publish/publish.sh
+++ b/msi/publish/publish.sh
@@ -12,133 +12,127 @@ SSH_OPTS=($SSH_OPTS)
 # $$ Contains current pid
 D="$AGENT_WORKDIR/$$"
 
-function clean(){
-  rm -rf "$D"
+function clean() {
+	rm -rf "$D"
 }
 
 # Generate and publish site content
-function generateSite(){
-
-  "$BASE/bin/indexGenerator.py" \
-    --distribution windows \
-    --targetDir "$MSIDIR"
-
+function generateSite() {
+	"$BASE/bin/indexGenerator.py" \
+		--distribution windows \
+		--targetDir "$MSIDIR"
 }
 
-function init(){
+function init() {
+	mkdir -p $D
 
-  mkdir -p $D
+	mkdir -p "${MSIDIR}/${VERSION}/"
 
-  mkdir -p "${MSIDIR}/${VERSION}/"
-
-  ssh "${SSH_OPTS[@]}" "$PKGSERVER" mkdir -p "$MSIDIR/${VERSION}/"
-
+	ssh "${SSH_OPTS[@]}" "$PKGSERVER" mkdir -p "$MSIDIR/${VERSION}/"
 }
 
-function skipIfAlreadyPublished(){
+function skipIfAlreadyPublished() {
+	if ssh "${SSH_OPTS[@]}" "$PKGSERVER" test -e "${MSIDIR}/${VERSION}/$(basename "$MSI")"; then
+		echo "File already published, nothing else todo"
+		exit 0
 
-  if ssh "${SSH_OPTS[@]}" "$PKGSERVER" test -e "${MSIDIR}/${VERSION}/$(basename "$MSI")"; then
-    echo "File already published, nothing else todo"
-    exit 0
-
-  fi
+	fi
 }
 
-function uploadPackage(){
+function uploadPackage() {
+	cp "${ARTIFACTNAME}-${VERSION}${RELEASELINE}.msi" "${MSI}"
 
-  cp "${ARTIFACTNAME}-${VERSION}${RELEASELINE}.msi" "${MSI}"
+	sha256sum "${MSI}" >"${MSI_SHASUM}"
 
-  sha256sum "${MSI}" > "${MSI_SHASUM}"
+	cat "${MSI_SHASUM}"
 
-  cat "${MSI_SHASUM}"
+	# Local
+	rsync \
+		--compress \
+		--verbose \
+		--recursive \
+		--ignore-existing \
+		--progress \
+		"${MSI}" "${MSIDIR}/${VERSION}/"
 
-  # Local
-  rsync \
-    --compress \
-    --verbose \
-    --recursive \
-    --ignore-existing \
-    --progress \
-    "${MSI}" "${MSIDIR}/${VERSION}/"
+	rsync \
+		--compress \
+		--ignore-existing \
+		--recursive \
+		--progress \
+		--verbose \
+		"${MSI_SHASUM}" "${MSIDIR}/${VERSION}/"
 
-  rsync \
-    --compress \
-    --ignore-existing \
-    --recursive \
-    --progress \
-    --verbose \
-    "${MSI_SHASUM}" "${MSIDIR}/${VERSION}/"
+	# Remote
+	rsync \
+		--archive \
+		--compress \
+		--verbose \
+		--ignore-existing \
+		--progress \
+		-e "ssh ${SSH_OPTS[*]}" \
+		"${MSI}" "$PKGSERVER:${MSIDIR}/${VERSION}/"
 
-  # Remote
-  rsync \
-    --archive \
-    --compress \
-    --verbose \
-    --ignore-existing \
-    --progress \
-    -e "ssh ${SSH_OPTS[*]}" \
-    "${MSI}" "$PKGSERVER:${MSIDIR}/${VERSION}/"
+	rsync \
+		--archive \
+		--compress \
+		--verbose \
+		--ignore-existing \
+		--progress \
+		-e "ssh ${SSH_OPTS[*]}" \
+		"${MSI_SHASUM}" "$PKGSERVER:${MSIDIR}/${VERSION}/"
 
-  rsync \
-    --archive \
-    --compress \
-    --verbose \
-    --ignore-existing \
-    --progress \
-    -e "ssh ${SSH_OPTS[*]}" \
-    "${MSI_SHASUM}" "$PKGSERVER:${MSIDIR}/${VERSION}/"
+	# Update the symlink to point to most recent Windows build
+	#
+	# Remove anything in current directory named 'latest'
+	# This is a safety measure just in case something was left there previously
+	rm -rf latest
 
-  # Update the symlink to point to most recent Windows build
-  #
-  # Remove anything in current directory named 'latest'
-  # This is a safety measure just in case something was left there previously
-  rm -rf latest
+	# Create a local symlink pointing to the MSI file in the VERSION directory.
+	# Don't need VERSION directory or MSI locally, just the unresolved symlink.
+	# The jenkins.io page downloads http://mirrors.jenkins-ci.org/windows/latest
+	# and assumes it points to the most recent MSI file.
+	ln -s ${VERSION}/"$(basename "$MSI")" latest
 
-  # Create a local symlink pointing to the MSI file in the VERSION directory.
-  # Don't need VERSION directory or MSI locally, just the unresolved symlink.
-  # The jenkins.io page downloads http://mirrors.jenkins-ci.org/windows/latest
-  # and assumes it points to the most recent MSI file.
-  ln -s ${VERSION}/"$(basename "$MSI")" latest
+	# Copy the symlink to PKGSERVER in the root of MSIDIR
+	# Overwrites the existing symlink on the destination
+	rsync \
+		--archive \
+		--links \
+		--verbose \
+		-e "ssh ${SSH_OPTS[*]}" \
+		latest "$PKGSERVER:${MSIDIR}/"
 
-  # Copy the symlink to PKGSERVER in the root of MSIDIR
-  # Overwrites the existing symlink on the destination
-  rsync \
-    --archive \
-    --links \
-    --verbose \
-    -e "ssh ${SSH_OPTS[*]}" \
-    latest "$PKGSERVER:${MSIDIR}/"
-
-  # Remove the local symlink
-  rm latest
+	# Remove the local symlink
+	rm latest
 }
 
 # The site need to be located in the binary directory
-function uploadSite(){
-  rsync \
-    --compress \
-    --verbose \
-    --recursive \
-    --progress \
-    -e "ssh ${SSH_OPTS[*]}" \
-    "${D}/" "${MSIDIR// /\\ }/"
+function uploadSite() {
+	rsync \
+		--compress \
+		--verbose \
+		--recursive \
+		--progress \
+		-e "ssh ${SSH_OPTS[*]}" \
+		"${D}/" "${MSIDIR// /\\ }/"
 
-  rsync \
-    --archive \
-    --compress \
-    --verbose \
-    --progress \
-    -e "ssh ${SSH_OPTS[*]}" \
-    "${D}/" "$PKGSERVER:${MSIDIR// /\\ }/"
+	rsync \
+		--archive \
+		--compress \
+		--verbose \
+		--progress \
+		-e "ssh ${SSH_OPTS[*]}" \
+		"${D}/" "$PKGSERVER:${MSIDIR// /\\ }/"
 }
 
-function show(){
-  echo "Parameters:"
-  echo "MSI: $MSI"
-  echo "MSIDIR: $MSIDIR"
-  echo "SSH_OPTS: ${SSH_OPTS[*]}"
-  echo "PKGSERVER: $PKGSERVER"
-  echo "---"
+function show() {
+	echo "Parameters:"
+	echo "MSI: $MSI"
+	echo "MSIDIR: $MSIDIR"
+	echo "SSH_OPTS: ${SSH_OPTS[*]}"
+	echo "PKGSERVER: $PKGSERVER"
+	echo "---"
 }
 
 show

--- a/rpm/build/SOURCES/jenkins.init.in
+++ b/rpm/build/SOURCES/jenkins.init.in
@@ -39,18 +39,33 @@
 
 # Check for missing binaries (stale symlinks should not happen)
 JENKINS_WAR="~~WAR~~"
-test -r "$JENKINS_WAR" || { echo "$JENKINS_WAR not installed";
-	if [ "$1" = "stop" ]; then exit 0;
-	else exit 5; fi; }
+test -r "$JENKINS_WAR" || {
+	echo "$JENKINS_WAR not installed"
+	if [ "$1" = "stop" ]; then
+		exit 0
+	else
+		exit 5
+	fi
+}
 
 # Check for existence of needed config file and read it
 JENKINS_CONFIG=/etc/sysconfig/@@ARTIFACTNAME@@
-test -e "$JENKINS_CONFIG" || { echo "$JENKINS_CONFIG not existing";
-	if [ "$1" = "stop" ]; then exit 0;
-	else exit 6; fi; }
-test -r "$JENKINS_CONFIG" || { echo "$JENKINS_CONFIG not readable. Perhaps you forgot 'sudo'?";
-	if [ "$1" = "stop" ]; then exit 0;
-	else exit 6; fi; }
+test -e "$JENKINS_CONFIG" || {
+	echo "$JENKINS_CONFIG not existing"
+	if [ "$1" = "stop" ]; then
+		exit 0
+	else
+		exit 6
+	fi
+}
+test -r "$JENKINS_CONFIG" || {
+	echo "$JENKINS_CONFIG not readable. Perhaps you forgot 'sudo'?"
+	if [ "$1" = "stop" ]; then
+		exit 0
+	else
+		exit 6
+	fi
+}
 
 JENKINS_PID_FILE="/var/run/@@ARTIFACTNAME@@.pid"
 JENKINS_LOCKFILE="/var/lock/subsys/@@ARTIFACTNAME@@"
@@ -62,12 +77,22 @@ JENKINS_LOCKFILE="/var/lock/subsys/@@ARTIFACTNAME@@"
 [ -f "$JENKINS_CONFIG" ] && . "$JENKINS_CONFIG"
 
 # Set up environment accordingly to the configuration settings
-[ -n "$JENKINS_HOME" ] || { echo "JENKINS_HOME not configured in $JENKINS_CONFIG";
-	if [ "$1" = "stop" ]; then exit 0;
-	else exit 6; fi; }
-[ -d "$JENKINS_HOME" ] || { echo "JENKINS_HOME directory does not exist: $JENKINS_HOME";
-	if [ "$1" = "stop" ]; then exit 0;
-	else exit 1; fi; }
+[ -n "$JENKINS_HOME" ] || {
+	echo "JENKINS_HOME not configured in $JENKINS_CONFIG"
+	if [ "$1" = "stop" ]; then
+		exit 0
+	else
+		exit 6
+	fi
+}
+[ -d "$JENKINS_HOME" ] || {
+	echo "JENKINS_HOME directory does not exist: $JENKINS_HOME"
+	if [ "$1" = "stop" ]; then
+		exit 0
+	else
+		exit 1
+	fi
+}
 
 # Search usable Java as /usr/bin/java might not point to minimal version required by Jenkins.
 # see http://www.nabble.com/guinea-pigs-wanted-----Hudson-RPM-for-RedHat-Linux-td25673707.html
@@ -80,10 +105,9 @@ candidates="
 /usr/lib/jvm/java-11-openjdk-amd64
 /usr/bin/java
 "
-for candidate in $candidates
-do
-  [ -x "$JENKINS_JAVA_CMD" ] && break
-  JENKINS_JAVA_CMD="$candidate"
+for candidate in $candidates; do
+	[ -x "$JENKINS_JAVA_CMD" ] && break
+	JENKINS_JAVA_CMD="$candidate"
 done
 
 PARAMS="--logfile=/var/log/@@ARTIFACTNAME@@/@@ARTIFACTNAME@@.log --webroot=/var/cache/@@ARTIFACTNAME@@/war"
@@ -103,7 +127,7 @@ PARAMS="--logfile=/var/log/@@ARTIFACTNAME@@/@@ARTIFACTNAME@@.log --webroot=/var/
 [ -n "$JENKINS_ARGS" ] && PARAMS="$PARAMS $JENKINS_ARGS"
 
 if [ "$JENKINS_ENABLE_ACCESS_LOG" = "yes" ]; then
-    PARAMS="$PARAMS --accessLoggerClassName=winstone.accesslog.SimpleAccessLogger --simpleAccessLogger.format=combined --simpleAccessLogger.file=/var/log/@@ARTIFACTNAME@@/access_log"
+	PARAMS="$PARAMS --accessLoggerClassName=winstone.accesslog.SimpleAccessLogger --simpleAccessLogger.format=combined --simpleAccessLogger.file=/var/log/@@ARTIFACTNAME@@/access_log"
 fi
 
 RETVAL=0
@@ -125,7 +149,7 @@ is_running() {
 }
 
 case "$1" in
-    start)
+start)
 	echo -n "Starting @@PRODUCTNAME@@ "
 	daemon --user "$JENKINS_USER" --pidfile "$JENKINS_PID_FILE" "$JENKINS_JAVA_CMD" $JENKINS_JAVA_OPTIONS "-DJENKINS_HOME=$JENKINS_HOME" -jar "$JENKINS_WAR" $PARAMS &
 	RETVAL=$?
@@ -147,18 +171,18 @@ case "$1" in
 			failure
 		fi
 	else
-	    failure
+		failure
 	fi
 	echo
 	;;
-    stop)
+stop)
 	echo -n "Shutting down @@PRODUCTNAME@@ "
 	killproc @@ARTIFACTNAME@@
 	rm -f $JENKINS_LOCKFILE
 	RETVAL=$?
 	echo
 	;;
-    try-restart|condrestart)
+try-restart | condrestart)
 	if test "$1" = "condrestart"; then
 		echo "${attn} Use try-restart ${done}(LSB)${attn} rather than condrestart ${warn}(RH)${norm}"
 	fi
@@ -169,29 +193,29 @@ case "$1" in
 		: # Not running is not a failure.
 	fi
 	;;
-    restart)
+restart)
 	$0 stop
 	$0 start
 	;;
-    force-reload)
+force-reload)
 	echo -n "Reload service @@PRODUCTNAME@@ "
 	$0 try-restart
 	;;
-    reload)
-    	$0 restart
+reload)
+	$0 restart
 	;;
-    status)
-    	status @@ARTIFACTNAME@@
+status)
+	status @@ARTIFACTNAME@@
 	RETVAL=$?
 	;;
-    probe)
+probe)
 	## Optional: Probe for the necessity of a reload, print out the
 	## argument to this init script which is required for a reload.
 	## Note: probe is not (yet) part of LSB (as of 1.9)
 
 	test "$JENKINS_CONFIG" -nt "$JENKINS_PID_FILE" && echo reload
 	;;
-    *)
+*)
 	echo "Usage: $0 {start|stop|status|try-restart|restart|force-reload|reload|probe}"
 	exit 1
 	;;

--- a/rpm/build/build.sh
+++ b/rpm/build/build.sh
@@ -12,14 +12,14 @@ cp -R "$(dirname "$0")"/* $D
 cp "$WAR" $D/SOURCES/jenkins.war
 
 pushd $D
-  mkdir -p BUILD RPMS SRPMS
-  rpmbuild -ba --define="_topdir $PWD" --define="_tmppath $PWD/tmp" --define="ver $VERSION" SPECS/jenkins.spec
+mkdir -p BUILD RPMS SRPMS
+rpmbuild -ba --define="_topdir $PWD" --define="_tmppath $PWD/tmp" --define="ver $VERSION" SPECS/jenkins.spec
 
-  # sign the results
-  for rpm in $(find RPMS -name '*.rpm'); do
-    rpmsign --addsign "${rpm}"
-    rpm -qpi "${rpm}"
-  done
+# sign the results
+for rpm in $(find RPMS -name '*.rpm'); do
+	rpmsign --addsign "${rpm}"
+	rpm -qpi "${rpm}"
+done
 popd
 
 mkdir -p "$(dirname "${RPM}")" || true

--- a/rpm/publish/publish.sh
+++ b/rpm/publish/publish.sh
@@ -15,137 +15,134 @@ D="$AGENT_WORKDIR/$$"
 # Convert string to array to correctly escape cli parameter
 SSH_OPTS=($SSH_OPTS)
 
-function clean(){
-  rm -rf $D
+function clean() {
+	rm -rf $D
 }
 
-function generateSite(){
-  gpg --export -a --output "$D/${ORGANIZATION}.key" "${GPG_KEYNAME}"
-  echo "$(gpg --import-options show-only --import $D/${ORGANIZATION}.key)" > "$D/${ORGANIZATION}.key.info"
-  
-  "$BASE/bin/indexGenerator.py" \
-    --distribution redhat \
-    --gpg-key-info-file "${D}/${ORGANIZATION}.key.info" \
-    --targetDir "$D"
-  
-  "$BASE/bin/branding.py" "$D"
-  
-  cp "$RPM" "$D/RPMS/noarch"
+function generateSite() {
+	gpg --export -a --output "$D/${ORGANIZATION}.key" "${GPG_KEYNAME}"
+	echo "$(gpg --import-options show-only --import $D/${ORGANIZATION}.key)" >"$D/${ORGANIZATION}.key.info"
 
-cat  > "$D/${ARTIFACTNAME}.repo" << EOF
+	"$BASE/bin/indexGenerator.py" \
+		--distribution redhat \
+		--gpg-key-info-file "${D}/${ORGANIZATION}.key.info" \
+		--targetDir "$D"
+
+	"$BASE/bin/branding.py" "$D"
+
+	cp "$RPM" "$D/RPMS/noarch"
+
+	cat >"$D/${ARTIFACTNAME}.repo" <<EOF
 [${ARTIFACTNAME}]
 name=${PRODUCTNAME}${RELEASELINE}
 baseurl=${RPM_URL}
 gpgcheck=1
 EOF
 
-  # generate index 
-  # locally
-  # disable this for now, as it's currently now used and generate errors
-  # createrepo --update -o "$RPM_WEBDIR" "$RPMDIR/"
-  # on the server
-  # shellcheck disable=SC2029
-  ssh "${SSH_OPTS[@]}" "$PKGSERVER"  createrepo --update -o "'$RPM_WEBDIR'" "'$RPMDIR/'"
-
+	# generate index
+	# locally
+	# disable this for now, as it's currently now used and generate errors
+	# createrepo --update -o "$RPM_WEBDIR" "$RPMDIR/"
+	# on the server
+	# shellcheck disable=SC2029
+	ssh "${SSH_OPTS[@]}" "$PKGSERVER" createrepo --update -o "'$RPM_WEBDIR'" "'$RPMDIR/'"
 }
 
-function skipIfAlreadyPublished(){
+function skipIfAlreadyPublished() {
+	if ssh "${SSH_OPTS[@]}" "$PKGSERVER" test -e "${RPMDIR}/$(basename "$RPM")"; then
+		echo "File already published, nothing else todo"
+		exit 0
 
-  if ssh "${SSH_OPTS[@]}" "$PKGSERVER" test -e "${RPMDIR}/$(basename "$RPM")"; then
-    echo "File already published, nothing else todo"
-    exit 0
-
-  fi
+	fi
 }
 
-function init(){
-  mkdir -p "$D/RPMS/noarch"
+function init() {
+	mkdir -p "$D/RPMS/noarch"
 
-  mkdir -p "$RPMDIR/"
-  # mkdir -p "$RPM_WEBDIR/" # May not be necessary
-  # shellcheck disable=SC2029
-  ssh "${SSH_OPTS[@]}" "$PKGSERVER"  mkdir -p "'$RPMDIR/'"
+	mkdir -p "$RPMDIR/"
+	# mkdir -p "$RPM_WEBDIR/" # May not be necessary
+	# shellcheck disable=SC2029
+	ssh "${SSH_OPTS[@]}" "$PKGSERVER" mkdir -p "'$RPMDIR/'"
 }
 
+function uploadPackage() {
+	# Local
+	rsync \
+		--verbose \
+		--compress \
+		--ignore-existing \
+		--recursive \
+		--progress \
+		"$RPM" "$RPMDIR/"
 
-function uploadPackage(){
-  # Local
-  rsync \
-    --verbose \
-    --compress \
-    --ignore-existing \
-    --recursive \
-    --progress \
-    "$RPM" "$RPMDIR/"
-
-  # Remote 
-  rsync \
-    --archive \
-    --verbose \
-    --compress \
-    -e "ssh ${SSH_OPTS[*]}" \
-    --ignore-existing \
-    --progress \
-    "$RPM" "$PKGSERVER:${RPMDIR// /\\ }/"
+	# Remote
+	rsync \
+		--archive \
+		--verbose \
+		--compress \
+		-e "ssh ${SSH_OPTS[*]}" \
+		--ignore-existing \
+		--progress \
+		"$RPM" "$PKGSERVER:${RPMDIR// /\\ }/"
 }
 
-function show(){
-  echo "Parameters:"
-  echo "RPM: $RPM"
-  echo "RPMDIR: $RPMDIR"
-  echo "RPM_WEBDIR: $RPM_WEBDIR"
-  echo "SSH_OPTS: ${SSH_OPTS[*]}"
-  echo "PKGSERVER: $PKGSERVER"
-  echo "GPG_KEYNAME: $GPG_KEYNAME"
-  echo "---"
+function show() {
+	echo "Parameters:"
+	echo "RPM: $RPM"
+	echo "RPMDIR: $RPMDIR"
+	echo "RPM_WEBDIR: $RPM_WEBDIR"
+	echo "SSH_OPTS: ${SSH_OPTS[*]}"
+	echo "PKGSERVER: $PKGSERVER"
+	echo "GPG_KEYNAME: $GPG_KEYNAME"
+	echo "---"
 }
 
-function uploadSite(){
-  pushd "$D"
-    # Disable copy on local network storage
-    #rsync \
-    #  --compress \
-    #  --recursive \
-    #  --verbose \
-    #  --exclude RPMS \
-    #  --exclude "HEADER.html" \
-    #  --exclude "FOOTER.html" \
-    #  --progress \
-    #  . "$RPM_WEBDIR/"
+function uploadSite() {
+	pushd "$D"
+	# Disable copy on local network storage
+	#rsync \
+	#  --compress \
+	#  --recursive \
+	#  --verbose \
+	#  --exclude RPMS \
+	#  --exclude "HEADER.html" \
+	#  --exclude "FOOTER.html" \
+	#  --progress \
+	#  . "$RPM_WEBDIR/"
 
-    rsync \
-      --archive \
-      --compress \
-      --verbose \
-      -e "ssh ${SSH_OPTS[*]}" \
-      --exclude RPMS \
-      --exclude "HEADER.html" \
-      --exclude "FOOTER.html" \
-      --progress \
-      . "$PKGSERVER:${RPM_WEBDIR// /\\ }/"
+	rsync \
+		--archive \
+		--compress \
+		--verbose \
+		-e "ssh ${SSH_OPTS[*]}" \
+		--exclude RPMS \
+		--exclude "HEADER.html" \
+		--exclude "FOOTER.html" \
+		--progress \
+		. "$PKGSERVER:${RPM_WEBDIR// /\\ }/"
 
-    # Following html need to be located inside the binary directory
-    rsync \
-      --compress \
-      --verbose \
-      --recursive \
-      --include "HEADER.html" \
-      --include "FOOTER.html" \
-      --exclude "*" \
-      --progress \
-      . "$RPMDIR/"
+	# Following html need to be located inside the binary directory
+	rsync \
+		--compress \
+		--verbose \
+		--recursive \
+		--include "HEADER.html" \
+		--include "FOOTER.html" \
+		--exclude "*" \
+		--progress \
+		. "$RPMDIR/"
 
-    rsync \
-      --archive \
-      --compress \
-      --verbose \
-      -e "ssh ${SSH_OPTS[*]}" \
-      --include "HEADER.html" \
-      --include "FOOTER.html" \
-      --exclude "*" \
-      --progress \
-      . "$PKGSERVER:${RPMDIR// /\\ }/"
-  popd
+	rsync \
+		--archive \
+		--compress \
+		--verbose \
+		-e "ssh ${SSH_OPTS[*]}" \
+		--include "HEADER.html" \
+		--include "FOOTER.html" \
+		--exclude "*" \
+		--progress \
+		. "$PKGSERVER:${RPMDIR// /\\ }/"
+	popd
 }
 
 show

--- a/rpm/setup.sh
+++ b/rpm/setup.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
 sudo apt-get install -y rpm expect createrepo || true
-

--- a/suse/build/SOURCES/jenkins.init.in
+++ b/suse/build/SOURCES/jenkins.init.in
@@ -2,17 +2,17 @@
 #
 #     SUSE system statup script for @@PRODUCTNAME@@
 #     Copyright (C) 2007  Pascal Bleser
-#          
+#
 #     This library is free software; you can redistribute it and/or modify it
 #     under the terms of the GNU Lesser General Public License as published by
 #     the Free Software Foundation; either version 2.1 of the License, or (at
 #     your option) any later version.
-#			      
+#
 #     This library is distributed in the hope that it will be useful, but
 #     WITHOUT ANY WARRANTY; without even the implied warranty of
 #     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 #     Lesser General Public License for more details.
-#      
+#
 #     You should have received a copy of the GNU Lesser General Public
 #     License along with this library; if not, write to the Free Software
 #     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307,
@@ -32,48 +32,83 @@
 
 # Check for missing binaries (stale symlinks should not happen)
 JENKINS_WAR="~~WAR~~"
-test -r "$JENKINS_WAR" || { echo "$JENKINS_WAR not installed"; 
-	if [ "$1" = "stop" ]; then exit 0;
-	else exit 5; fi; }
+test -r "$JENKINS_WAR" || {
+	echo "$JENKINS_WAR not installed"
+	if [ "$1" = "stop" ]; then
+		exit 0
+	else
+		exit 5
+	fi
+}
 
 # Check for existence of needed config file and read it
 JENKINS_CONFIG=/etc/sysconfig/@@ARTIFACTNAME@@
-test -r "$JENKINS_CONFIG" || { echo "$JENKINS_CONFIG not existing";
-	if [ "$1" = "stop" ]; then exit 0;
-	else exit 6; fi; }
+test -r "$JENKINS_CONFIG" || {
+	echo "$JENKINS_CONFIG not existing"
+	if [ "$1" = "stop" ]; then
+		exit 0
+	else
+		exit 6
+	fi
+}
 
 JENKINS_PID_FILE="/var/run/@@ARTIFACTNAME@@.pid"
 JENKINS_USER="@@ARTIFACTNAME@@"
 JENKINS_NICE="0"
 
-# Read config	
+# Read config
 . "$JENKINS_CONFIG"
 
 . /etc/rc.status
 rc_reset # Reset status of this service
 
 # Set up environment accordingly to the configuration settings
-[ -n "$JENKINS_HOME" ] || { echo "JENKINS_HOME not configured in $JENKINS_CONFIG";
-	if [ "$1" = "stop" ]; then exit 0;
-	else exit 6; fi; }
-[ -d "$JENKINS_HOME" ] || { echo "JENKINS_HOME directory does not exist: $JENKINS_HOME";
-	if [ "$1" = "stop" ]; then exit 0;
-	else exit 1; fi; }
+[ -n "$JENKINS_HOME" ] || {
+	echo "JENKINS_HOME not configured in $JENKINS_CONFIG"
+	if [ "$1" = "stop" ]; then
+		exit 0
+	else
+		exit 6
+	fi
+}
+[ -d "$JENKINS_HOME" ] || {
+	echo "JENKINS_HOME directory does not exist: $JENKINS_HOME"
+	if [ "$1" = "stop" ]; then
+		exit 0
+	else
+		exit 1
+	fi
+}
 
 if [ -z "$JENKINS_JAVA_HOME" ]; then
-    . /etc/profile.d/alljava.sh
-    [ -n "$JAVA_HOME" ] || { echo "Failed to determine JAVA_HOME, set JENKINS_JAVA_HOME in $JENKINS_CONFIG";
-	if [ "$1" = "stop" ]; then exit 0;
-	else exit 6; fi; }
+	. /etc/profile.d/alljava.sh
+	[ -n "$JAVA_HOME" ] || {
+		echo "Failed to determine JAVA_HOME, set JENKINS_JAVA_HOME in $JENKINS_CONFIG"
+		if [ "$1" = "stop" ]; then
+			exit 0
+		else
+			exit 6
+		fi
+	}
 else
-    JAVA_HOME="$JENKINS_JAVA_HOME"
+	JAVA_HOME="$JENKINS_JAVA_HOME"
 fi
-[ -d "$JAVA_HOME" ] || { echo "Invalid JENKINS_JAVA_HOME: directory does not exist: $JAVA_HOME";
-    if [ "$1" = "stop" ]; then exit 0;
-    else exit 6; fi; }
-[ -e "$JAVA_HOME/bin/java" ] || { echo "Invalid JENKINS_JAVA_HOME: bin/java not found under $JAVA_HOME";
-    if [ "$1" = "stop" ]; then exit 0;
-    else exit 6; fi; }
+[ -d "$JAVA_HOME" ] || {
+	echo "Invalid JENKINS_JAVA_HOME: directory does not exist: $JAVA_HOME"
+	if [ "$1" = "stop" ]; then
+		exit 0
+	else
+		exit 6
+	fi
+}
+[ -e "$JAVA_HOME/bin/java" ] || {
+	echo "Invalid JENKINS_JAVA_HOME: bin/java not found under $JAVA_HOME"
+	if [ "$1" = "stop" ]; then
+		exit 0
+	else
+		exit 6
+	fi
+}
 export JAVA_HOME
 
 JAVA_CMD="$JAVA_HOME/bin/java $JENKINS_JAVA_OPTIONS -DJENKINS_HOME=$JENKINS_HOME -jar $JENKINS_WAR"
@@ -86,12 +121,17 @@ PARAMS="--javaHome=$JAVA_HOME --logfile=/var/log/@@ARTIFACTNAME@@/@@ARTIFACTNAME
 [ -n "$JENKINS_ARGS" ] && PARAMS="$PARAMS $JENKINS_ARGS"
 
 if [ "$JENKINS_ENABLE_ACCESS_LOG" = "yes" ]; then
-    PARAMS="$PARAMS --accessLoggerClassName=winstone.accesslog.SimpleAccessLogger --simpleAccessLogger.format=combined --simpleAccessLogger.file=/var/log/@@ARTIFACTNAME@@/access_log"
+	PARAMS="$PARAMS --accessLoggerClassName=winstone.accesslog.SimpleAccessLogger --simpleAccessLogger.format=combined --simpleAccessLogger.file=/var/log/@@ARTIFACTNAME@@/access_log"
 fi
 
-[ -z "$JENKINS_INIT_SHELL" -o -x "$JENKINS_INIT_SHELL" ] || { echo "JENKINS_INIT_SHELL does not refer to a shell: $JENKINS_INIT_SHELL";
-        if [ "$1" = "stop" ]; then exit 0;
-        else exit 6; fi; }
+[ -z "$JENKINS_INIT_SHELL" -o -x "$JENKINS_INIT_SHELL" ] || {
+	echo "JENKINS_INIT_SHELL does not refer to a shell: $JENKINS_INIT_SHELL"
+	if [ "$1" = "stop" ]; then
+		exit 0
+	else
+		exit 6
+	fi
+}
 
 is_running() {
 	JPROC=$(pgrep java -U "$JENKINS_USER")
@@ -104,44 +144,44 @@ is_running() {
 }
 
 case "$1" in
-    start)
+start)
 	echo -n "Starting @@PRODUCTNAME@@ "
-        /sbin/checkproc -k -p "$JENKINS_PID_FILE" "$JAVA_HOME/bin/java" >/var/log/@@ARTIFACTNAME@@.rc 2>&1
-        CHECK=$?
-        if [ $CHECK -eq 7 ]; then
-                rm -f "$JENKINS_PID_FILE"
-                if [ -x "$JENKINS_INIT_SHELL" ]; then
-                       startproc -n $JENKINS_NICE -s -e -l /var/log/@@ARTIFACTNAME@@.rc -p "$JENKINS_PID_FILE" /bin/su -l -s "$JENKINS_INIT_SHELL" -c "$JAVA_CMD $PARAMS &" "$JENKINS_USER"
-                else
-                       HOME=$JENKINS_HOME startproc -n $JENKINS_NICE -s -e -l /var/log/@@ARTIFACTNAME@@.rc -u "$JENKINS_USER" -p "$JENKINS_PID_FILE" $JAVA_CMD $PARAMS
-                fi
-                attempt=1
-                is_started=false
-                while [ $attempt -le 30 ]; do
-                        if is_running; then
-                                is_started=true
-                                break
-                        fi
-                        sleep 1
-                        attempt=$((attempt + 1))
-                done
-                if $is_started; then
-                        rc_status -v
-                else
-                        rc_failed
-                        rc_status -v
-                fi
-        else
-                rc_failed $CHECK
-                rc_status -v
-        fi
+	/sbin/checkproc -k -p "$JENKINS_PID_FILE" "$JAVA_HOME/bin/java" >/var/log/@@ARTIFACTNAME@@.rc 2>&1
+	CHECK=$?
+	if [ $CHECK -eq 7 ]; then
+		rm -f "$JENKINS_PID_FILE"
+		if [ -x "$JENKINS_INIT_SHELL" ]; then
+			startproc -n $JENKINS_NICE -s -e -l /var/log/@@ARTIFACTNAME@@.rc -p "$JENKINS_PID_FILE" /bin/su -l -s "$JENKINS_INIT_SHELL" -c "$JAVA_CMD $PARAMS &" "$JENKINS_USER"
+		else
+			HOME=$JENKINS_HOME startproc -n $JENKINS_NICE -s -e -l /var/log/@@ARTIFACTNAME@@.rc -u "$JENKINS_USER" -p "$JENKINS_PID_FILE" $JAVA_CMD $PARAMS
+		fi
+		attempt=1
+		is_started=false
+		while [ $attempt -le 30 ]; do
+			if is_running; then
+				is_started=true
+				break
+			fi
+			sleep 1
+			attempt=$((attempt + 1))
+		done
+		if $is_started; then
+			rc_status -v
+		else
+			rc_failed
+			rc_status -v
+		fi
+	else
+		rc_failed $CHECK
+		rc_status -v
+	fi
 	;;
-    stop)
+stop)
 	echo -n "Shutting down @@PRODUCTNAME@@ "
 	/sbin/killproc -p "$JENKINS_PID_FILE" "$JAVA_HOME/bin/java"
 	rc_status -v
 	;;
-    try-restart|condrestart)
+try-restart | condrestart)
 	if test "$1" = "condrestart"; then
 		echo "${attn} Use try-restart ${done}(LSB)${attn} rather than condrestart ${warn}(RH)${norm}"
 	fi
@@ -149,37 +189,37 @@ case "$1" in
 	if test $? = 0; then
 		$0 restart
 	else
-		rc_reset	# Not running is not a failure.
+		rc_reset # Not running is not a failure.
 	fi
 	rc_status
 	;;
-    restart)
+restart)
 	$0 stop
 	$0 start
 	rc_status
 	;;
-    force-reload)
+force-reload)
 	echo -n "Reload service @@PRODUCTNAME@@ "
 	$0 try-restart
 	rc_status
 	;;
-    reload)
+reload)
 	rc_failed 3
 	rc_status -v
 	;;
-    status)
+status)
 	echo -n "Checking for service @@PRODUCTNAME@@ "
 	/sbin/checkproc -p "$JENKINS_PID_FILE" "$JAVA_HOME/bin/java"
 	rc_status -v
 	;;
-    probe)
+probe)
 	## Optional: Probe for the necessity of a reload, print out the
 	## argument to this init script which is required for a reload.
 	## Note: probe is not (yet) part of LSB (as of 1.9)
 
 	test "$JENKINS_CONFIG" -nt "$JENKINS_PID_FILE" && echo reload
 	;;
-    *)
+*)
 	echo "Usage: $0 {start|stop|status|try-restart|restart|force-reload|reload|probe}"
 	exit 1
 	;;

--- a/suse/build/build.sh
+++ b/suse/build/build.sh
@@ -10,14 +10,14 @@ cp -R "$(dirname "$0")"/* $D
 cp "$WAR" $D/SOURCES/jenkins.war
 
 pushd $D
-  mkdir -p BUILD RPMS SRPMS
-  rpmbuild -ba --define="_topdir $PWD" --define="_tmppath $PWD/tmp" --define="ver $VERSION" SPECS/jenkins.spec
+mkdir -p BUILD RPMS SRPMS
+rpmbuild -ba --define="_topdir $PWD" --define="_tmppath $PWD/tmp" --define="ver $VERSION" SPECS/jenkins.spec
 
-  # sign the results
-  for rpm in $(find RPMS -name '*.rpm'); do
-    rpmsign --addsign "${rpm}"
-    rpm -qpi "${rpm}"
-  done
+# sign the results
+for rpm in $(find RPMS -name '*.rpm'); do
+	rpmsign --addsign "${rpm}"
+	rpm -qpi "${rpm}"
+done
 popd
 
 mkdir -p "$(dirname "${SUSE}")" || true

--- a/suse/publish/publish.sh
+++ b/suse/publish/publish.sh
@@ -15,156 +15,151 @@ D="$AGENT_WORKDIR/$$"
 SSH_OPTS=($SSH_OPTS)
 SCP_OPTS=($SCP_OPTS)
 
-function clean(){
-  rm -rf $D
+function clean() {
+	rm -rf $D
 }
 
-function generateSite(){
+function generateSite() {
+	"$BASE/bin/indexGenerator.py" \
+		--distribution opensuse \
+		--targetDir "${D}"
 
-  "$BASE/bin/indexGenerator.py" \
-    --distribution opensuse \
-    --targetDir "${D}"
-  
-  gpg --export -a --output "$D/repodata/repomd.xml.key" "${GPG_KEYNAME}"
-  
-  "$BASE/bin/branding.py" $D
-  
-  cp "$SUSE" $D/RPMS/noarch
+	gpg --export -a --output "$D/repodata/repomd.xml.key" "${GPG_KEYNAME}"
+
+	"$BASE/bin/branding.py" $D
+
+	cp "$SUSE" $D/RPMS/noarch
 }
 
-function init(){
-  # where to put binary files
-  mkdir -p "$SUSEDIR/" # Local
+function init() {
+	# where to put binary files
+	mkdir -p "$SUSEDIR/" # Local
 
-  # shellcheck disable=SC2029
-  ssh "${SSH_OPTS[@]}" "$PKGSERVER"  mkdir -p "'$SUSEDIR/'" # Remote
+	# shellcheck disable=SC2029
+	ssh "${SSH_OPTS[@]}" "$PKGSERVER" mkdir -p "'$SUSEDIR/'" # Remote
 
-  # where to put repository index and other web contents
-  mkdir -p "$SUSE_WEBDIR"
+	# where to put repository index and other web contents
+	mkdir -p "$SUSE_WEBDIR"
 
-  mkdir -p $D/RPMS/noarch $D/repodata
+	mkdir -p $D/RPMS/noarch $D/repodata
 }
 
-function skipIfAlreadyPublished(){
+function skipIfAlreadyPublished() {
+	if ssh "${SSH_OPTS[@]}" "$PKGSERVER" "test -e ${SUSEDIR}/$(basename $SUSE)"; then
+		echo "File already published, nothing else todo"
+		exit 0
 
-  if ssh "${SSH_OPTS[@]}" "$PKGSERVER" "test -e ${SUSEDIR}/$(basename $SUSE)"; then
-    echo "File already published, nothing else todo"
-    exit 0
-
-  fi
-
+	fi
 }
 
-function show(){
-  echo "Parameters:"
-  echo "SUSE: $SUSE"
-  echo "SUSEDIR: $SUSEDIR"
-  echo "SUSE_WEBDIR: $SUSE_WEBDIR"
-  echo "SSH_OPTS: ${SSH_OPTS[*]}"
-  echo "PKGSERVER: $PKGSERVER"
-  echo "GPG_KEYNAME: $GPG_KEYNAME"
-  echo "---"
+function show() {
+	echo "Parameters:"
+	echo "SUSE: $SUSE"
+	echo "SUSEDIR: $SUSEDIR"
+	echo "SUSE_WEBDIR: $SUSE_WEBDIR"
+	echo "SSH_OPTS: ${SSH_OPTS[*]}"
+	echo "PKGSERVER: $PKGSERVER"
+	echo "GPG_KEYNAME: $GPG_KEYNAME"
+	echo "---"
 }
 
-function uploadPackage(){
-  rsync \
-    --recursive \
-    --verbose \
-    --compress \
-    --ignore-existing \
-    --progress \
-    "$SUSE" "$SUSEDIR/" # Local
+function uploadPackage() {
+	rsync \
+		--recursive \
+		--verbose \
+		--compress \
+		--ignore-existing \
+		--progress \
+		"$SUSE" "$SUSEDIR/" # Local
 
-  rsync \
-    --archive \
-    --verbose \
-    --compress \
-    --ignore-existing \
-    --progress \
-    -e "ssh ${SSH_OPTS[*]}" \
-    "${SUSE}" "$PKGSERVER:${SUSEDIR// /\\ }" # Remote
+	rsync \
+		--archive \
+		--verbose \
+		--compress \
+		--ignore-existing \
+		--progress \
+		-e "ssh ${SSH_OPTS[*]}" \
+		"${SUSE}" "$PKGSERVER:${SUSEDIR// /\\ }" # Remote
 }
 
-function uploadSite(){
+function uploadSite() {
+	pushd $D
+	rsync \
+		--recursive \
+		--verbose \
+		--compress \
+		--progress \
+		--exclude RPMS \
+		--exclude "HEADER.html" \
+		--exclude "FOOTER.html" \
+		. "$SUSE_WEBDIR/" #Local
 
-  pushd $D
-    rsync \
-      --recursive \
-      --verbose \
-      --compress \
-      --progress \
-      --exclude RPMS \
-      --exclude "HEADER.html" \
-      --exclude "FOOTER.html" \
-      . "$SUSE_WEBDIR/" #Local
+	# shellcheck disable=SC2029
+	rsync \
+		--archive \
+		--verbose \
+		--compress \
+		--progress \
+		-e "ssh ${SSH_OPTS[*]}" \
+		--exclude RPMS \
+		--exclude "HEADER.html" \
+		--exclude "FOOTER.html" \
+		. "$PKGSERVER:${SUSE_WEBDIR// /\\ }/" # Remote
 
-    # shellcheck disable=SC2029
-    rsync \
-      --archive \
-      --verbose \
-      --compress \
-      --progress \
-      -e "ssh ${SSH_OPTS[*]}" \
-      --exclude RPMS \
-      --exclude "HEADER.html" \
-      --exclude "FOOTER.html" \
-      . "$PKGSERVER:${SUSE_WEBDIR// /\\ }/" # Remote
-  
-    # generate index on the server
-    # server needs 'createrepo' pacakge
-    # Disable this for now as not critical
-    # createrepo --update -o "$SUSE_WEBDIR" "$SUSEDIR/" #Local
-    # cp "${SUSE_WEBDIR// /\\ }/repodata/repomd.xml" repodata/ # Local
+	# generate index on the server
+	# server needs 'createrepo' pacakge
+	# Disable this for now as not critical
+	# createrepo --update -o "$SUSE_WEBDIR" "$SUSEDIR/" #Local
+	# cp "${SUSE_WEBDIR// /\\ }/repodata/repomd.xml" repodata/ # Local
 
-    # shellcheck disable=SC2029
-    ssh "${SSH_OPTS[@]}" "$PKGSERVER"   createrepo --update -o "'$SUSE_WEBDIR'" "'$SUSEDIR/'" # Remote
+	# shellcheck disable=SC2029
+	ssh "${SSH_OPTS[@]}" "$PKGSERVER" createrepo --update -o "'$SUSE_WEBDIR'" "'$SUSEDIR/'" # Remote
 
-    scp \
-      "${SCP_OPTS[@]}" \
-      "$PKGSERVER:${SUSE_WEBDIR// /\\ }/repodata/repomd.xml" \
-      repodata/ # Remote
+	scp \
+		"${SCP_OPTS[@]}" \
+		"$PKGSERVER:${SUSE_WEBDIR// /\\ }/repodata/repomd.xml" \
+		repodata/ # Remote
 
+	gpg \
+		--batch \
+		--pinentry-mode loopback \
+		-u "$GPG_KEYNAME" \
+		-a \
+		--detach-sign \
+		--passphrase-file "$GPG_PASSPHRASE_FILE" \
+		--yes \
+		repodata/repomd.xml
 
-    gpg \
-      --batch \
-      --pinentry-mode loopback \
-      -u "$GPG_KEYNAME" \
-      -a \
-      --detach-sign \
-      --passphrase-file "$GPG_PASSPHRASE_FILE" \
-      --yes \
-      repodata/repomd.xml
+	scp \
+		"${SCP_OPTS[@]}" \
+		repodata/repomd.xml.asc \
+		"$PKGSERVER:${SUSE_WEBDIR// /\\ }/repodata/"
 
-     scp \
-      "${SCP_OPTS[@]}" \
-      repodata/repomd.xml.asc \
-      "$PKGSERVER:${SUSE_WEBDIR// /\\ }/repodata/"
+	cp repodata/repomd.xml.asc "${SUSE_WEBDIR// /\\ }/repodata/"
 
-     cp repodata/repomd.xml.asc "${SUSE_WEBDIR// /\\ }/repodata/"
+	# Following html need to be located inside the binary directory
+	rsync \
+		--compress \
+		--verbose \
+		--recursive \
+		--include "HEADER.html" \
+		--include "FOOTER.html" \
+		--exclude "*" \
+		--progress \
+		. "$SUSEDIR/"
 
-    # Following html need to be located inside the binary directory
-    rsync \
-      --compress \
-      --verbose \
-      --recursive \
-      --include "HEADER.html" \
-      --include "FOOTER.html" \
-      --exclude "*" \
-      --progress \
-      . "$SUSEDIR/"
+	rsync \
+		--archive \
+		--compress \
+		--verbose \
+		-e "ssh ${SSH_OPTS[*]}" \
+		--include "HEADER.html" \
+		--include "FOOTER.html" \
+		--exclude "*" \
+		--progress \
+		. "$PKGSERVER:${SUSEDIR// /\\ }/"
 
-    rsync \
-      --archive \
-      --compress \
-      --verbose \
-      -e "ssh ${SSH_OPTS[*]}" \
-      --include "HEADER.html" \
-      --include "FOOTER.html" \
-      --exclude "*" \
-      --progress \
-      . "$PKGSERVER:${SUSEDIR// /\\ }/"
-    
-  popd
+	popd
 }
 
 show


### PR DESCRIPTION
I have been finding it quite annoying to edit the scripts in this repository, as they have wildly inconsistent formatting (sometimes spaces and tabs in the same file, confusing even `sleuth.vim` on my system). This PR changes no logic but applies a fresh coat of [`shfmt(1)`](https://github.com/mvdan/sh) on all shell scripts, making the formatting consistent so they are easier to read and edit. I suggest reviewing this with "Hide whitespace" enabled in the GitHub UI.