### PR TITLE
Backport gpg key banner to stable branches

### DIFF
--- a/templates/header.debian.html
+++ b/templates/header.debian.html
@@ -2,6 +2,12 @@
 
 {% block distribution_instruction %}
 
+<div class="alert alert-danger">
+    <b>Important Notice:</b> Beginning with LTS 2.387.2 and weekly 2.397, releases will be signed with a new GPG key. <br>
+    Administrators <b>must</b> install the new key on their servers <b>before</b> attempting to update Jenkins. <br>
+    <a target="_blank" href="https://jenkins.io/blog/2023/03/27/repository-signing-keys-changing/">Read more about the key rotation on the blog</a>.
+</div>
+
 <p>
   This is the Debian package repository of {{product_name}} to automate installation and upgrade.
 
@@ -9,7 +15,7 @@
 
   <pre class="text-white bg-dark">
     <code>
-  curl -fsSL <a href="{{web_url}}/{{organization}}.key" style="color:white">{{web_url}}/{{organization}}.key</a> | sudo tee \
+  curl -fsSL <a href="{{web_url}}/{{organization}}-2023.key" style="color:white">{{web_url}}/{{organization}}-2023.key</a> | sudo tee \
     /usr/share/keyrings/jenkins-keyring.asc > /dev/null</code>
   </pre>
 

--- a/templates/header.redhat.html
+++ b/templates/header.redhat.html
@@ -2,6 +2,11 @@
 
 {% block distribution_instruction %}
 
+<div class="alert alert-danger">
+    <b>Important Notice:</b> Beginning with LTS 2.387.2 and weekly 2.397, releases will be signed with a new GPG key. <br>
+    Administrators <b>must</b> install the new key on their servers <b>before</b> attempting to update Jenkins. <br>
+    <a target="_blank" href="https://jenkins.io/blog/2023/03/27/repository-signing-keys-changing/">Read more about the key rotation on the blog</a>.
+</div>
 
   <p>
   To use this repository, run the following command:
@@ -9,7 +14,7 @@
   <pre class="text-white bg-dark">
 
   sudo wget -O /etc/yum.repos.d/{{artifactName}}.repo {{ web_url }}/{{artifactName}}.repo
-  sudo rpm --import {{ web_url }}/{{organization}}.key
+  sudo rpm --import {{ web_url }}/{{organization}}-2023.key
   </pre>
 
   <p>


### PR DESCRIPTION
Backports https://github.com/jenkinsci/packaging/pull/379 to the current stable branch.