### PR TITLE
Switch back to createrepo remotely

### DIFF
--- a/rpm/publish/publish.sh
+++ b/rpm/publish/publish.sh
@@ -42,10 +42,10 @@ EOF
 	# generate index
 	# locally
 	# disable this for now, as it's currently now used and generate errors
-	# createrepo_c --update -o "$RPM_WEBDIR" "$RPMDIR/"
+	# createrepo --update -o "$RPM_WEBDIR" "$RPMDIR/"
 	# on the server
 	# shellcheck disable=SC2029
-	ssh "${SSH_OPTS[@]}" "$PKGSERVER" createrepo_c --update -o "'$RPM_WEBDIR'" "'$RPMDIR/'"
+	ssh "${SSH_OPTS[@]}" "$PKGSERVER" createrepo --update -o "'$RPM_WEBDIR'" "'$RPMDIR/'"
 }
 
 function skipIfAlreadyPublished() {

--- a/rpm/setup.sh
+++ b/rpm/setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eux
 
-sudo apt-get install -y rpm expect createrepo-c || true
+sudo apt-get install -y rpm expect || true
 
 exit 0

--- a/suse/publish/publish.sh
+++ b/suse/publish/publish.sh
@@ -107,13 +107,13 @@ function uploadSite() {
 		. "$PKGSERVER:${SUSE_WEBDIR// /\\ }/" # Remote
 
 	# generate index on the server
-	# server needs 'createrepo_c' pacakge
+	# server needs 'createrepo' pacakge
 	# Disable this for now as not critical
-	# createrepo_c --update -o "$SUSE_WEBDIR" "$SUSEDIR/" #Local
+	# createrepc --update -o "$SUSE_WEBDIR" "$SUSEDIR/" #Local
 	# cp "${SUSE_WEBDIR// /\\ }/repodata/repomd.xml" repodata/ # Local
 
 	# shellcheck disable=SC2029
-	ssh "${SSH_OPTS[@]}" "$PKGSERVER" createrepo_c --update -o "'$SUSE_WEBDIR'" "'$SUSEDIR/'" # Remote
+	ssh "${SSH_OPTS[@]}" "$PKGSERVER" createrepo --update -o "'$SUSE_WEBDIR'" "'$SUSEDIR/'" # Remote
 
 	scp \
 		"${SCP_OPTS[@]}" \


### PR DESCRIPTION
See https://github.com/jenkinsci/packaging/pull/317#discussion_r892741934

https://github.com/jenkins-infra/helpdesk/issues/2978

Looks like historically it was generated locally and then disabled at some point when it wasn't working