### PR TITLE
Do not publish MSI

### DIFF
--- a/bin/indexGenerator.py
+++ b/bin/indexGenerator.py
@@ -29,11 +29,13 @@ class IndexGenerator:
             "web_url": os.getenv("SUSE_URL"),
         },
         "war": {"extension": ".war", "template": "header.war.html", "web_url": "unset"},
-        "windows": {
-            "extension": ".msi",
-            "template": "header.msi.html",
-            "web_url": "unset",
-        },
+        # TODO: Restore when MSI code signing certificate is installed and configured
+        #
+        # "windows": {
+        #     "extension": ".msi",
+        #     "template": "header.msi.html",
+        #     "web_url": "unset",
+        # },
     }
 
     HELP_MESSAGE = """

--- a/make.ps1
+++ b/make.ps1
@@ -4,6 +4,11 @@ Param(
     [String] $target = "package"
 )
 
+# TODO: Remove when MSI code signing certificate is available
+# echo "Not packaging Windows components until code signing certificate is available"
+# echo "Exiting make.ps1 early"
+# exit 0
+
 # # refers to the definition of a release target
 # BRAND:=./branding/test.mk
 # include ${BRAND}

--- a/make.ps1
+++ b/make.ps1
@@ -5,9 +5,9 @@ Param(
 )
 
 # TODO: Remove when MSI code signing certificate is available
-# echo "Not packaging Windows components until code signing certificate is available"
-# echo "Exiting make.ps1 early"
-# exit 0
+echo "Not packaging Windows components until code signing certificate is available"
+echo "Exiting make.ps1 early"
+exit 0
 
 # # refers to the definition of a release target
 # BRAND:=./branding/test.mk

--- a/msi/publish/publish.sh
+++ b/msi/publish/publish.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# TODO: Remove this when code signing certificate is installed and configured
+exit 0
+
 set -euxo pipefail
 
 : "${AGENT_WORKDIR:=/tmp}"


### PR DESCRIPTION
## Do not publish MSI

MSI installer needs to be signed with a code signing certificate.  Our code signing certificate has expired.  Attorneys from the Linux Foundation and the Continuous Delivery Foundation are working to renew the code signing certificate. Once that is completed, these changes can be removed and we'll resume publishing the MSI installer for Windows.  

Exit early from make.ps1 in case it is used in the build process.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Matching pull request in the release repository:

* https://github.com/jenkins-infra/release/pull/356