### PR TITLE
Make Debian scripts shellcheck-clean

### DIFF
--- a/deb/build/debian/jenkins.init
+++ b/deb/build/debian/jenkins.init
@@ -17,39 +17,38 @@ PATH=/bin:/usr/bin:/sbin:/usr/sbin
 
 DESC="@@SUMMARY@@"
 NAME=@@ARTIFACTNAME@@
-SCRIPTNAME=/etc/init.d/$NAME
+SCRIPTNAME=/etc/init.d/${NAME}
 
-[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+[ -r /etc/default/${NAME} ] && . /etc/default/${NAME}
 
-#DAEMON=$JENKINS_SH
 DAEMON=/usr/bin/daemon
-DAEMON_ARGS="--name=$NAME --inherit --env=JENKINS_HOME=$JENKINS_HOME --output=$JENKINS_LOG --pidfile=$PIDFILE"
+DAEMON_ARGS="--name=${NAME} --inherit --env=JENKINS_HOME=${JENKINS_HOME} --output=${JENKINS_LOG} --pidfile=${PIDFILE}"
 JAVA=$(type -p java)
 
-if [ -n "$UMASK" ]; then
-	DAEMON_ARGS="$DAEMON_ARGS --umask=$UMASK"
+if [ -n "${UMASK}" ]; then
+	DAEMON_ARGS="${DAEMON_ARGS} --umask=${UMASK}"
 fi
-if [ "$JENKINS_ENABLE_ACCESS_LOG" = "yes" ]; then
-	JENKINS_ARGS="$JENKINS_ARGS --accessLoggerClassName=winstone.accesslog.SimpleAccessLogger --simpleAccessLogger.format=combined --simpleAccessLogger.file=/var/log/$NAME/access_log"
+if [ "${JENKINS_ENABLE_ACCESS_LOG}" = "yes" ]; then
+	JENKINS_ARGS="${JENKINS_ARGS} --accessLoggerClassName=winstone.accesslog.SimpleAccessLogger --simpleAccessLogger.format=combined --simpleAccessLogger.file=/var/log/${NAME}/access_log"
 fi
 
 SU=/bin/su
 
 # Exit if the package is not installed
-if [ ! -x "$DAEMON" ]; then
+if [ ! -x "${DAEMON}" ]; then
 	echo "daemon package not installed" >&2
 	exit 1
 fi
 
 # Exit if not supposed to run standalone
-if [ "$RUN_STANDALONE" = "false" ]; then
+if [ "${RUN_STANDALONE}" = "false" ]; then
 	echo "Not configured to run standalone" >&2
 	exit 1
 fi
 
 # Make sure there exists a java executable, it may not be always the case
-if [ -z "$JAVA" ]; then
-	echo "ERROR: No Java executable found in current PATH: $PATH" >&2
+if [ -z "${JAVA}" ]; then
+	echo "ERROR: No Java executable found in current PATH: ${PATH}" >&2
 	echo "If you actually have java installed on the system make sure the executable is in the aforementioned path and that 'type -p java' returns the java executable path" >&2
 	exit 1
 fi
@@ -57,14 +56,14 @@ fi
 # Which Java versions can be used to run Jenkins
 JAVA_ALLOWED_VERSIONS=("1.8" "11")
 # Work out the JAVA version we are working with:
-JAVA_VERSION=$($JAVA -version 2>&1 | sed -n ';s/.* version "\([0-9]\{2,\}\|[0-9]\.[0-9]\)\..*".*/\1/p;')
+JAVA_VERSION=$(${JAVA} -version 2>&1 | sed -n ';s/.* version "\([0-9]\{2,\}\|[0-9]\.[0-9]\)\..*".*/\1/p;')
 
-if [[ ${JAVA_ALLOWED_VERSIONS[*]} =~ $JAVA_VERSION ]]; then
+if [[ ${JAVA_ALLOWED_VERSIONS[*]} =~ ${JAVA_VERSION} ]]; then
 	echo "Correct java version found" >&2
 else
 	echo "Found an incorrect Java version" >&2
 	echo "Java version found:" >&2
-	echo $($JAVA -version) >&2
+	${JAVA} -version >&2
 	echo "Aborting" >&2
 	exit 1
 fi
@@ -87,8 +86,8 @@ fi
 
 # Make sure we run as root, since setting the max open files through
 # ulimit requires root access
-if [ $(id -u) -ne 0 ]; then
-	echo "The $NAME init script can only be run as root"
+if [ "$(id -u)" -gt 0 ]; then
+	echo "The ${NAME} init script can only be run as root"
 	exit 1
 fi
 
@@ -98,24 +97,25 @@ check_tcp_port() {
 	local default=$3
 	local assigned_address=$4
 	local default_address=$5
+	local port
 
-	if [ -n "$assigned" ]; then
-		port=$assigned
+	if [ -n "${assigned}" ]; then
+		port=${assigned}
 	else
-		port=$default
+		port=${default}
 	fi
 
-	if [ -n "$assigned_address" ]; then
-		address=$assigned_address
+	if [ -n "${assigned_address}" ]; then
+		address=${assigned_address}
 	else
-		address=$default_address
+		address=${default_address}
 	fi
 
-	count=$(netstat --listen --numeric-ports | grep $address\:$port[[:space:]] | grep -c .)
+	count=$(netstat --listen --numeric-ports | grep "${address}:${port}[[:space:]]" | grep -c .)
 
-	if [ $count -ne 0 ]; then
-		echo "The selected $service port ($port) on address $address seems to be in use by another program "
-		echo "Please select another address/port combination to use for $NAME"
+	if [ "${count}" -gt 0 ]; then
+		echo "The selected ${service} port (${port}) on address ${address} seems to be in use by another program "
+		echo "Please select another address/port combination to use for ${NAME}"
 		return 1
 	fi
 }
@@ -125,52 +125,50 @@ check_tcp_port() {
 #
 do_start() {
 	# the default location is /var/run/jenkins/jenkins.pid but the parent directory needs to be created
-	mkdir $(dirname $PIDFILE) >/dev/null 2>&1 || true
-	chown $JENKINS_USER $(dirname $PIDFILE)
+	mkdir "$(dirname "${PIDFILE}")" >/dev/null 2>&1 || true
+	chown "${JENKINS_USER}" "$(dirname "${PIDFILE}")"
 	# Return
 	#   0 if daemon has been started
 	#   1 if daemon was already running
 	#   2 if daemon could not be started
-	$DAEMON $DAEMON_ARGS --running && return 1
+	${DAEMON} ${DAEMON_ARGS} --running && return 1
 
 	# Verify if there is a jenkins process already running without a daemon
 	get_running || return 2
 
 	# Verify that the jenkins port is not already in use, winstone does not exit
 	# even for BindException
-	check_tcp_port "http" "$HTTP_PORT" "@@PORT@@" "$HTTP_HOST" "0.0.0.0" || return 2
+	check_tcp_port "http" "${HTTP_PORT}" "@@PORT@@" "${HTTP_HOST}" "0.0.0.0" || return 2
 
 	# If the var MAXOPENFILES is enabled in /etc/default/jenkins then set the max open files to the
 	# proper value
-	if [ -n "$MAXOPENFILES" ]; then
-		[ "$VERBOSE" != no ] && echo Setting up max open files limit to $MAXOPENFILES
-		ulimit -n $MAXOPENFILES
+	if [ -n "${MAXOPENFILES}" ]; then
+		[ "${VERBOSE}" != no ] && echo "Setting up max open files limit to ${MAXOPENFILES}"
+		ulimit -n "${MAXOPENFILES}"
 	fi
-
 	# notify of explicit umask
-	if [ -n "$UMASK" ]; then
-		[ "$VERBOSE" != no ] && echo Setting umask to $UMASK
+	if [ -n "${UMASK}" ]; then
+		[ "${VERBOSE}" != no ] && echo "Setting umask to ${UMASK}"
 	fi
 
 	# --user in daemon doesn't prepare environment variables like HOME, USER, LOGNAME or USERNAME,
 	# so we let su do so for us now
-	$SU -l $JENKINS_USER --shell=/bin/bash -c "$DAEMON $DAEMON_ARGS -- $JAVA $JAVA_ARGS -jar $JENKINS_WAR $JENKINS_ARGS" || return 2
+	${SU} -l "${JENKINS_USER}" --shell=/bin/bash -c "${DAEMON} ${DAEMON_ARGS} -- ${JAVA} ${JAVA_ARGS} -jar ${JENKINS_WAR} ${JENKINS_ARGS}" || return 2
 }
 
 #
 # Verify that all jenkins processes have been shutdown
 #
 get_running() {
-	return $(pgrep -U $JENKINS_USER -f $JENKINS_WAR | grep -c .)
+	return "$(pgrep -U "${JENKINS_USER}" -f "${JENKINS_WAR}" | grep -c .)"
 }
 
 #
 # killall jenkins processes that have not been shutdown
 #
 force_stop() {
-	get_running
-	if [ $? -ne 0 ]; then
-		killall -u $JENKINS_USER java daemon || return 3
+	if ! get_running; then
+		killall -u "${JENKINS_USER}" java daemon || return 3
 		# wait for the process to really terminate
 		for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
 			sleep 1
@@ -182,7 +180,7 @@ force_stop() {
 
 # Get the status of the daemon process
 get_daemon_status() {
-	$DAEMON $DAEMON_ARGS --running || return 1
+	${DAEMON} ${DAEMON_ARGS} --running || return 1
 }
 
 #
@@ -197,11 +195,11 @@ do_stop() {
 	get_daemon_status
 	case "$?" in
 	0)
-		$DAEMON $DAEMON_ARGS --stop || return 2
+		${DAEMON} ${DAEMON_ARGS} --stop || return 2
 		# wait for the process to really terminate
 		for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
 			sleep 1
-			$DAEMON $DAEMON_ARGS --running || break
+			${DAEMON} ${DAEMON_ARGS} --running || break
 		done
 		if get_daemon_status; then
 			force_stop || return "$?"
@@ -213,18 +211,17 @@ do_stop() {
 	esac
 
 	# Many daemons don't delete their pidfiles when they exit.
-	rm -f $PIDFILE
+	rm -f "${PIDFILE}"
 	return 0
 }
 
 # Verify the process did in fact start successfully and didn't just bomb out
 do_check_started_ok() {
 	sleep 1
-	if [ "$1" -ne "0" ]; then
-		return $1
+	if [ "$1" -gt 0 ]; then
+		return "$1"
 	fi
-	get_running
-	if [ "$?" -eq "0" ]; then
+	if get_running; then
 		return 2
 	else
 		return 0
@@ -233,12 +230,14 @@ do_check_started_ok() {
 
 case "$1" in
 start)
-	log_daemon_msg "Starting $DESC" "$NAME"
+	log_daemon_msg "Starting ${DESC}" "${NAME}"
 	do_start
 	START_STATUS="$?"
-	do_check_started_ok "$START_STATUS"
+	do_check_started_ok "${START_STATUS}"
 	case "$?" in
-	0 | 1) log_end_msg 0 ;;
+	0 | 1)
+		log_end_msg 0
+		;;
 	2)
 		log_end_msg 1
 		exit 7
@@ -246,10 +245,12 @@ start)
 	esac
 	;;
 stop)
