### PR TITLE
Support newer versions of systemd

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,124 +8,141 @@ platforms:
   # deb
   - name: debian-10
     image: dokken/debian-10:latest
-    command: /sbin/init
+    override_command: false
     volumes:
       - ${MOLECULE_PROJECT_DIRECTORY}/target:/var/tmp/target
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
     privileged: true
   - name: debian-11
     image: dokken/debian-11:latest
-    command: /sbin/init
+    override_command: false
     volumes:
       - ${MOLECULE_PROJECT_DIRECTORY}/target:/var/tmp/target
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
     privileged: true
   - name: ubuntu-18-04
     image: dokken/ubuntu-18.04:latest
-    command: /sbin/init
+    override_command: false
     volumes:
       - ${MOLECULE_PROJECT_DIRECTORY}/target:/var/tmp/target
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
     privileged: true
   - name: ubuntu-20-04
     image: dokken/ubuntu-20.04:latest
-    command: /sbin/init
+    override_command: false
     volumes:
       - ${MOLECULE_PROJECT_DIRECTORY}/target:/var/tmp/target
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
     privileged: true
   - name: ubuntu-22-04
     image: dokken/ubuntu-22.04:latest
-    command: /sbin/init
+    override_command: false
     volumes:
       - ${MOLECULE_PROJECT_DIRECTORY}/target:/var/tmp/target
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
     privileged: true
   # rpm
   - name: almalinux-8
     image: dokken/almalinux-8:latest
-    command: /sbin/init
+    override_command: false
     volumes:
       - ${MOLECULE_PROJECT_DIRECTORY}/target:/var/tmp/target
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
     privileged: true
   - name: almalinux-9
     image: dokken/almalinux-9:latest
-    command: /sbin/init
+    override_command: false
     volumes:
       - ${MOLECULE_PROJECT_DIRECTORY}/target:/var/tmp/target
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
     privileged: true
   - name: amazonlinux-2
     image: dokken/amazonlinux-2:latest
-    command: /sbin/init
+    override_command: false
     volumes:
       - ${MOLECULE_PROJECT_DIRECTORY}/target:/var/tmp/target
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
     privileged: true
   - name: centos-stream-8
     image: dokken/centos-stream-8:latest
-    command: /sbin/init
+    override_command: false
     volumes:
       - ${MOLECULE_PROJECT_DIRECTORY}/target:/var/tmp/target
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
     privileged: true
   - name: centos-stream-9
     image: dokken/centos-stream-9:latest
-    command: /sbin/init
+    override_command: false
     volumes:
       - ${MOLECULE_PROJECT_DIRECTORY}/target:/var/tmp/target
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
     privileged: true
   - name: fedora-35
     image: dokken/fedora-35:latest
-    command: /sbin/init
+    override_command: false
     volumes:
       - ${MOLECULE_PROJECT_DIRECTORY}/target:/var/tmp/target
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
     privileged: true
   - name: fedora-36
     image: dokken/fedora-36:latest
-    command: /sbin/init
+    override_command: false
     volumes:
       - ${MOLECULE_PROJECT_DIRECTORY}/target:/var/tmp/target
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
     privileged: true
   - name: oraclelinux-8
     image: dokken/oraclelinux-8:latest
-    command: /sbin/init
+    override_command: false
     volumes:
       - ${MOLECULE_PROJECT_DIRECTORY}/target:/var/tmp/target
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
     privileged: true
   - name: oraclelinux-9
     image: dokken/oraclelinux-9:latest
-    command: /sbin/init
+    override_command: false
     volumes:
       - ${MOLECULE_PROJECT_DIRECTORY}/target:/var/tmp/target
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
     privileged: true
   - name: rockylinux-8
     image: dokken/rockylinux-8:latest
-    command: /sbin/init
+    override_command: false
     volumes:
       - ${MOLECULE_PROJECT_DIRECTORY}/target:/var/tmp/target
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
     privileged: true
   - name: rockylinux-9
     image: dokken/rockylinux-9:latest
-    command: /sbin/init
+    override_command: false
     volumes:
       - ${MOLECULE_PROJECT_DIRECTORY}/target:/var/tmp/target
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
     privileged: true
   # suse
   - name: opensuse-leap-15
     image: dokken/opensuse-leap-15:latest
-    command: /sbin/init
+    override_command: false
     volumes:
       - ${MOLECULE_PROJECT_DIRECTORY}/target:/var/tmp/target
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
     privileged: true
 provisioner:
   name: ansible

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ansible
 docker
 jinja2
-molecule-docker==2.0.0
+git+https://github.com/ansible-community/molecule-docker.git@main#egg=molecule-docker


### PR DESCRIPTION
See [Docker and systemd, getting rid of dreaded 'Failed to connect to bus' error](https://www.jeffgeerling.com/blog/2022/docker-and-systemd-getting-rid-dreaded-failed-connect-bus-error).

Note that this PR upgrades us to `molecule-docker` `HEAD`. Support for `cgroupns_mode` was only released in 2.1.0, but that release also contains a regression that prevents us from using it. The regression is fixed in `HEAD` but unreleased. So by consuming `HEAD` we get the regression fix as well as support for `cgroupns_mode`, which is needed for newer versions of `systemd`. When a new version of `molecule-docker` is released we can upgrade to it and stop consuming `HEAD`.

Testing done: PR CI build passes before and after this change. Local build on Ubuntu 22.04.1 LTS x86_64 and systemd 249 (249.11-0ubuntu3.6) fails before this PR and passes after this PR.

Closes #352