### PR TITLE
[JENKINS-56911] Debian package postinst script does not support group names with spaces

### DIFF
--- a/deb/build/debian/jenkins.postinst
+++ b/deb/build/debian/jenkins.postinst
@@ -38,19 +38,19 @@ configure)
 
 	# directories needed for jenkins
 	# we don't do -R because it can take a long time on big installation
-	chown $JENKINS_USER:$JENKINS_GROUP /var/lib/@@ARTIFACTNAME@@ /var/log/@@ARTIFACTNAME@@
+	chown "${JENKINS_USER}:${JENKINS_GROUP}" /var/lib/@@ARTIFACTNAME@@ /var/log/@@ARTIFACTNAME@@
 	# we don't do "chmod 750" so that the user can choose the pemission for g and o on their own
 	chmod u+rwx /var/lib/@@ARTIFACTNAME@@ /var/log/@@ARTIFACTNAME@@
 
 	# make sure jenkins can delete everything in /var/cache/jenkins to
 	# re-explode war.
-	chown -R $JENKINS_USER:$JENKINS_GROUP /var/cache/@@ARTIFACTNAME@@
+	chown -R "${JENKINS_USER}:${JENKINS_GROUP}" /var/cache/@@ARTIFACTNAME@@
 	chmod -R 750 /var/cache/@@ARTIFACTNAME@@
 
 	# older installations may use /var/run/jenkins
 	# so make sure that they can delete too.
 	if [ -d "/var/run/@@ARTIFACTNAME@@" ]; then
-		chown -R $JENKINS_USER:$JENKINS_GROUP /var/run/@@ARTIFACTNAME@@
+		chown -R "${JENKINS_USER}:${JENKINS_GROUP}" /var/run/@@ARTIFACTNAME@@
 		chmod -R 750 /var/run/@@ARTIFACTNAME@@
 	fi
 	;;


### PR DESCRIPTION
Fixes [JENKINS-56911](https://issues.jenkins.io/browse/JENKINS-56911)