### PR TITLE
Prefer --httpPort from JENKINS_ARGS over HTTP_PORT

### DIFF
--- a/systemd/migrate.sh
+++ b/systemd/migrate.sh
@@ -219,10 +219,10 @@ read_old_options() {
 		NEW_JENKINS_LISTEN_ADDRESS="${JENKINS_LISTEN_ADDRESS}"
 	fi
 
-	if [ -n "${HTTP_PORT}" ] && [ "${HTTP_PORT}" -gt 0 ]; then
-		NEW_JENKINS_PORT="${HTTP_PORT}"
-	elif [ -n "${JENKINS_PORT}" ] && [ "${JENKINS_PORT}" -gt 0 ]; then
+	if [ -n "${JENKINS_PORT}" ] && [ "${JENKINS_PORT}" -gt 0 ]; then
 		NEW_JENKINS_PORT="${JENKINS_PORT}"
+	elif [ -n "${HTTP_PORT}" ] && [ "${HTTP_PORT}" -gt 0 ]; then
+		NEW_JENKINS_PORT="${HTTP_PORT}"
 	fi
 
 	if [ -n "${JENKINS_HTTPS_LISTEN_ADDRESS}" ]; then


### PR DESCRIPTION
If the Jenkins options file looks like this:
```
  HTTP_PORT=8080
  JENKINS_ARGS="--httpPort=8081"
```

Then it is 8081 from "--httpPort=8081" that should be used, not 8080 from $HTTP_PORT but the migration script prefers $HTTP_PORT.

It's not entirely clear why HTTP_PORT exists in the options file at all when it wasn't used for this purpose by any init script. The debian version would check if the port can be used but it won't pass it to Jenkins. Only when the example "--httpPort=$HTTP_PORT" is added (which is not part of the default JENKINS_ARGS) will it do anything.

Prefer the HTTP port from $JENKINS_ARGS over the one in $HTTP_PORT.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
