### PR TITLE
Add preview support for Java 17

### DIFF
--- a/systemd/jenkins.sh
+++ b/systemd/jenkins.sh
@@ -34,6 +34,8 @@ infer_java_cmd() {
 }
 
 check_java_version() {
+	printf '%s' "${JENKINS_OPTS}" | grep -q '\--enable-future-java' && return 0
+
 	java_version=$("${JENKINS_JAVA_CMD}" -version 2>&1 |
 		sed -n ';s/.* version "\([0-9]\{2,\}\|[0-9]\.[0-9]\)\..*".*/\1/p;')
 
@@ -120,10 +122,10 @@ main() {
 
 	infer_java_cmd || die 'failed to find a valid Java installation'
 
+	infer_jenkins_opts
+
 	check_java_version ||
 		die "invalid java version: $("${JENKINS_JAVA_CMD}" -version)"
-
-	infer_jenkins_opts
 
 	java_opts_tmp="${JAVA_OPTS}"
 	unset JAVA_OPTS

--- a/systemd/jenkins.sh
+++ b/systemd/jenkins.sh
@@ -125,7 +125,7 @@ main() {
 	infer_jenkins_opts
 
 	check_java_version ||
-		die "invalid java version: $("${JENKINS_JAVA_CMD}" -version)"
+		die "invalid Java version: $("${JENKINS_JAVA_CMD}" -version 2>&1)"
 
 	java_opts_tmp="${JAVA_OPTS}"
 	unset JAVA_OPTS


### PR DESCRIPTION
As of jenkinsci/jenkins#6356 there is no longer any need for `--add-opens` on Java 17, but there is still a problem with the version check in this repository which causes a hard failure on anything other than Java 8 and Java 11. I considered removing this entirely, as it seems to be a bit heavy-handed, but then I decided that it is a useful guardrail to prevent users from accidentally running Jenkins in an unsupported configuration. So instead I am just skipping the Java version check when the `--enable-future-java` Jenkins option is provided, which is needed to enable Java 17 preview support anyway.

### Testing done

Functional testing: started Jenkins successfully with Java 17 and this `systemd` configuration (with jenkinsci/jenkins#6356):

```
[Service]
Environment="JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64"
Environment="JENKINS_OPTS=--enable-future-java"
Environment="JENKINS_WAR=/home/basil/src/jenkinsci/jenkins/war/target/jenkins.war"
```

Regression testing: started Jenkins successfully with Java 11 and this `systemd` configuration:

```
[Service]
Environment="JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64"
```

Fixes #217