### PR TITLE
Automatically purge handler count options from older RPM installations

### DIFF
--- a/systemd/migrate.sh
+++ b/systemd/migrate.sh
@@ -267,6 +267,9 @@ read_old_options() {
 
 migrate_options() {
 	if [ -f /etc/systemd/system/@@ARTIFACTNAME@@.service.d/override.conf ]; then
+		if grep -q '\-\-handlerCount' /etc/systemd/system/@@ARTIFACTNAME@@.service.d/override.conf; then
+			sed -ibak -r -e 's/--handlerCount[A-Za-z]+=[0-9]+//g' /etc/systemd/system/@@ARTIFACTNAME@@.service.d/override.conf
+		fi
 		return
 	fi
 


### PR DESCRIPTION
While new systemd-based installations didn't set the (unimplemented) handler count options, older System V based RPM installations did, and the migration logic dutifully migrated it over to systemd. Since these options are now a hard error on recent versions of Winstone, be friendlier to these users by automatically purging them from any systemd configuration files. This might be viewed as a bit presumptuous from the perspective of keeping user configuration sacrosanct, but I think this is enough of a rough edge that people have cut themselves on (as evidenced by [JENKINS-70182](https://issues.jenkins.io/browse/JENKINS-70182)) that it is worth doing. To test this I added these options to my systemd configuration, observed that startup failed, and observed that the handler count options were deleted after running this script and that startup succeeded.