### PR TITLE
Remove explicit dependency on `sysvinit-utils`

### DIFF
--- a/deb/build/debian/control
+++ b/deb/build/debian/control
@@ -8,5 +8,5 @@ Homepage: @@HOMEPAGE@@
 
 Package: @@ARTIFACTNAME@@
 Architecture: all
-Depends: ${misc:Depends}, adduser, lsb-base (>= 3.2-14), net-tools, sysvinit-utils
+Depends: ${misc:Depends}, adduser, lsb-base (>= 3.2-14), net-tools
 Description: @@DESCRIPTION_FILE@@


### PR DESCRIPTION
The Debian package declares a depends on `sysvinit-utils`, which is an essential package, without using a versioned `depends`. Packages do not need to depend on essential packages; essential means that they will always be present. The only reason to list an explicit dependency on an essential package is if you need a particular version of that package. We don't need a particular version, so we should just remove the explicit dependency on `sysvinit-utils`.