### PR TITLE
[JENKINS-67724] Debian package fails to start when `JAVA_ARGS` contains spaces

### DIFF
--- a/deb/build/debian/jenkins.init
+++ b/deb/build/debian/jenkins.init
@@ -130,6 +130,7 @@ do_start_cmd_override() {
 		LOGNAME="${JENKINS_USER}" \
 		USERNAME="${JENKINS_USER}" \
 		PWD="${JENKINS_HOME}" \
+		eval \
 		start-stop-daemon \
 		--start \
 		--quiet \

--- a/molecule/default/install-deb.yml
+++ b/molecule/default/install-deb.yml
@@ -18,7 +18,7 @@
 - lineinfile:
     path: /etc/default/jenkins
     regexp: '^JAVA_ARGS='
-    line: "JAVA_ARGS=\"-Djava.awt.headless=true -Xmx256m\""
+    line: "JAVA_ARGS=\"-Djava.awt.headless=true -Xmx256m -Dhudson.model.DirectoryBrowserSupport.CSP=\\\"default-src 'self';\\\"\""
 - systemd:
     daemon_reload: true
   when: ansible_service_mgr == 'systemd'

--- a/molecule/default/install-rpm.yml
+++ b/molecule/default/install-rpm.yml
@@ -32,7 +32,7 @@
 - lineinfile:
     path: /etc/sysconfig/jenkins
     regexp: '^JENKINS_JAVA_OPTIONS='
-    line: "JENKINS_JAVA_OPTIONS=\"-Djava.awt.headless=true -Xmx256m\""
+    line: "JENKINS_JAVA_OPTIONS=\"-Djava.awt.headless=true -Xmx256m -Dhudson.model.DirectoryBrowserSupport.CSP=\\\"default-src 'self';\\\"\""
 - systemd:
     daemon_reload: true
   when: ansible_service_mgr == 'systemd'

--- a/molecule/default/install-suse.yml
+++ b/molecule/default/install-suse.yml
@@ -32,7 +32,7 @@
 - lineinfile:
     path: /etc/sysconfig/jenkins
     regexp: '^JENKINS_JAVA_OPTIONS='
-    line: "JENKINS_JAVA_OPTIONS=\"-Djava.awt.headless=true -Xmx256m\""
+    line: "JENKINS_JAVA_OPTIONS=\"-Djava.awt.headless=true -Xmx256m -Dhudson.model.DirectoryBrowserSupport.CSP=\\\"default-src 'self';\\\"\""
 - systemd:
     daemon_reload: true
   when: ansible_service_mgr == 'systemd'


### PR DESCRIPTION
#261 contained a bug: it did not support `JAVA_ARGS` that contain spaces. Since we've been bitten by problems like this a few times now, I updated the automated tests to cover this case for all supported platforms. The new test fails on Debian before the fix to `deb/build/debian/jenkins.init` and passes with it.