### PR TITLE
Upgrade Ansible from 6.7.0 to 7.4.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    ignore:
-      # Starting with 7.x, Ansible requires Python >=3.9, which our Ubuntu
-      # 20.04-based agent VMs do not provide.
-      - dependency-name: "ansible"
-        versions: [">=7.0.0"]

--- a/molecule/default/install-rpm.yml
+++ b/molecule/default/install-rpm.yml
@@ -1,14 +1,19 @@
 ---
-- command:
-    cmd: amazon-linux-extras install java-openjdk11 -y
-    creates: /usr/lib/jvm/jre-11-openjdk
-  when: ansible_distribution == 'Amazon'
 - package:
     name:
       - fontconfig
-      - java-11-openjdk
     state: present
     update_cache: true
+- package:
+    name:
+      - java-11-openjdk
+    state: present
+  when: ansible_distribution != 'Amazon'
+- package:
+    name:
+      - java-11-amazon-corretto-headless
+    state: present
+  when: ansible_distribution == 'Amazon'
 - file:
     path: /var/tmp/target/credentials
     state: directory

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -63,8 +63,8 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
     privileged: true
-  - name: amazonlinux-2  # EOL 2025-06-30
-    image: dokken/amazonlinux-2:latest
+  - name: amazonlinux-2023  # EOL 2025-03-15
+    image: dokken/amazonlinux-2023:latest
     override_command: false
     volumes:
       - ${MOLECULE_PROJECT_DIRECTORY}/target:/var/tmp/target

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ansible==6.7.0
+ansible==7.4.0
 jinja2==3.1.2
 molecule-plugins[docker]==23.0.0


### PR DESCRIPTION
Perhaps we can upgrade Ansible now that our agents are running on 22.04. `systemd` no longer seems to work in the Amazon Linux 2 Docker container when running on an Ubuntu 22.04 Docker host, so I have removed this test in favor of a test based on an Amazon Linux 2023 Docker container, which does work on an Ubuntu 22.04 Docker host. Without affecting our existing support for installing Jenkins on Amazon Linux 2, this allows us to continue to do automated testing on Amazon Linux and helps us keep our documentation up-to-date. Since Amazon Linux 2023 no longer ships a vanilla OpenJDK 11 package, I updted the test to use Corretto, updating the user-facing documentation in https://github.com/jenkins-infra/jenkins.io/pull/6245 as well.