### PR TITLE
Declare minimum required version of `sysvinit-utils`

### DIFF
--- a/deb/build/debian/control
+++ b/deb/build/debian/control
@@ -8,5 +8,5 @@ Homepage: @@HOMEPAGE@@
 
 Package: @@ARTIFACTNAME@@
 Architecture: all
-Depends: ${misc:Depends}, adduser, lsb-base (>= 3.2-14), net-tools
+Depends: ${misc:Depends}, adduser, lsb-base (>= 3.2-14), net-tools, sysvinit-utils (>= 2.88dsf-50)
 Description: @@DESCRIPTION_FILE@@


### PR DESCRIPTION
In #264 I wrote:

> The Debian package declares a depends on `sysvinit-utils`, which is an essential package, without using a versioned `depends`. Packages do not need to depend on essential packages; essential means that they will always be present. The only reason to list an explicit dependency on an essential package is if you need a particular version of that package. We don't need a particular version, so we should just remove the explicit dependency on `sysvinit-utils`.

It turns out that we do in fact need a particular version: one that contains `/lib/init/init-d-script`, which we started depending on in #261. The first version that contains `/lib/init/init-d-script` is 2.88dsf-50 (shipped in Ubuntu 16.04), so this PR updates our control file to explicitly declare this dependency.

This will mean that Ubuntu 14.04 installations with older versions of `sysvinit-utils` will be unable to upgrade to the new package. But this is better than the status quo, where they can upgrade to a broken system.