### PR TITLE
Fix styling of debian install instructions

### DIFF
--- a/templates/header.debian.html
+++ b/templates/header.debian.html
@@ -27,11 +27,11 @@
 Update your local package index, then finally install {{product_name}}:
 
   <pre class="text-white bg-dark">
-
-    <code>
+   <code>
   sudo apt-get update
   sudo apt-get install fontconfig openjdk-11-jre
-  sudo apt-get install {{artifactName}}</code>
+  sudo apt-get install {{artifactName}}
+   </code>
   </pre>
 </p>
 


### PR DESCRIPTION
Before:
![Screenshot 2023-03-21 at 20 14 54](https://user-images.githubusercontent.com/13383509/226716940-d2a730fb-a0fc-4eed-bb7d-804b5fc97d10.png)

After:
![Screenshot 2023-03-21 at 20 15 46](https://user-images.githubusercontent.com/13383509/226717141-c0edac3d-35af-4e3a-9827-0c002279a478.png)

Always bothered me and kind of looks like that there's a line missing when it's not.