### PR TITLE
Allow running on Java 17 without --enable-future-java

### DIFF
--- a/systemd/jenkins.sh
+++ b/systemd/jenkins.sh
@@ -41,7 +41,7 @@ check_java_version() {
 
 	if [ -z "${java_version}" ]; then
 		return 1
-	elif [ "${java_version}" != "11" ] && [ "${java_version}" != "1.8" ]; then
+	elif [ "${java_version}" != "17" ] && [ "${java_version}" != "11" ] && [ "${java_version}" != "1.8" ]; then
 		return 1
 	else
 		return 0


### PR DESCRIPTION
As of https://github.com/jenkinsci/jenkins/pull/6600 I cannot think of any reason _not_ to run Jenkins with Java 17: it works better than Java 11 in every case I am aware of. So let us allow users to use Java 17 without having to pass the scary `--enable-future-java` flag. I plan to mention in the blog post announcing the requirement of Java 11 that we're also taking Java 17 out of preview mode. I also plan to filing a PR to the Docker repository to remove the "preview" label from the Java 17 images around the same time.

### Testing done

Verified that with the changes from this PR and https://github.com/jenkinsci/extras-executable-war/pull/58 I could start Jenkins via `systemd(1)` with `Environment="JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64"` in my drop-in unit without `Environment="JENKINS_OPTS=--enable-future-java"` (which I needed before).