### PR TITLE
Use regular branding in CI builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ podTemplate(yaml: readTrusted('KubernetesPod.yaml'), workingDir: '/home/jenkins/
     withEnv([
       "BUILDENV=${WORKSPACE}/env/test.mk",
       "BRANDING_DIR=${WORKSPACE}/branding",
-      "BRAND=${WORKSPACE}/branding/test.mk",
+      "BRAND=${WORKSPACE}/branding/jenkins.mk",
       "GPG_FILE=${WORKSPACE}/credentials/sandbox.gpg",
       "GPG_KEYNAME=Bogus Test",
       "GPG_PASSPHRASE=s3cr3t",

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
     environment:
     - "BUILDENV=/srv/releases/jenkins/env/test.mk"
     - "BRANDING_DIR=/srv/releases/jenkins/branding"
-    - "BRAND=/srv/releases/jenkins/branding/test.mk"
+    - "BRAND=/srv/releases/jenkins/branding/jenkins.mk"
     - "GPG_FILE=/srv/releases/jenkins/credentials/sandbox.gpg"
     - "GPG_KEYNAME=Bogus Test"
     - "GPG_PASSPHRASE=s3cr3t"

--- a/molecule/default/install-deb.yml
+++ b/molecule/default/install-deb.yml
@@ -17,7 +17,7 @@
 - apt:
     deb: "{{ package_list.files[0].path }}"
 - lineinfile:
-    path: /etc/default/jenkinstest
+    path: /etc/default/jenkins
     regexp: '^JAVA_ARGS='
     line: "JAVA_ARGS=\"-Djava.awt.headless=true -Xmx256m\""
 - systemd:

--- a/molecule/default/install-rpm.yml
+++ b/molecule/default/install-rpm.yml
@@ -24,7 +24,7 @@
     disable_gpg_check: true  # TODO get this working
     state: present
 - lineinfile:
-    path: /etc/sysconfig/jenkinstest
+    path: /etc/sysconfig/jenkins
     regexp: '^JENKINS_JAVA_OPTIONS='
     line: "JENKINS_JAVA_OPTIONS=\"-Djava.awt.headless=true -Xmx256m\""
 - systemd:

--- a/molecule/default/install-suse.yml
+++ b/molecule/default/install-suse.yml
@@ -20,7 +20,7 @@
     disable_gpg_check: true  # TODO get this working
     state: present
 - lineinfile:
-    path: /etc/sysconfig/jenkinstest
+    path: /etc/sysconfig/jenkins
     regexp: '^JENKINS_JAVA_OPTIONS='
     line: "JENKINS_JAVA_OPTIONS=\"-Djava.awt.headless=true -Xmx256m\""
 - systemd:

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -3,7 +3,7 @@
   hosts: all
   tasks:
   - stat:
-      path: "{{ '/var/run/jenkinstest/jenkinstest.pid' if ansible_os_family == 'Debian' else '/var/run/jenkinstest.pid' }}"
+      path: "{{ '/var/run/jenkins/jenkins.pid' if ansible_os_family == 'Debian' else '/var/run/jenkins.pid' }}"
     register: pid_file
   - assert:
       that:
@@ -16,17 +16,17 @@
         - (service_pids.pids | length) == 0
       fail_msg: "{{ service_pids.pids|join(',') }}"
   - service:
-      name: jenkinstest
+      name: jenkins
       state: started
   - uri:
-      url: "http://127.0.0.1:7777"
+      url: "http://127.0.0.1:8080"
       status_code: 403
     register: result
     until: result.status == 403
     retries: 20
     delay: 5
   - stat:
-      path: "{{ '/var/run/jenkinstest/jenkinstest.pid' if ansible_os_family == 'Debian' else '/var/run/jenkinstest.pid' }}"
+      path: "{{ '/var/run/jenkins/jenkins.pid' if ansible_os_family == 'Debian' else '/var/run/jenkins.pid' }}"
     register: pid_file
   - assert:
       that:
@@ -39,17 +39,17 @@
         - (service_pids.pids | length) == 1
       fail_msg: "{{ service_pids.pids | join(',') }}"
   - slurp:
-      src: "{{ '/var/run/jenkinstest/jenkinstest.pid' if ansible_os_family == 'Debian' else '/var/run/jenkinstest.pid' }}"
+      src: "{{ '/var/run/jenkins/jenkins.pid' if ansible_os_family == 'Debian' else '/var/run/jenkins.pid' }}"
     register: pid_file_contents
   - assert:
       that:
         - service_pids.pids[0] == (pid_file_contents['content'] | b64decode | trim | int)
       fail_msg: "Service PID {{ service_pids.pids[0] }} does not match PID file {{ pid_file_contents['content'] | b64decode | trim | int }}"
   - service:
-      name: jenkinstest
+      name: jenkins
       state: stopped
   - stat:
-      path: "{{ '/var/run/jenkinstest/jenkinstest.pid' if ansible_os_family == 'Debian' else '/var/run/jenkinstest.pid' }}"
+      path: "{{ '/var/run/jenkins/jenkins.pid' if ansible_os_family == 'Debian' else '/var/run/jenkins.pid' }}"
     register: pid_file
   - assert:
       that:


### PR DESCRIPTION
The `jenkinstest` branding is fairly annoying and makes it impossible to test CI builds on normal environments. This PR switches CI builds to the regular branding, which should make things simpler.