### PR TITLE
[JENKINS-69638] Support HTTP/2 without custom `--extraLibFolder` configuration

### DIFF
--- a/systemd/jenkins.service
+++ b/systemd/jenkins.service
@@ -84,18 +84,12 @@ Environment="JENKINS_PORT=@@PORT@@"
 #Environment="JENKINS_HTTPS_KEYSTORE_PASSWORD=s3cR3tPa55w0rD"
 
 # IP address to listen on for HTTP2 requests. Default is disabled.
-#
-# Note: HTTP2 support may require additional configuration.
-# See the Winstone documentation for more information.
 #Environment="JENKINS_HTTP2_LISTEN_ADDRESS="
 
 # HTTP2 port to listen on. Default is disabled.
 # To be able to listen on privileged ports (port numbers less than 1024),
 # add the CAP_NET_BIND_SERVICE capability to the AmbientCapabilities
 # directive below.
-#
-# Note: HTTP2 support may require additional configuration.
-# See the Winstone documentation for more information.
 #Environment="JENKINS_HTTP2_PORT="
 
 # Controls which capabilities to include in the ambient capability set for the


### PR DESCRIPTION
Previously:

- https://github.com/jenkinsci/winstone/pull/282
- https://github.com/jenkinsci/winstone/pull/285
- https://github.com/jenkins-infra/jenkins.io/pull/5472
- https://github.com/jenkinsci/jenkins/pull/7117

Now that we don't require custom `--extraLibFolder` configuration, there is no need to warn the user about it or refer them to the Winstone documentation.