### PR TITLE
Run job weekly only on master branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,13 @@
-properties([
+def jobProperties = [
   buildDiscarder(logRotator(numToKeepStr: '50', artifactNumToKeepStr: '5')),
-  disableConcurrentBuilds(abortPrevious: true),
-  pipelineTriggers([cron('@weekly')]) // Run at least weekly to assure we test recent releases
-])
+  disableConcurrentBuilds(abortPrevious: true)
+]
+
+if (env.BRANCH_NAME == 'master') {
+  jobProperties << pipelineTriggers([cron('@weekly')]) // Run at least weekly on the master branch to assure we test recent releases
+}
+
+properties(jobProperties)
 
 podTemplate(yaml: readTrusted('KubernetesPod.yaml'), workingDir: '/home/jenkins/agent') {
   nodeWithTimeout(POD_LABEL) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,8 +3,8 @@ def jobProperties = [
   disableConcurrentBuilds(abortPrevious: true)
 ]
 
-if (env.BRANCH_NAME == 'master') {
-  jobProperties << pipelineTriggers([cron('@weekly')]) // Run at least weekly on the master branch to assure we test recent releases
+if (env.BRANCH_IS_PRIMARY) {
+  jobProperties << pipelineTriggers([cron('@weekly')]) // Run at least weekly on the primary branch to assure we test recent releases
 }
 
 properties(jobProperties)


### PR DESCRIPTION
## Run job weekly only on master branch

See the conversation in https://github.com/jenkinsci/packaging/pull/291#discussion_r820060557

The master branch should regularly run tests.  Other branches do not benefit enough from running the tests and risk that we'll waste time and money running tests on outdated stable branches.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
