### PR TITLE
Remove references to `limits.conf`

### DIFF
--- a/systemd/jenkins.service
+++ b/systemd/jenkins.service
@@ -125,19 +125,15 @@ Environment="JENKINS_PORT=@@PORT@@"
 #Environment="JENKINS_OPTS="
 
 # Maximum core file size. If unset, the value from the OS is inherited.
-# The default limit comes from /etc/security/limits.conf.
 #LimitCORE=infinity
 
 # Maximum file size. If unset, the value from the OS is inherited.
-# The default limit comes from /etc/security/limits.conf.
 #LimitFSIZE=infinity
 
 # File descriptor limit. If unset, the value from the OS is inherited.
-# The default limit comes from /etc/security/limits.conf.
 #LimitNOFILE=8192
 
 # Maximum number of processes. If unset, the value from the OS is inherited.
-# The default limit comes from /etc/security/limits.conf.
 #LimitNPROC=32768
 
 # Set the umask to control the permission bits of files that Jenkins creates.


### PR DESCRIPTION
When writing this section, I copied the comments from the old System V `init` configuration, but after some more research I don't think these comments are accurate. Based on [this blog post](https://shellpower.wordpress.com/2019/11/28/systemd-not-honoring-etc-security-limits-conf/) and others it seems that `systemd` ignores `limits.conf`. This PR deletes the inaccurate comments.