### PR TITLE
Stop customizing `TimeoutStartSec` in tests

### DIFF
--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -17,7 +17,7 @@
       dest: /etc/systemd/system/jenkins.service.d/override.conf
       content: |
         [Service]
-        TimeoutStartSec=180
+        TimeoutStartSec=250
         Environment="JAVA_OPTS=-Djava.awt.headless=true -Xmx256m -Dhudson.model.DirectoryBrowserSupport.CSP=\"default-src 'self';\" -Djenkins.model.Jenkins.extendTimeoutSeconds=180"
     when: ansible_service_mgr == 'systemd'
   - systemd:

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -17,8 +17,8 @@
       dest: /etc/systemd/system/jenkins.service.d/override.conf
       content: |
         [Service]
-        TimeoutStartSec=120
-        Environment="JAVA_OPTS=-Djava.awt.headless=true -Xmx256m -Dhudson.model.DirectoryBrowserSupport.CSP=\"default-src 'self';\" -Djenkins.model.Jenkins.extendTimeoutSeconds=120"
+        TimeoutStartSec=180
+        Environment="JAVA_OPTS=-Djava.awt.headless=true -Xmx256m -Dhudson.model.DirectoryBrowserSupport.CSP=\"default-src 'self';\" -Djenkins.model.Jenkins.extendTimeoutSeconds=180"
     when: ansible_service_mgr == 'systemd'
   - systemd:
       daemon_reload: true

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -17,7 +17,7 @@
       dest: /etc/systemd/system/jenkins.service.d/override.conf
       content: |
         [Service]
-        Environment="JAVA_OPTS=-Djava.awt.headless=true -Xmx256m -Dhudson.model.DirectoryBrowserSupport.CSP=\"default-src 'self';\" -Djenkins.model.Jenkins.extendTimeoutSeconds=30"
+        Environment="JAVA_OPTS=-Djava.awt.headless=true -Xmx256m -Dhudson.model.DirectoryBrowserSupport.CSP=\"default-src 'self';\" -Djenkins.model.Jenkins.extendTimeoutSeconds=60"
     when: ansible_service_mgr == 'systemd'
   - systemd:
       daemon_reload: true

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -17,7 +17,8 @@
       dest: /etc/systemd/system/jenkins.service.d/override.conf
       content: |
         [Service]
-        Environment="JAVA_OPTS=-Djava.awt.headless=true -Xmx256m -Dhudson.model.DirectoryBrowserSupport.CSP=\"default-src 'self';\" -Djenkins.model.Jenkins.extendTimeoutSeconds=500"
+        TimeoutStartSec=250
+        Environment="JAVA_OPTS=-Djava.awt.headless=true -Xmx256m -Dhudson.model.DirectoryBrowserSupport.CSP=\"default-src 'self';\" -Djenkins.model.Jenkins.extendTimeoutSeconds=250"
     when: ansible_service_mgr == 'systemd'
   - systemd:
       daemon_reload: true

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -17,7 +17,7 @@
       dest: /etc/systemd/system/jenkins.service.d/override.conf
       content: |
         [Service]
-        Environment="JAVA_OPTS=-Djava.awt.headless=true -Xmx256m -Dhudson.model.DirectoryBrowserSupport.CSP=\"default-src 'self';\""
+        Environment="JAVA_OPTS=-Djava.awt.headless=true -Xmx256m -Dhudson.model.DirectoryBrowserSupport.CSP=\"default-src 'self';\" -Djenkins.model.Jenkins.extendTimeoutSeconds=30"
     when: ansible_service_mgr == 'systemd'
   - systemd:
       daemon_reload: true

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -17,7 +17,7 @@
       dest: /etc/systemd/system/jenkins.service.d/override.conf
       content: |
         [Service]
-        Environment="JAVA_OPTS=-Djava.awt.headless=true -Xmx256m -Dhudson.model.DirectoryBrowserSupport.CSP=\"default-src 'self';\" -Djenkins.model.Jenkins.extendTimeoutSeconds=60"
+        Environment="JAVA_OPTS=-Djava.awt.headless=true -Xmx256m -Dhudson.model.DirectoryBrowserSupport.CSP=\"default-src 'self';\" -Djenkins.model.Jenkins.extendTimeoutSeconds=120"
     when: ansible_service_mgr == 'systemd'
   - systemd:
       daemon_reload: true

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -17,8 +17,8 @@
       dest: /etc/systemd/system/jenkins.service.d/override.conf
       content: |
         [Service]
-        TimeoutStartSec=250
-        Environment="JAVA_OPTS=-Djava.awt.headless=true -Xmx256m -Dhudson.model.DirectoryBrowserSupport.CSP=\"default-src 'self';\" -Djenkins.model.Jenkins.extendTimeoutSeconds=250"
+        TimeoutStartSec=120
+        Environment="JAVA_OPTS=-Djava.awt.headless=true -Xmx256m -Dhudson.model.DirectoryBrowserSupport.CSP=\"default-src 'self';\" -Djenkins.model.Jenkins.extendTimeoutSeconds=120"
     when: ansible_service_mgr == 'systemd'
   - systemd:
       daemon_reload: true

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -17,8 +17,8 @@
       dest: /etc/systemd/system/jenkins.service.d/override.conf
       content: |
         [Service]
-        TimeoutStartSec=250
-        Environment="JAVA_OPTS=-Djava.awt.headless=true -Xmx256m -Dhudson.model.DirectoryBrowserSupport.CSP=\"default-src 'self';\" -Djenkins.model.Jenkins.extendTimeoutSeconds=180"
+        TimeoutStartSec=180
+        Environment="JAVA_OPTS=-Djava.awt.headless=true -Xmx256m -Dhudson.model.DirectoryBrowserSupport.CSP=\"default-src 'self';\" -Djenkins.model.Jenkins.extendTimeoutSeconds=250"
     when: ansible_service_mgr == 'systemd'
   - systemd:
       daemon_reload: true

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -17,7 +17,7 @@
       dest: /etc/systemd/system/jenkins.service.d/override.conf
       content: |
         [Service]
-        Environment="JAVA_OPTS=-Djava.awt.headless=true -Xmx256m -Dhudson.model.DirectoryBrowserSupport.CSP=\"default-src 'self';\" -Djenkins.model.Jenkins.extendTimeoutSeconds=120"
+        Environment="JAVA_OPTS=-Djava.awt.headless=true -Xmx256m -Dhudson.model.DirectoryBrowserSupport.CSP=\"default-src 'self';\" -Djenkins.model.Jenkins.extendTimeoutSeconds=500"
     when: ansible_service_mgr == 'systemd'
   - systemd:
       daemon_reload: true

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -18,7 +18,6 @@
       content: |
         [Service]
         Environment="JAVA_OPTS=-Djava.awt.headless=true -Xmx256m -Dhudson.model.DirectoryBrowserSupport.CSP=\"default-src 'self';\""
-        TimeoutStartSec=600
     when: ansible_service_mgr == 'systemd'
   - systemd:
       daemon_reload: true


### PR DESCRIPTION
With the release of jenkinsci/jenkins#6237, it should no longer be necessary to customize `TimeoutStartSec` in common use cases, including this repository's tests.