-	log_daemon_msg "Stopping $DESC" "$NAME"
+	log_daemon_msg "Stopping ${DESC}" "${NAME}"
 	do_stop
 	case "$?" in
-	0 | 1) log_end_msg 0 ;;
+	0 | 1)
+		log_end_msg 0
+		;;
 	2 | 3)
 		log_end_msg 1
 		exit 100
@@ -261,16 +262,18 @@ restart | force-reload)
 	# If the "reload" option is implemented then remove the
 	# 'force-reload' alias
 	#
-	log_daemon_msg "Restarting $DESC" "$NAME"
+	log_daemon_msg "Restarting ${DESC}" "${NAME}"
 	do_stop
 	case "$?" in
 	0 | 1)
 		do_start
 		START_STATUS="$?"
 		sleep 1
-		do_check_started_ok "$START_STATUS"
+		do_check_started_ok "${START_STATUS}"
 		case "$?" in
-		0) log_end_msg 0 ;;
+		0)
+			log_end_msg 0
+			;;
 		1)
 			log_end_msg 1
 			exit 100
@@ -291,16 +294,16 @@ status)
 	get_daemon_status
 	case "$?" in
 	0)
-		echo "$DESC is running with the pid $(cat $PIDFILE)"
+		echo "${DESC} is running with the pid $(cat "${PIDFILE}")"
 		rc=0
 		;;
 	*)
 		get_running
 		procs=$?
