### PR TITLE
Allow Windows users to use the `docker` image while having checked out the repo when using Windows.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,9 @@
 # and leave all files detected as binary untouched.
 * text=auto
 
+# Git will always convert line endings to LF on checkout. You should use this for files that must keep LF endings, even on Windows.
+* text eol=lf
+
 #
 # The above will handle all files NOT found below
 #

--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,7 @@
 *.jellytag      text
 *.less          text
 *.properties    text
+*.py            text
 *.rb            text
 *.sh            text
 *.txt           text


### PR DESCRIPTION
I am working on Windows most of the time.
I do know this platform is not supported to develop with Jenkins.
The documentation of this repo recommends using  `docker-compose`, which I did, but I got some problems because `git` was making the text files compatible with Windows, but I was about to use them with a `docker` container running `Ubuntu`.
So... I got some problems with carriage returns and new lines (#316).
This `.gitattributes` file allowed me to checkout in another directory and fire the `docker-compose` command and then subsequent commands (like `./prep.sh`) with no more errors linked to line endings.
Thanks to @dduportal for suggesting it.

As for the tests, if you have access to a Windows machine, 
 * clone my `gitattributes` branch: `git clone --branch gitattributes https://github.com/gounthar/packaging.git`
 * go in the directory and launch `docker-compose run --rm packaging bash`
 * when in the container, issue a `./prep.sh`

If you have no error like this one:
```bash
jenkins@420db984a78b:/srv/releases/jenkins$ ./prep.sh
: invalid option
```

then you're good to go.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
