### PR TITLE
Support port numbers less than 1024 in systemd

### DIFF
--- a/systemd/jenkins.service
+++ b/systemd/jenkins.service
@@ -61,12 +61,18 @@ Environment="JAVA_OPTS=-Djava.awt.headless=true"
 #Environment="JENKINS_LISTEN_ADDRESS="
 
 # Port to listen on for HTTP requests. Set to -1 to disable.
+# To be able to listen on privileged ports (port numbers less than 1024),
+# add the CAP_NET_BIND_SERVICE capability to the AmbientCapabilities
+# directive below.
 Environment="JENKINS_PORT=@@PORT@@"
 
 # IP address to listen on for HTTPS requests. Default is disabled.
 #Environment="JENKINS_HTTPS_LISTEN_ADDRESS="
 
 # Port to listen on for HTTPS requests. Default is disabled.
+# To be able to listen on privileged ports (port numbers less than 1024),
+# add the CAP_NET_BIND_SERVICE capability to the AmbientCapabilities
+# directive below.
 #Environment="JENKINS_HTTPS_PORT=443"
 
 # Path to the keystore in JKS format (as created by the JDK's keytool).
@@ -84,10 +90,22 @@ Environment="JENKINS_PORT=@@PORT@@"
 #Environment="JENKINS_HTTP2_LISTEN_ADDRESS="
 
 # HTTP2 port to listen on. Default is disabled.
+# To be able to listen on privileged ports (port numbers less than 1024),
+# add the CAP_NET_BIND_SERVICE capability to the AmbientCapabilities
+# directive below.
 #
 # Note: HTTP2 support may require additional configuration.
 # See the Winstone documentation for more information.
 #Environment="JENKINS_HTTP2_PORT="
+
+# Controls which capabilities to include in the ambient capability set for the
+# executed process. Takes a whitespace-separated list of capability names, e.g.
+# CAP_SYS_ADMIN, CAP_DAC_OVERRIDE, CAP_SYS_PTRACE. Ambient capability sets are
+# useful if you want to execute a process as a non-privileged user but still
+# want to give it some capabilities. For example, add the CAP_NET_BIND_SERVICE
+# capability to be able to listen on privileged ports (port numbers less than
+# 1024).
+#AmbientCapabilities=CAP_NET_BIND_SERVICE
 
 # Debug level for logs. The higher the value, the more verbose. 5 is INFO.
 #Environment="JENKINS_DEBUG_LEVEL=5"

--- a/systemd/migrate.sh
+++ b/systemd/migrate.sh
@@ -345,7 +345,10 @@ migrate_options() {
 		edited=true
 	fi
 
+	privileged_port=false
+
 	if [ "${NEW_JENKINS_PORT}" != "${NEW_JENKINS_PORT_DEFAULT}" ]; then
+		[ "${NEW_JENKINS_PORT}" -lt 1024 ] && privileged_port=true
 		NEW_JENKINS_PORT="$(printf '%s' "${NEW_JENKINS_PORT}" | sed -e 's/"/\\"/g')"
 		echo "Environment=\"JENKINS_PORT=${NEW_JENKINS_PORT}\"" >>"${tmpfile}"
 		edited=true
@@ -358,6 +361,7 @@ migrate_options() {
 	fi
 
 	if [ -n "${NEW_JENKINS_HTTPS_PORT}" ]; then
+		[ "${NEW_JENKINS_HTTPS_PORT}" -lt 1024 ] && privileged_port=true
 		NEW_JENKINS_HTTPS_PORT="$(printf '%s' "${NEW_JENKINS_HTTPS_PORT}" | sed -e 's/"/\\"/g')"
 		echo "Environment=\"JENKINS_HTTPS_PORT=${NEW_JENKINS_HTTPS_PORT}\"" >>"${tmpfile}"
 		edited=true
@@ -382,8 +386,14 @@ migrate_options() {
 	fi
 
 	if [ -n "${NEW_JENKINS_HTTP2_PORT}" ]; then
+		[ "${NEW_JENKINS_HTTP2_PORT}" -lt 1024 ] && privileged_port=true
 		NEW_JENKINS_HTTP2_PORT="$(printf '%s' "${NEW_JENKINS_HTTP2_PORT}" | sed -e 's/"/\\"/g')"
 		echo "Environment=\"JENKINS_HTTP2_PORT=${NEW_JENKINS_HTTP2_PORT}\"" >>"${tmpfile}"
+		edited=true
+	fi
+
+	if $privileged_port; then
+		echo "AmbientCapabilities=CAP_NET_BIND_SERVICE" >>"${tmpfile}"
 		edited=true
 	fi
 


### PR DESCRIPTION
## Background

See [JENKINS-41218 (comment)](https://issues.jenkins.io/browse/JENKINS-41218?focusedCommentId=421905&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-421905) (CC @zbynek).

## Problem

When the Jenkins port is set to a privileged port (port numbers less than 1024), Jenkins fails to start with a permissions error.

## Solution

Direct the user to enable the [`CAP_NET_BIND_SERVICE` capability](https://manpages.debian.org/bullseye/manpages/capabilities.7.en.html#CAP_NET_BIND_SERVICE) in such scenarios, and update the migration script to do so automatically when migrating such configurations to `systemd`.

## Testing Done

Set `HTTP_PORT=80` in the legacy `/etc/default/jenkins` file and deleted any `systemd` drop-ins, then installed the package from this PR. Verified that the drop-in created by the migration script contained the `CAP_NET_BIND_SERVICE` and that Jenkins started successfully on port 80 and could accept HTTP connections.