### PR TITLE
Support custom user in Debian `postinst` script

### DIFF
--- a/deb/build/debian/jenkins.postinst
+++ b/deb/build/debian/jenkins.postinst
@@ -21,8 +21,8 @@ case "$1" in
 configure)
 	if [ -d /run/systemd/system ]; then
 		# TODO --value would eliminate the need for cut, but older versions of systemd do not support it
-		JENKINS_USER=$(systemctl show @@ARTIFACTNAME@@ --property=User | cut -d= -f2-)
-		JENKINS_GROUP=$(systemctl show @@ARTIFACTNAME@@ --property=Group | cut -d= -f2-)
+		JENKINS_USER=$(systemctl show @@ARTIFACTNAME@@ --property=User 2>/dev/null | cut -d= -f2-)
+		JENKINS_GROUP=$(systemctl show @@ARTIFACTNAME@@ --property=Group 2>/dev/null | cut -d= -f2-)
 	elif [ -r /etc/default/@@ARTIFACTNAME@@ ]; then
 		. /etc/default/@@ARTIFACTNAME@@
 	fi

--- a/deb/build/debian/jenkins.postinst
+++ b/deb/build/debian/jenkins.postinst
@@ -19,7 +19,13 @@ set -e
 
 case "$1" in
 configure)
-	[ -r /etc/default/@@ARTIFACTNAME@@ ] && . /etc/default/@@ARTIFACTNAME@@
+	if [ -d /run/systemd/system ]; then
+		# TODO --value would eliminate the need for cut, but older versions of systemd do not support it
+		JENKINS_USER=$(systemctl show @@ARTIFACTNAME@@ --property=User | cut -d= -f2-)
+		JENKINS_GROUP=$(systemctl show @@ARTIFACTNAME@@ --property=Group | cut -d= -f2-)
+	elif [ -r /etc/default/@@ARTIFACTNAME@@ ]; then
+		. /etc/default/@@ARTIFACTNAME@@
+	fi
 	: "${JENKINS_USER:=@@ARTIFACTNAME@@}"
 	: "${JENKINS_GROUP:=@@ARTIFACTNAME@@}"
 


### PR DESCRIPTION
### Problem

I recently added the following to my service definition with `systemctl edit jenkins`:

```
[Service]
User=basil
Group=basil
```

When upgrading Jenkins, I now get

```
$ sudo dpkg -i jenkins_2.373_all.deb 
(Reading database ... 501958 files and directories currently installed.)
Preparing to unpack jenkins_2.373_all.deb ...
Unpacking jenkins (2.373) over (2.373) ...
Setting up jenkins (2.373) ...
Job for jenkins.service failed because the control process exited with error code.
See "systemctl status jenkins.service" and "journalctl -xeu jenkins.service" for details.
invoke-rc.d: initscript jenkins, action "restart" failed.
● jenkins.service - Jenkins Continuous Integration Server
     Loaded: loaded (/lib/systemd/system/jenkins.service; enabled; vendor preset: enabled)
    Drop-In: /etc/systemd/system/jenkins.service.d
             └─override.conf
     Active: activating (auto-restart) (Result: exit-code) since Tue 2022-10-11 11:13:31 PDT; 3ms ago
    Process: 1200861 ExecStart=/usr/bin/jenkins (code=exited, status=1/FAILURE)
   Main PID: 1200861 (code=exited, status=1/FAILURE)
        CPU: 899ms
dpkg: error processing package jenkins (--install):
 installed jenkins package post-installation script subprocess returned error exit status 1
Errors were encountered while processing:
 jenkins
```

### Evaluation

The Debian `postinst` script has logic to `chown(1)` the directories the correct user, but the logic to detect the target user only works for System V, not `systemd`.

### Solution

Handle the `systemd` case by checking which user `systemd` is using and `chown`'ing to that instead.

### Testing done

**Regression testing:** `molecule test` against the supported matrix (also done in the PR build).

**Functional testing:** Used `systemctl edit` to customize my user and group, then installed the package. Previously this failed; with these changes, it works as expected (debug trace below):

```
$ sudo dpkg -i jenkins_2.373_all.deb 
(Reading database ... 501958 files and directories currently installed.)
Preparing to unpack jenkins_2.373_all.deb ...
Unpacking jenkins (2.373) over (2.373) ...
Setting up jenkins (2.373) ...
+ set -e
+ [ -d /run/systemd/system ]
+ systemctl show jenkins --property=User
+ cut -d= -f2-
+ JENKINS_USER=basil
+ systemctl show jenkins --property=Group
+ cut -d= -f2-
+ JENKINS_GROUP=basil
+ : basil
+ : basil
+ getent group basil
+ id basil
+ chown basil:basil /var/lib/jenkins /var/log/jenkins
+ chmod u+rwx /var/lib/jenkins /var/log/jenkins
+ chown -R basil:basil /var/cache/jenkins
+ chmod -R 750 /var/cache/jenkins
+ [ -d /var/run/jenkins ]
+ /usr/share/jenkins/migrate /etc/default/jenkins
+ [ configure = configure ]
+ deb-systemd-helper unmask jenkins.service
+ deb-systemd-helper --quiet was-enabled jenkins.service
+ deb-systemd-helper enable jenkins.service
+ [ configure = configure ]
+ [ -z  ]
+ [ -x /etc/init.d/jenkins ]
+ update-rc.d jenkins defaults
+ [ -n 2.373 ]
+ _dh_action=restart
+ invoke-rc.d jenkins restart
+ exit 0
```