### PR TITLE
Remove Ubuntu 21.04, 21.10, and Fedora 34 tests

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -44,9 +44,6 @@ platforms:
   - name: centos-stream-9
     image: dokken/centos-stream-9:latest
     <<: *jenkins_systemd_platform_anchor
-  - name: fedora-34
-    image: dokken/fedora-34:latest
-    <<: *jenkins_systemd_platform_anchor
   - name: fedora-35
     image: dokken/fedora-35:latest
     <<: *jenkins_systemd_platform_anchor

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -25,9 +25,6 @@ platforms:
   - name: ubuntu-20-04
     image: dokken/ubuntu-20.04:latest
     <<: *jenkins_systemd_platform_anchor
-  - name: ubuntu-21-04
-    image: dokken/ubuntu-21.04:latest
-    <<: *jenkins_systemd_platform_anchor
   - name: ubuntu-21-10
     image: dokken/ubuntu-21.10:latest
     <<: *jenkins_systemd_platform_anchor

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -25,9 +25,6 @@ platforms:
   - name: ubuntu-20-04
     image: dokken/ubuntu-20.04:latest
     <<: *jenkins_systemd_platform_anchor
-  - name: ubuntu-21-10
-    image: dokken/ubuntu-21.10:latest
-    <<: *jenkins_systemd_platform_anchor
   - name: ubuntu-22-04
     image: dokken/ubuntu-22.04:latest
     <<: *jenkins_systemd_platform_anchor


### PR DESCRIPTION
## Remove Ubuntu 21.04 and Fedora 34 tests

- Remove Ubuntu 21.04 (hirsute) - end of life
- Remove Ubuntu 21.10 (impish) - no longer available on http://archive.ubuntu.com/ubuntu/dists/
- Remove Fedora 34 - no longer supported by Fedora project

Ubuntu 21.04 has been unsupported since January 2022 and seems to be failing to install.
Fedora 34 has been unsupported since early June 2022.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
