### PR TITLE
[JENKINS-69570] Java version check incorrect in `/etc/init.d/jenkins`

### DIFF
--- a/deb/build/debian/jenkins.init
+++ b/deb/build/debian/jenkins.init
@@ -35,7 +35,7 @@ check_arguments() {
 
 	# Work out the JAVA version we are working with:
 	JAVA_VERSION=$("${JAVA}" -version 2>&1 | sed -n ';s/.* version "\([0-9]\{2,\}\|[0-9]\.[0-9]\)\..*".*/\1/p;')
-	if [ "${JAVA_VERSION}" = "1.8" ]; then
+	if [ "${JAVA_VERSION}" = "17" ]; then
 		echo "Correct java version found" >&2
 	elif [ "${JAVA_VERSION}" = "11" ]; then
 		echo "Correct java version found" >&2

--- a/systemd/jenkins.sh
+++ b/systemd/jenkins.sh
@@ -41,7 +41,7 @@ check_java_version() {
 
 	if [ -z "${java_version}" ]; then
 		return 1
-	elif [ "${java_version}" != "17" ] && [ "${java_version}" != "11" ] && [ "${java_version}" != "1.8" ]; then
+	elif [ "${java_version}" != "17" ] && [ "${java_version}" != "11" ]; then
 		return 1
 	else
 		return 0


### PR DESCRIPTION
### Problem

See [JENKINS-69570](https://issues.jenkins.io/browse/JENKINS-69570). On `systemd`-based distributions (including all currently supported Red Hat and SuSE based distributions) the Java version check is done in `systemd/jenkins.sh`, and it currently works with Java 17. But on System V init based Debian systems (e.g. Devuan) the logic in `deb/build/debian/jenkins.init` is invoked, and it does not handle Java 17.

### Solution

Handle Java 17 in `deb/build/debian/jenkins.init` just as it is handled in `systemd/jenkins.sh`.

### Bonus

Remove support for Java 8 in the same two files, as current weekly and LTS releases no longer support Java 8.

### Testing done

Installed Devuan and Java 17, reproduced the problem as described in the ticket, then updated `/etc/init.d/jenkins` as in this PR and could no longer reproduce the problem.