### PR TITLE
Fix shellcheck errors in `build.sh` and `setup.sh` scripts

### DIFF
--- a/deb/setup.sh
+++ b/deb/setup.sh
@@ -1,2 +1,5 @@
-#!/bin/bash
+#!/bin/bash -eux
+
 sudo apt-get install -y devscripts apt-utils || true
+
+exit 0

--- a/rpm/build/build.sh
+++ b/rpm/build/build.sh
@@ -1,26 +1,24 @@
-#!/bin/bash
-
-set -e
+#!/bin/bash -eux
 
 # prepare fresh directories
 D=$(mktemp -d)
-trap 'rm -rf "$D"' EXIT
+trap 'rm -rf "${D}"' EXIT
 
-cp -R "$(dirname "$0")"/* $D
-"$BASE/bin/branding.py" $D
+cp -R "$(dirname "$0")"/* "${D}"
+"${BASE}/bin/branding.py" "${D}"
 
-cp "$WAR" $D/SOURCES/jenkins.war
+cp "${WAR}" "${D}/SOURCES/jenkins.war"
 
-pushd $D
+pushd "${D}"
 mkdir -p BUILD RPMS SRPMS
-rpmbuild -ba --define="_topdir $PWD" --define="_tmppath $PWD/tmp" --define="ver $VERSION" SPECS/jenkins.spec
+rpmbuild -ba --define="_topdir ${PWD}" --define="_tmppath ${PWD}/tmp" --define="ver ${VERSION}" SPECS/jenkins.spec
 
 # sign the results
-for rpm in $(find RPMS -name '*.rpm'); do
-	rpmsign --addsign "${rpm}"
-	rpm -qpi "${rpm}"
-done
+find RPMS -type f -name '*.rpm' -exec rpmsign --addsign '{}' \;
+find RPMS -type f -name '*.rpm' -exec rpm -qpi '{}' \;
 popd
 
-mkdir -p "$(dirname "${RPM}")" || true
-mv $D/RPMS/noarch/*.rpm "${RPM}"
+mkdir -p "$(dirname "${RPM}")"
+mv "${D}"/RPMS/noarch/*.rpm "${RPM}"
+
+exit 0

--- a/rpm/setup.sh
+++ b/rpm/setup.sh
@@ -1,2 +1,5 @@
-#!/bin/bash
+#!/bin/bash -eux
+
 sudo apt-get install -y rpm expect createrepo || true
+
+exit 0

--- a/setup.mk
+++ b/setup.mk
@@ -16,7 +16,7 @@ export MSI?=$(error Required variable MSI must point to the jenkins.msi file you
 export MSI_SHASUM:=${MSI}.sha256
 
 # where to generate Debian/Ubuntu DEB file?
-export DEB=${TARGET}/debian/${ARTIFACTNAME}_${VERSION}${DEB_REVISION}_all.deb
+export DEB=${TARGET}/debian/${ARTIFACTNAME}_${VERSION}_all.deb
 
 # where to generate RHEL/CentOS RPM file?
 export RPM=${TARGET}/rpm/${ARTIFACTNAME}-${VERSION}-1.1.noarch.rpm

--- a/suse/build/build.sh
+++ b/suse/build/build.sh
@@ -1,26 +1,24 @@
-#!/bin/bash -e
+#!/bin/bash -eux
 
 # prepare fresh directories
-D=/tmp/$$
-mkdir $D
+D=$(mktemp -d)
+trap 'rm -rf "${D}"' EXIT
 
-cp -R "$(dirname "$0")"/* $D
-"$BASE/bin/branding.py" $D
+cp -R "$(dirname "$0")"/* "${D}"
+"${BASE}/bin/branding.py" "${D}"
 
-cp "$WAR" $D/SOURCES/jenkins.war
+cp "${WAR}" "${D}/SOURCES/jenkins.war"
 
-pushd $D
+pushd "${D}"
 mkdir -p BUILD RPMS SRPMS
-rpmbuild -ba --define="_topdir $PWD" --define="_tmppath $PWD/tmp" --define="ver $VERSION" SPECS/jenkins.spec
+rpmbuild -ba --define="_topdir ${PWD}" --define="_tmppath ${PWD}/tmp" --define="ver ${VERSION}" SPECS/jenkins.spec
 
 # sign the results
-for rpm in $(find RPMS -name '*.rpm'); do
-	rpmsign --addsign "${rpm}"
-	rpm -qpi "${rpm}"
-done
+find RPMS -type f -name '*.rpm' -exec rpmsign --addsign '{}' \;
+find RPMS -type f -name '*.rpm' -exec rpm -qpi '{}' \;
 popd
 
-mkdir -p "$(dirname "${SUSE}")" || true
-mv $D/RPMS/noarch/*.rpm ${SUSE}
+mkdir -p "$(dirname "${SUSE}")"
+mv "${D}"/RPMS/noarch/*.rpm "${SUSE}"
 
-rm -rf $D
+exit 0


### PR DESCRIPTION
Makes `build.sh` and `setup.sh` scripts shellcheck-clean, mostly by fixing quoting errors. These scripts are exercised as part of every build, including CI builds.