### PR TITLE
Workaround broken centos stream 9 repo setup

### DIFF
--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -16,7 +16,7 @@ ENV {{ var }} {{ value }}
 
 RUN if [ $(command -v apt-get) ] && [ $(command -v systemctl) ]  && [ ! -f /sbin/init ]; then export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -y python3 sudo bash ca-certificates iproute2 python3-apt python3-psutil aptitude systemd-sysv && apt-get clean && rm -rf /var/lib/apt/lists/*; \
     elif [ $(command -v apt-get) ]; then export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -y python3 sudo bash ca-certificates iproute2 python3-apt python3-psutil aptitude && apt-get clean && rm -rf /var/lib/apt/lists/*; \
-    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install /usr/bin/python3 /usr/bin/python3-config /usr/bin/dnf-3 python3-psutil sudo bash iproute && dnf clean all; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python3-devel /usr/bin/dnf-3 python3-psutil sudo bash iproute && dnf clean all; \
     elif [ $(command -v yum) ]; then yum makecache fast && yum install -y /usr/bin/python /usr/bin/python2-config sudo yum-plugin-ovl python-psutil bash iproute && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
     elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python3 python3-psutil sudo bash iproute2 && zypper clean -a; \
     elif [ $(command -v apk) ]; then apk update && apk add --no-cache python3 sudo bash ca-certificates; \


### PR DESCRIPTION
https://github.com/jenkinsci/packaging/pull/266#issuecomment-1039415918

This fails:
```
[root@5435bc08e1f9 /]# dnf --assumeyes install /usr/bin/python3 /usr/bin/python3-config
Last metadata expiration check: 0:03:37 ago on Mon Feb 14 22:11:33 2022.
Package python3-3.9.10-2.el9.aarch64 is already installed.
Error:
 Problem: package python3-devel-3.9.10-1.el9.aarch64 requires python3 = 3.9.10-1.el9, but none of the providers can be installed
  - cannot install both python3-3.9.10-1.el9.aarch64 and python3-3.9.10-2.el9.aarch64
  - cannot install the best candidate for the job
(try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
```

They are coming from different repos, `baseos` and `appstream`.

The `appstream` repo ones only work with `3.9.10-1.el9` whereas base is shipping `python3-3.9.10-2.el9`.

This okay as a workaround?

I assume it'll get fixed at some point