### PR TITLE
Display Maven version information without stopping build

### DIFF
--- a/deb/publish/publish.sh
+++ b/deb/publish/publish.sh
@@ -47,7 +47,7 @@ function generateSite() {
 	# Remote ftparchive-merge
 	# https://github.com/kohsuke/apt-ftparchive-merge
 	pushd $D/binary
-	mvn org.kohsuke:apt-ftparchive-merge:1.6:merge -Durl="$DEB_URL/binary/" -Dout=../merged
+	mvn -V org.kohsuke:apt-ftparchive-merge:1.6:merge -Durl="$DEB_URL/binary/" -Dout=../merged
 	popd
 
 	# Local ftparchive-merge


### PR DESCRIPTION
This PR adds the `-V` argument when invoking Maven, which displays the version of Maven and Java used in the build without stopping the build, which could be useful for debugging purposes (especially as we switch builds to Java 11).