### PR TITLE
Add servlet container tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,6 +53,7 @@ nodeWithTimeout('docker') {
             pip install -U pip wheel
             pip install -r requirements.txt
             ANSIBLE_FORCE_COLOR=true molecule test
+            ANSIBLE_FORCE_COLOR=true molecule test -s servlet
             deactivate
         '''.stripIndent()
       }

--- a/molecule/servlet/Dockerfile.j2
+++ b/molecule/servlet/Dockerfile.j2
@@ -1,0 +1,32 @@
+# Molecule managed
+
+{% if item.registry is defined and '/' not in item.image %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+{% if item.env is defined %}
+{% for var, value in item.env.items() %}
+{% if value %}
+ENV {{ var }} {{ value }}
+{% endif %}
+{% endfor %}
+{% endif %}
+
+{% if 'wildfly' in item.image %}
+USER root
+{% endif %}
+
+RUN if [ $(command -v apt-get) ]; then export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -y python3 sudo bash ca-certificates iproute2 python3-apt python3-psutil python3-lxml aptitude && apt-get clean && rm -rf /var/lib/apt/lists/*; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install /usr/bin/python3 /usr/bin/python3-config /usr/bin/dnf-3 python3-psutil sudo bash iproute && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y /usr/bin/python3 /usr/bin/python3-config python3-pip gcc sudo yum-plugin-ovl bash iproute && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python3 sudo bash iproute2 && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python3 bash ca-certificates; \
+    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python3 sudo bash ca-certificates iproute2 && xbps-remove -O; fi
+
+{% if 'wildfly' in item.image %}
+RUN chown jboss /opt/jboss
+RUN pip3 install psutil
+USER jboss
+{% endif %}

--- a/molecule/servlet/configure-tomcat.yml
+++ b/molecule/servlet/configure-tomcat.yml
@@ -1,0 +1,20 @@
+---
+- copy:
+    dest: "/usr/local/tomcat/bin/setenv.sh"
+    content: "export CATALINA_OPTS=-DJENKINS_HOME=/var/tmp/jenkins_home"
+    mode: "0755"
+- xml:
+    path: "/usr/local/tomcat/conf/server.xml"
+    xpath: "/Server/Service/Engine/Host"
+    set_children:
+      - Valve:
+          className: "org.apache.catalina.valves.AccessLogValve"
+          directory: "logs"
+          prefix: "localhost_access_log"
+          suffix: ".txt"
+          pattern: '%h %l %u %t "%r" %s %b'
+      - Valve:
+          className: "org.apache.catalina.valves.RemoteIpValve"
+          remoteIpHeader: "X-Forwarded-For"
+          proxiesHeader: "X-Forwarded-By"
+          protocolHeader: "X-Forwarded-Proto"

--- a/molecule/servlet/configure-wildfly.yml
+++ b/molecule/servlet/configure-wildfly.yml
@@ -1,0 +1,5 @@
+---
+- lineinfile:
+    path: "/opt/jboss/wildfly/bin/standalone.conf"
+    regexp: '^#?JAVA_OPTS="\$JAVA_OPTS -DJENKINS_HOME='
+    line: 'JAVA_OPTS="$JAVA_OPTS -DJENKINS_HOME=/var/tmp/jenkins_home"'

--- a/molecule/servlet/converge.yml
+++ b/molecule/servlet/converge.yml
@@ -1,0 +1,8 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - include_tasks: configure-tomcat.yml
+      when: ansible_hostname == 'tomcat-9'
+    - include_tasks: configure-wildfly.yml
+      when: ansible_hostname == 'wildfly-26'

--- a/molecule/servlet/molecule.yml
+++ b/molecule/servlet/molecule.yml
@@ -1,0 +1,22 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: tomcat-9
+    image: tomcat:9-jdk11-temurin
+    volumes:
+      - ${MOLECULE_PROJECT_DIRECTORY}/jenkins.war:/usr/local/tomcat/webapps/jenkins.war
+  - name: wildfly-26
+    image: quay.io/wildfly/wildfly:26.1.2.Final-jdk11
+    volumes:
+      - ${MOLECULE_PROJECT_DIRECTORY}/jenkins.war:/opt/jboss/wildfly/standalone/deployments/jenkins.war
+provisioner:
+  name: ansible
+  inventory:
+    host_vars:
+      wildfly-26:
+        ansible_python_interpreter: "/usr/bin/python3"
+verifier:
+  name: ansible

--- a/molecule/servlet/verify.yml
+++ b/molecule/servlet/verify.yml
@@ -1,0 +1,55 @@
+---
+- name: Verify
+  hosts: all
+  tasks:
+    - pids:
+        name: java
+      register: service_pids
+    - assert:
+        that:
+          - (service_pids.pids | length) == 0
+        fail_msg: "{{ service_pids.pids | join(',') }}"
+    - command:
+        cmd: /usr/local/tomcat/bin/catalina.sh start
+      when: ansible_hostname == 'tomcat-9'
+    - shell:
+        cmd: "/opt/jboss/wildfly/bin/standalone.sh &"
+      when: ansible_hostname == 'wildfly-26'
+    - uri:
+        url: "http://127.0.0.1:8080/jenkins/login"
+        return_content: true
+      register: result
+      until: result.status == 200
+      retries: 20
+      delay: 5
+    - assert:
+        that:
+          - "'<title>Sign in [Jenkins]</title>' in result.content"
+        fail_msg: "{{ result.content }}"
+    - pids:
+        name: java
+      register: service_pids
+    - assert:
+        that:
+          - (service_pids.pids | length) == 1
+        fail_msg: "{{ service_pids.pids | join(',') }}"
+    - file:
+        path: "/var/tmp/jenkins_home"
+      register: jenkins_dir
+    - assert:
+        that:
+          - "jenkins_dir.state == 'directory'"
+        fail_msg: "{{ jenkins_dir.state }}"
+    - command:
+        cmd: /usr/local/tomcat/bin/catalina.sh stop
+      when: ansible_hostname == 'tomcat-9'
+    - command:
+        cmd: /opt/jboss/wildfly/bin/jboss-cli.sh --connect command=:shutdown
+      when: ansible_hostname == 'wildfly-26'
+    - pids:
+        name: java
+      register: service_pids
+    - assert:
+        that:
+          - (service_pids.pids | length) == 0
+        fail_msg: "{{ service_pids.pids | join(',') }}"

--- a/molecule/servlet/verify.yml
+++ b/molecule/servlet/verify.yml
@@ -17,7 +17,6 @@
       when: ansible_hostname == 'wildfly-26'
     - uri:
         url: "http://127.0.0.1:8080/jenkins/login"
-        status_code: [-1, 200]
         return_content: true
       register: result
       until: result.status == 200

--- a/molecule/servlet/verify.yml
+++ b/molecule/servlet/verify.yml
@@ -17,6 +17,7 @@
       when: ansible_hostname == 'wildfly-26'
     - uri:
         url: "http://127.0.0.1:8080/jenkins/login"
+        status_code: [-1, 200]
         return_content: true
       register: result
       until: result.status == 200


### PR DESCRIPTION
Verify that Jenkins launches to the login screen with a custom `JENKINS_HOME` on Tomcat 9 and WildFly 26, which are the latest versions that support the `javax.servlet` API that we use. This is not a statement of official support for alternative servlet containers, but this verifies that we do not accidentally regress de facto working functionality. To test this I ran `molecule test -s servlet` locally.