### PR TITLE
Fix jio component URLs

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -56,7 +56,7 @@
 <script data="jio" src="https://cdn.jsdelivr.net/npm/@jenkinsci/jenkins-io-components/+esm" type="module"></script>
 <script data="jio" nomodule="" src="https://cdn.jsdelivr.net/npm/@jenkinsci/jenkins-io-components/"></script>
   <div class="fixed-top">
-    <jio-navbar class="fixed-top" property="https://www.jenkins.io"/>
+    <jio-navbar class="fixed-top" property="https://get.jenkins.io"/>
   </div>
 
   <div class='container'>

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -3,8 +3,7 @@
     </div>
   </div>
 </div>
-
-<jio-footer property="https://www.jenkins.io"/>
+<jio-footer id="footer" property="https://get.jenkins.io"/>
 
 </body>
 


### PR DESCRIPTION
Currently, all links head to get.jenkins.io/etc. Testing locally, switching the component property to the page URL ensures URLs use the proper destinations like jenkins.io as base URL.