### PR TITLE
Backporting for LTS 2.332.2

### DIFF
--- a/msi/build/jenkins.wxs
+++ b/msi/build/jenkins.wxs
@@ -1,9 +1,4 @@
 <?xml version="1.0"?>
-
-<!--
-  WiX variables are supposed to look like <DOLLAR>(var.VARNAME), which means
-  it has to be written like <BACKSLASH><DOLLAR>(var.VARNAME) to survive the first processing
--->
 <Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'
      xmlns:fire="http://schemas.microsoft.com/wix/FirewallExtension"
      xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
@@ -18,11 +13,10 @@
     <Icon Id="installer.ico" SourceFile="$(var.InstallerIco)" />
     <Binary Id="Cryptography" SourceFile="msiext-1.5\CustomActions\Cryptography.dll" />
 
-
     <!-- Save the command line value INSTALLDIR and restore it later in the sequence or it will be overwritten by the value saved to the registry during an upgrade -->
     <!-- http://robmensching.com/blog/posts/2010/5/2/the-wix-toolsets-remember-property-pattern/ -->
     <CustomAction Id='SaveCmdLineValueINSTALLDIR' Property='CMDLINE_INSTALLDIR' Value='[INSTALLDIR]' Execute='firstSequence' />
-    <CustomAction Id='SetFromCmdLineValueINSTALLDIR' Property='INSTALLDIR' Value='[CMDLINE_INSTALLDIR]' Execute='firstSequence' />
+    <CustomAction Id='SetFromCmdLineValueINSTALLDIR' Property='JENKINSDIR' Value='[CMDLINE_INSTALLDIR]' Execute='firstSequence' />
     <InstallUISequence>
         <Custom Action='SaveCmdLineValueINSTALLDIR' Before='AppSearch' />
         <Custom Action='SetFromCmdLineValueINSTALLDIR' After='AppSearch'>
@@ -39,7 +33,7 @@
     <!-- Save the command line value PORT and restore it later in the sequence or it will be overwritten by the value saved to the registry during an upgrade -->
     <!-- http://robmensching.com/blog/posts/2010/5/2/the-wix-toolsets-remember-property-pattern/ -->
     <CustomAction Id='SaveCmdLineValuePORT' Property='CMDLINE_PORT' Value='[PORT]' Execute='firstSequence' />
-    <CustomAction Id='SetFromCmdLineValuePORT' Property='PORT' Value='[CMDLINE_PORT]' Execute='firstSequence' />
+    <CustomAction Id='SetFromCmdLineValuePORT' Property='PORTNUMBER' Value='[CMDLINE_PORT]' Execute='firstSequence' />
     <InstallUISequence>
         <Custom Action='SaveCmdLineValuePORT' Before='AppSearch' />
         <Custom Action='SetFromCmdLineValuePORT' After='AppSearch'>
@@ -104,8 +98,8 @@
         </Custom>
     </InstallExecuteSequence>
 
-    <!-- Determine the directory of a previous installation (if one exists). If not INSTALLDIR stays empty -->
-    <Property Id="INSTALLDIR">
+    <!-- Determine the directory of a previous installation (if one exists). If not JENKINSDIR stays empty -->
+    <Property Id="JENKINSDIR">
         <RegistrySearch Id="DetermineInstallLocation" Type="raw" Root="HKLM" Key="Software\Jenkins\InstalledProducts\Jenkins" Name="InstallLocation" Win64="yes" />
     </Property>
 
@@ -214,7 +208,7 @@
                   ErrorControl="normal"
                   Description="$(var.ProductSummary)"
                   Account="[SERVICE_USERNAME]"
-                  Password="[SERVICE_PASSWORD]" />            
+                  Password="[SERVICE_PASSWORD]" />
           </Component>
 
           <!-- Registry entries -->
@@ -236,8 +230,8 @@
             <ServiceControl Id="Control$(var.ArtifactName)Service" Name="$(var.ArtifactName)" Start="install" Stop="both" Wait="yes" Remove="uninstall" />
           </Component>
 
