### PR TITLE
Remove key rotation banner

### DIFF
--- a/templates/header.debian.html
+++ b/templates/header.debian.html
@@ -2,12 +2,6 @@
 
 {% block distribution_instruction %}
 
-<div class="alert alert-danger">
-    <b>Important Notice:</b> Beginning with LTS 2.387.2 and weekly 2.397, releases will be signed with a new GPG key. <br>
-    Administrators <b>must</b> install the new key on their servers <b>before</b> attempting to update Jenkins. <br>
-    <a target="_blank" href="https://jenkins.io/blog/2023/03/27/repository-signing-keys-changing/">Read more about the key rotation on the blog</a>.
-</div>
-
 <p>
   This is the Debian package repository of {{product_name}} to automate installation and upgrade.
 

--- a/templates/header.redhat.html
+++ b/templates/header.redhat.html
@@ -2,12 +2,6 @@
 
 {% block distribution_instruction %}
 
-<div class="alert alert-danger">
-    <b>Important Notice:</b> Beginning with LTS 2.387.2 and weekly 2.397, releases will be signed with a new GPG key. <br>
-    Administrators <b>must</b> install the new key on their servers <b>before</b> attempting to update Jenkins. <br>
-    <a target="_blank" href="https://jenkins.io/blog/2023/03/27/repository-signing-keys-changing/">Read more about the key rotation on the blog</a>.
-</div>
-
   <p>
   To use this repository, run the following command:
 


### PR DESCRIPTION
The warning has been removed from the carousel at jenkins.io some time ago. I propose to remove it from this repository too.
The current LTS line, 2.401, will continue showing the warning, given it's the first new LTS line with the updated key.