### PR TITLE
Bump `Standards-Version` from 3.9.8 to 4.6.0

### DIFF
--- a/deb/build/debian/control
+++ b/deb/build/debian/control
@@ -3,7 +3,7 @@ Section: devel
 Priority: optional
 Maintainer: @@AUTHOR@@
 Build-Depends: debhelper (>= 10)
-Standards-Version: 3.9.8
+Standards-Version: 4.6.0
 Homepage: @@HOMEPAGE@@
 
 Package: @@ARTIFACTNAME@@


### PR DESCRIPTION
This doesn't introduce any new `lintian` errors, and I read through the [upgrade checklist](https://www.debian.org/doc/packaging-manuals/upgrading-checklist.txt) and didn't find anything that applied to us.