### PR TITLE
Verify login page loads

### DIFF
--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -35,7 +35,6 @@
       state: started
   - uri:
       url: "http://127.0.0.1:8080/login"
-      status_code: [-1, 200]
       return_content: true
     register: result
     until: result.status == 200

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -34,12 +34,17 @@
       name: jenkins
       state: started
   - uri:
-      url: "http://127.0.0.1:8080"
-      status_code: 403
+      url: "http://127.0.0.1:8080/login"
+      status_code: [-1, 200]
+      return_content: true
     register: result
-    until: result.status == 403
+    until: result.status == 200
     retries: 20
     delay: 5
+  - assert:
+      that:
+        - "'<title>Sign in [Jenkins]</title>' in result.content"
+      fail_msg: "{{ result.content }}"
   - pids:
       name: java
     register: service_pids


### PR DESCRIPTION
While implementing #350 I noticed that the regular tests could be improved to assert that the login page actually loaded with the expected content.