-          <!-- 
-            We have this for the case if someone doesn't have the service started during install, if that component isn't installed, then the service will 
+          <!--
+            We have this for the case if someone doesn't have the service started during install, if that component isn't installed, then the service will
             not be uninstalled during uninstallation. This component makes sure that the service will be uninstalled correctly in this case.
           -->
           <Component Id="UninstallService" Guid="9D0DEE31-5560-4FDD-8A73-236A4102BFE0">

--- a/systemd/migrate.sh
+++ b/systemd/migrate.sh
@@ -52,6 +52,12 @@ NEW_JENKINS_WEBROOT="${NEW_JENKINS_WEBROOT_DEFAULT}"
 has_prefix=false
 
 read_old_options() {
+	# This could only be the case for deb
+	if [ -n "${HTTP_PORT}" ] && [ "${HTTP_PORT}" -gt 0 ]; then
+		# Normalize to rpm convention
+		JENKINS_PORT="${HTTP_PORT}"
+	fi
+
 	if [ -n "${JENKINS_ARGS}" ]; then
 		if [ -n "${NAME}" ]; then
 			# For deb, these are all the arguments, except for the JENKINS_ENABLE_ACCESS_LOG additions
@@ -219,9 +225,7 @@ read_old_options() {
 		NEW_JENKINS_LISTEN_ADDRESS="${JENKINS_LISTEN_ADDRESS}"
 	fi
 
-	if [ -n "${HTTP_PORT}" ] && [ "${HTTP_PORT}" -gt 0 ]; then
-		NEW_JENKINS_PORT="${HTTP_PORT}"
-	elif [ -n "${JENKINS_PORT}" ] && [ "${JENKINS_PORT}" -gt 0 ]; then
+	if [ -n "${JENKINS_PORT}" ] && [ "${JENKINS_PORT}" -gt 0 ]; then
 		NEW_JENKINS_PORT="${JENKINS_PORT}"
 	fi
 


### PR DESCRIPTION
```
Latest core version: jenkins-2.340

Fixed
-----

JENKINS-68007		Minor     		2.339
	Prefer --httpPort from JENKINS_ARGS over HTTP_PORT when the two differ
	https://issues.jenkins.io/browse/JENKINS-68007

JENKINS-67995		Minor     		2.339
	SystemdLifecycle logging "Operation not permitted" calling sd_notify(3) during startup
	regression
	https://issues.jenkins.io/browse/JENKINS-67995

JENKINS-67797		Minor     		2.336 (Feb 22, 2022)
	Weather status hover text reports wrong result on jobs not yet built
	regression
	https://issues.jenkins.io/browse/JENKINS-67797

JENKINS-66446		Critical  		2.338, Remoting 4.13
	WebSocket agent does not reconnect: ClassNotFoundException: jenkins.slaves.restarter.JnlpSlaveRestarterInstaller
	https://issues.jenkins.io/browse/JENKINS-66446

JENKINS-65809		Major     		2.335
	Jenkins fails to restart after plugin updates on Debian 11 (bullseye)
	https://issues.jenkins.io/browse/JENKINS-65809

JENKINS-41218		Critical  		2.335
	Provide native systemd unit
	https://issues.jenkins.io/browse/JENKINS-41218
```

Only found commit for [JENKINS-68007](https://issues.jenkins.io/browse/JENKINS-68007)

Seems like
- [JENKINS-65809](https://issues.jenkins.io/browse/JENKINS-65809)
- [JENKINS-41218](https://issues.jenkins.io/browse/JENKINS-41218)

were included in `stable-2.332` before 
- https://github.com/jenkinsci/packaging/commit/35e665912ef3dc3c735539667c485051428f49b1
- https://github.com/jenkinsci/packaging/commit/cfa89d8c710ab478a06b8358463ffb4aa3e6f346