### PR TITLE
[JENKINS-68007] Prefer `--httpPort` from `JENKINS_ARGS` over `HTTP_PORT` when the two differ

### DIFF
--- a/systemd/migrate.sh
+++ b/systemd/migrate.sh
@@ -52,6 +52,12 @@ NEW_JENKINS_WEBROOT="${NEW_JENKINS_WEBROOT_DEFAULT}"
 has_prefix=false
 
 read_old_options() {
+	# This could only be the case for deb
+	if [ -n "${HTTP_PORT}" ] && [ "${HTTP_PORT}" -gt 0 ]; then
+		# Normalize to rpm convention
+		JENKINS_PORT="${HTTP_PORT}"
+	fi
+
 	if [ -n "${JENKINS_ARGS}" ]; then
 		if [ -n "${NAME}" ]; then
 			# For deb, these are all the arguments, except for the JENKINS_ENABLE_ACCESS_LOG additions
@@ -219,9 +225,7 @@ read_old_options() {
 		NEW_JENKINS_LISTEN_ADDRESS="${JENKINS_LISTEN_ADDRESS}"
 	fi
 
-	if [ -n "${HTTP_PORT}" ] && [ "${HTTP_PORT}" -gt 0 ]; then
-		NEW_JENKINS_PORT="${HTTP_PORT}"
-	elif [ -n "${JENKINS_PORT}" ] && [ "${JENKINS_PORT}" -gt 0 ]; then
+	if [ -n "${JENKINS_PORT}" ] && [ "${JENKINS_PORT}" -gt 0 ]; then
 		NEW_JENKINS_PORT="${JENKINS_PORT}"
 	fi
 


### PR DESCRIPTION
### Problem

Originally reported in #295 (thanks @nomis!). I distilled the problem statement from that PR into a set of steps to reproduce, expected result, and actual result in [JENKINS-68007](https://issues.jenkins.io/browse/JENKINS-68007).

Note that I am marking this as an `lts-candidate`, but I want to note that the scope of this bug is very small indeed. There is no issue in the existing migration code for the common cases:

- `HTTP_PORT` is customized and `JENKINS_ARGS` has `--httpPort=$HTTP_PORT` (which is what we recommend in our examples)
- `HTTP_PORT` is customized and `JENKINS_ARGS` has `--httpPort` set to the same number

The only case in which the existing migration code has a problem is if the two numbers differ, which is an unexpected edge case.

### Solution

The approach taken in #295 (inverting the order of the `if` statements) does fix the problem, but I think this solution is more robust. Rather than trying to support two conventions, this PR normalizes the code to the RPM convention early on during execution (before we parse the value of `--httpPort`. That way, we only have one variable to keep track of in our mind as we continue reading the code, and the `if` statement only needs one conditional branch rather than two. Simpler.

### Testing done

Reproduced the original problem as described in the Jira issue. Could no longer reproduce the problem with the changes from this PR.