### PR TITLE
[WIP] Ubuntu has various createrepo dependencies depending on its version…

### DIFF
--- a/rpm/setup.sh
+++ b/rpm/setup.sh
@@ -1,5 +1,50 @@
 #!/bin/bash -eux
 
-sudo apt-get install -y rpm expect createrepo || true
+removeEnclosingQuotes() {
+  local unquotedText=$(sed -e 's/^"//' -e 's/"$//' <<<"$1")
+  echo $unquotedText
+}
+
+getCreateRepoPackageForDistro() {
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  local DISTRIB=$(awk -F= '/^NAME/{print $2}' /etc/os-release)
+  local DISTRO=$(removeEnclosingQuotes "$DISTRIB")
+  # echo "Distribution is ${DISTRO}"
+  if [[ ${DISTRO} == "Ubuntu"* ]]; then
+    if uname -a | grep -q '^Linux.*Microsoft';
+    then
+      # ubuntu via WSL Windows Subsystem for Linux
+      echo "createrepo"
+    else
+      # native ubuntu
+      local UBUNTU_VERSION=$(awk -F= '/^VERSION_ID/{print $2}' /etc/os-release)
+      local FINAL_UBUNTU_VERSION=$(removeEnclosingQuotes "${UBUNTU_VERSION}")
+      if [[ $(echo "$FINAL_UBUNTU_VERSION > 21.04" | bc -l) ]]; then
+        echo "createrepo-c"
+      elif [[ $(echo "$FINAL_UBUNTU_VERSION < 18.04" | bc -l) ]]; then
+        echo "createrepo"
+      else
+        echo "We're doomed"
+        exit 1
+      fi
+    fi
+  elif [[ ${DISTRO} == "Debian"* ]]; then
+    # debian
+    echo "createrepo"
+  else
+    echo "We're doomed"
+    exit 1
+  fi
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  # macOS OSX
+  echo "We're doomed"
+  exit 1
+fi
+}
+
+getCreateRepoPackageForDistro
+
+
+sudo apt-get install -y rpm expect $(getCreateRepoPackageForDistro) || true
 
 exit 0


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This is linked to issue #314.

Ubuntu had [`createrepo`](https://answers.launchpad.net/createrepo/+question/690448) until `18.04`, then it disappeared in `20.04`, and
reappeared in `21.04` as `createrepo-c` which is a rewrite in `C`.
We should then choose `createrepo` or `createrepo-c` or nothing,
depending on the `Ubuntu` distro version.

Here is a rough draft of `setup.sh` that chooses `createrepo` or `createrepo-c` depending on the `Ubuntu` version.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue


<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
