### PR TITLE
Remove `-headless` to be consistent with other code

### DIFF
--- a/molecule/default/install-rpm.yml
+++ b/molecule/default/install-rpm.yml
@@ -11,7 +11,7 @@
   when: ansible_distribution != 'Amazon'
 - package:
     name:
-      - java-11-amazon-corretto-headless
+      - java-11-amazon-corretto
     state: present
   when: ansible_distribution == 'Amazon'
 - file:


### PR DESCRIPTION
Amends #388. We don't use `-headless` anywhere else, so let's not use it here either for consistency.