### PR TITLE
Backporting for LTS 2.332.3

### DIFF
--- a/deb/build/debian/control
+++ b/deb/build/debian/control
@@ -3,10 +3,10 @@ Section: devel
 Priority: optional
 Maintainer: @@AUTHOR@@
 Build-Depends: debhelper (>= 10)
-Standards-Version: 4.6.0
+Standards-Version: 3.9.8
 Homepage: @@HOMEPAGE@@
 
 Package: @@ARTIFACTNAME@@
 Architecture: all
-Depends: ${misc:Depends}, adduser, lsb-base (>= 3.2-14), net-tools, sysvinit-utils (>= 2.88dsf-50)
+Depends: ${misc:Depends}, adduser, lsb-base (>= 3.2-14), net-tools, sysvinit-utils
 Description: @@DESCRIPTION_FILE@@

--- a/deb/build/debian/jenkins.init
+++ b/deb/build/debian/jenkins.init
@@ -130,7 +130,6 @@ do_start_cmd_override() {
 		LOGNAME="${JENKINS_USER}" \
 		USERNAME="${JENKINS_USER}" \
 		PWD="${JENKINS_HOME}" \
-		eval \
 		start-stop-daemon \
 		--start \
 		--quiet \


### PR DESCRIPTION
```
Latest core version: jenkins-2.343

Fixed
-----

JENKINS-68149           Major                   2.332.2
        2.332.1 upgrade changes JENKINS_WAR default location but doesn't apply it in the configuration
        https://issues.jenkins.io/browse/JENKINS-68149

JENKINS-67075           Minor                   Wed, 13 Apr 2022 06:40:58 +0000
        Failure to restart from Jenkins: "jenkins: /usr/bin/java" not found
        https://issues.jenkins.io/browse/JENKINS-67075
```