### PR TITLE
`git status` is not clean

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -20,24 +20,30 @@
 *.jellytag      text
 *.less          text
 *.properties    text
+*.ps1           -text
 *.py            text
 *.rb            text
+*.rtf           -text
 *.sh            text
 *.txt           text
 *.xml           text
 
 # These files are binary and should be left untouched
 # (binary is a macro for -text -diff)
+*.bmp           binary
 *.class         binary
 *.gz            binary
 *.tgz           binary
 *.ear           binary
+*.exe           binary
 *.gif           binary
+*.gpg           binary
 *.hpi           binary
 *.ico           binary
 *.jar           binary
 *.jpg           binary
 *.jpeg          binary
+*.keychain      binary
 *.png           binary
 *.war           binary
 *.zip           binary


### PR DESCRIPTION
### Steps to reproduce

1. Run `git clone https://github.com/jenkinsci/packaging.git` on a Linux system.
2. Run `cd packaging/`
3. Run `git status`

### Expected results

`git status` is clean.

### Actual results

```
$ git status
On branch master
Your branch is up to date with 'origin/master'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   credentials/sandbox.gpg
        modified:   credentials/test.gpg
        modified:   credentials/test.keychain
        modified:   credentials/test.secret.gpg
        modified:   make.ps1
        modified:   msi/build/License.rtf
        modified:   msi/build/jenkins.bmp
        modified:   msi/build/nuget.exe

no changes added to commit (use "git add" and/or "git commit -a")
```

### Evaluation

#319 was incomplete. It did not declare `.gpg`, `.keychain`, `.bmp`, and `.exe` as binary files, and it set the `.ps1` and `.rtf` files in the Windows build as having Unix line breaks when they in fact have Windows line breaks. As a result, Git tries to convert these files to Unix line breaks on checkout, which is not the expected result.

### Solution

Declare `.gpg`, `.keychain`, `.bmp`, and `.exe` as the binary files that they are. Unset the `text` attribute from `.ps1` and `.rtf` files so that these files (which exclusively apply to Windows builds) do not get converted to Unix line breaks.

### Testing done

Followed the steps to reproduce before and after this PR. After this PR, I got the expected results.