-		if [ $procs -eq 0 ]; then
-			echo -n "$DESC is not running"
-			if [ -f $PIDFILE ]; then
-				echo ", but the pidfile ($PIDFILE) still exists"
+		if [ ${procs} -eq 0 ]; then
+			echo -n "${DESC} is not running"
+			if [ -f "${PIDFILE}" ]; then
+				echo ", but the pidfile (${PIDFILE}) still exists"
 				rc=1
 			else
 				echo
@@ -308,17 +311,17 @@ status)
 			fi
 
 		else
-			echo "$procs instances of jenkins are running at the moment"
-			echo "but the pidfile $PIDFILE is missing"
+			echo "${procs} instances of jenkins are running at the moment"
+			echo "but the pidfile ${PIDFILE} is missing"
 			rc=0
 		fi
 
-		exit $rc
+		exit ${rc}
 		;;
 	esac
 	;;
 *)
-	echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
+	echo "Usage: ${SCRIPTNAME} {start|stop|status|restart|force-reload}" >&2
 	exit 3
 	;;
 esac

--- a/deb/build/debian/jenkins.postinst
+++ b/deb/build/debian/jenkins.postinst
@@ -20,8 +20,8 @@ set -e
 case "$1" in
 configure)
 	[ -r /etc/default/@@ARTIFACTNAME@@ ] && . /etc/default/@@ARTIFACTNAME@@
-	: ${JENKINS_USER:=@@ARTIFACTNAME@@}
-	: ${JENKINS_GROUP:=@@ARTIFACTNAME@@}
+	: "${JENKINS_USER:=@@ARTIFACTNAME@@}"
+	: "${JENKINS_GROUP:=@@ARTIFACTNAME@@}"
 
 	# Create @@ARTIFACTNAME@@ group and user if they don't exist.
 	# sometimes tools that users want Jenkins to run need a shell,


### PR DESCRIPTION
Makes the Debian scripts `shellcheck(1)`-clean, largely by adding proper quoting where necessary.