### PR TITLE
Remove fedora-35 tests

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -87,14 +87,6 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
     privileged: true
-  - name: fedora-35
-    image: dokken/fedora-35:latest
-    override_command: false
-    volumes:
-      - ${MOLECULE_PROJECT_DIRECTORY}/target:/var/tmp/target
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    cgroupns_mode: host
-    privileged: true
   - name: fedora-36
     image: dokken/fedora-36:latest
     override_command: false


### PR DESCRIPTION
Fedora 35 is EOL and no longer distributed, see https://dl.fedoraproject.org/pub/fedora/linux/releases/35/.

I recommend dropping our tests.