### PR TITLE
Fix javaHome arg in Debian default file comment

### DIFF
--- a/deb/build/debian/jenkins.default
+++ b/deb/build/debian/jenkins.default
@@ -67,7 +67,8 @@ HTTP_PORT=@@PORT@@
 PREFIX=/$NAME
 
 # arguments to pass to jenkins.
-# --javahome=$JAVA_HOME
+# full list available from java -jar jenkins.war --help
+# --javaHome=$JAVA_HOME
 # --httpListenAddress=$HTTP_HOST (default 0.0.0.0)
 # --httpPort=$HTTP_PORT (default 8080; disable with -1)
 # --httpsPort=$HTTP_PORT


### PR DESCRIPTION
## Fix `javaHome` argument in Debian defaults file

The `--javahome` argument that was listed in the Debian defaults file is rejected by Jenkins when it is included in the JENKINS_ARGS variable.

The `--javaHome` argument is accepted by Jenkins but does not seem to set the JAVA_HOME environment variable in Jenkins 2.330 on Debian 11.  The JAVA_HOME environment variable is not shown in Jenkins 2.330 in the "Manage Jenkins" -> "System Information" page of Jenkins 2.330 and is not shown in the environment variable list reported by a job run on the Jenkins 2.330 controller.

The `--javaHome` argument is accepted by Jenkins and sets the JAVA_HOME environment variable in Jenkins 2.333 when using pull request #266 (systemd support) and is shown in the environment variable list reported by a job run on the Jenkins 2.333 controller installed with the systemd support provided in pull request #266.

See https://github.com/jenkinsci/packaging/pull/266

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
