### PR TITLE
[JENKINS-68149] Handle old WAR location from RPM

### DIFF
--- a/systemd/migrate.sh
+++ b/systemd/migrate.sh
@@ -196,6 +196,10 @@ read_old_options() {
 		NEW_JENKINS_WAR="${JENKINS_WAR}"
 	fi
 	if [ "${NEW_JENKINS_WAR}" = "/usr/share/@@ARTIFACTNAME@@/@@ARTIFACTNAME@@.war" ]; then
+		# deb
+		NEW_JENKINS_WAR="${NEW_JENKINS_WAR_DEFAULT}"
+	elif [ "${NEW_JENKINS_WAR}" = "/usr/lib/@@ARTIFACTNAME@@/@@ARTIFACTNAME@@.war" ]; then
+		# rpm
 		NEW_JENKINS_WAR="${NEW_JENKINS_WAR_DEFAULT}"
 	fi
 


### PR DESCRIPTION
Thanks to @meiswjn for reporting this issue in [JENKINS-68149](https://issues.jenkins.io/browse/JENKINS-68149). The problem here is that it is all too easy to mess up the merge of the old `sysconfig` script when upgrading, which then results in the migration script thinking that you've explicitly changed the WAR path when in fact you just messed up the merge. I actually messed this up myself once while testing, which is why I added an explicit check for this case in the migration script. Ah, but I only handled the Debian case, not the RPM case. So if you hit this edge case (messing up the merge for the RPM version) you could very well hit a problem. This PR removes the sharp edge by adding additional logic for the RPM case.