### PR TITLE
[JENKINS-68170] Show warning dialog if Java 8 is selected (#302)

### DIFF
--- a/msi/build/jenkins.wxs
+++ b/msi/build/jenkins.wxs
@@ -124,6 +124,8 @@
       <RegistrySearch Id="DetermineServicePassword" Type="raw" Root="HKLM" Key="Software\Jenkins\InstalledProducts\Jenkins" Name="SP" Win64="yes" />
     </Property>
 
+    <SetProperty After='AppSearch' Id='JAVA11_RECOMMENDED_SHOWN' Value='0'>1</SetProperty>
+
     <Property Id="CRYPTUNPROTECT_FLAGS" Value="CRYPTPROTECT_LOCAL_MACHINE|CRYPTPROTECT_UI_FORBIDDEN" />
     <CustomAction Id="SetEncryptedServicePASSWORD" Property="CRYPTUNPROTECT_DATA" Value="[SERVICE_PASSWORD_ENC]" />
     <CustomAction Id="DecryptServicePassword" BinaryKey="Cryptography" DllEntry="CryptUnprotectDataHex" Execute="immediate" />
@@ -368,6 +370,15 @@
 
       <Property Id="WixUI_Mode" Value="FeatureTree" />
 
+      <Dialog Id="InfoMessageDlg" Width="260" Height="100" Title="[INFO_TITLE]">
+        <Control Id="Return" Type="PushButton" X="102" Y="75" Width="56" Height="17" Default="yes" Cancel="yes" Text="OK">
+            <Publish Property="JAVA11_RECOMMENDED_SHOWN" Value="1">1</Publish>
+            <Publish Event="EndDialog" Value="Return">1</Publish>
+        </Control>
+        <Control Id="Text" Type="Text" X="48" Y="15" Width="200" Height="55" Text="[INFO_MESSAGE]" />
+        <Control Id="Icon" Type="Icon" X="15" Y="15" Width="24" Height="24" FixedSize="yes" IconSize="32" Text="!(loc.Java8DeprecationWarningIcon)" />
+      </Dialog>
+
       <Dialog Id="JavaHomeDlg" Width="370" Height="270" Title="!(loc.JavaHomeDlgTitle)">
           <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="!(loc.WixUINext)">
             <Publish Event="DoAction" Value="ValidateJavaHome" Order="1">1</Publish>
@@ -376,6 +387,12 @@
             <Publish Property="ERROR_TITLE" Value="!(loc.JavaHomeDlgErrorTitle)" Order="2"><![CDATA[JAVA_EXE_FOUND = "0" OR JAVA_EXE_VERSION = "10" OR JAVA_EXE_VERSION = "9"]]></Publish>
             <Publish Property="ERROR_MESSAGE" Value="!(loc.JavaJomeDlgErrorMessage)" Order="3"><![CDATA[JAVA_EXE_FOUND = "0" OR JAVA_EXE_VERSION = "10" OR JAVA_EXE_VERSION = "9"]]></Publish>
             <Publish Event="SpawnDialog" Value="GenericErrorDlg" Order="4"><![CDATA[JAVA_EXE_FOUND = "0" OR JAVA_EXE_VERSION = "10" OR JAVA_EXE_VERSION = "9"]]></Publish>
+
+            <!-- Spawn the info dialog if Java 8 was found. -->
+            <Publish Property="INFO_TITLE" Value="!(loc.Java8DeprecationWarningTitle)" Order="5"><![CDATA[JAVA_EXE_FOUND <> "0" AND JAVA_EXE_VERSION = "8"]]></Publish>
+            <Publish Property="INFO_MESSAGE" Value="!(loc.Java8DeprecationWarningMessage)" Order="6"><![CDATA[JAVA_EXE_FOUND <> "0" AND JAVA_EXE_VERSION = "8"]]></Publish>
+            <Publish Event="SpawnDialog" Value="InfoMessageDlg" Order="7"><![CDATA[JAVA_EXE_FOUND <> "0" AND JAVA_EXE_VERSION = "8" AND JAVA11_RECOMMENDED_SHOWN = "0" ]]></Publish>
+
             <Publish Property="JAVA_HOME" Value="[JAVA_HOME]">1</Publish>
           </Control>
           <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="!(loc.WixUIBack)" />
@@ -489,4 +506,3 @@
     <Property Id="WIXUI_INSTALLDIR" Value="JENKINSDIR" />
   </Product>
 </Wix>
-

--- a/msi/build/jenkins_en-US.wxl
+++ b/msi/build/jenkins_en-US.wxl
@@ -16,4 +16,9 @@
   <String Id="ServiceCredDlg_LocalSystemText" Overridable="yes">Run service as LocalSystem (not recommended)</String>
   <String Id="FirewallException_Description">Enables a firewall exception for the Java running Jenkins on port [PORTNUMBER] (not recommended).</String>
   <String Id="StartJenkinsService_Description">Starts the Jenkins service after install.</String>
+
+  <!-- Java 8 Deprectation Warning Dialog -->
+  <String Id="Java8DeprecationWarningTitle" Overridable="yes">Java 11 Recommended</String>
+  <String Id="Java8DeprecationWarningMessage" Overridable="yes">Java 11 is the recommended version of Java for running Jenkins. In the future, Java 8 will be deprecated and no longer work to run Jenkins. Please upgrade to Java 11 at your earliest convenience.</String>
+  <String Id="Java8DeprecationWarningIcon" Overridable="yes">WixUI_Ico_Info</String>
 </WixLocalization>


### PR DESCRIPTION
Add dialog that is shown if Java 8 is selected to run Jenkins

https://issues.jenkins.io/browse/JENKINS-68170

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
