### PR TITLE
Add fedora 37

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -95,6 +95,14 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
     privileged: true
+  - name: fedora-37
+    image: dokken/fedora-37:latest
+    override_command: false
+    volumes:
+      - ${MOLECULE_PROJECT_DIRECTORY}/target:/var/tmp/target
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
   - name: oraclelinux-8
     image: dokken/oraclelinux-8:latest
     override_command: false


### PR DESCRIPTION
Fedora 36 is EOL by the 16th of May 2023, in favor of the current maintained version, 37.
Let's add 37 alongside 36, during the interim phase.