### PR TITLE
Prefer Java 17 in Windows installer

### DIFF
--- a/msi/build/jenkins.wxs
+++ b/msi/build/jenkins.wxs
@@ -168,11 +168,11 @@
         Return="check"
         Impersonate="no" />
 
-    <!-- This will find the JRE/JDK directory either Java 11, 17 or 21 (prefer 11) -->
+    <!-- This will find the JRE/JDK directory either Java 11, 17 or 21 (prefer 17) -->
     <Property Id="JAVA_HOME">
       <RegistrySearch Id="JDK21_HOME_REGSEARCH" Root="HKLM" Key="SOFTWARE\JavaSoft\JDK\21" Name="JavaHome" Type="raw" Win64="yes" />
-      <RegistrySearch Id="JDK17_HOME_REGSEARCH" Root="HKLM" Key="SOFTWARE\JavaSoft\JDK\17" Name="JavaHome" Type="raw" Win64="yes" />
       <RegistrySearch Id="JDK11_HOME_REGSEARCH" Root="HKLM" Key="SOFTWARE\JavaSoft\JDK\11" Name="JavaHome" Type="raw" Win64="yes" />
+      <RegistrySearch Id="JDK17_HOME_REGSEARCH" Root="HKLM" Key="SOFTWARE\JavaSoft\JDK\17" Name="JavaHome" Type="raw" Win64="yes" />
     </Property>
 
     <Property Id="ARPPRODUCTICON" Value="installer.ico" />


### PR DESCRIPTION
Does anyone feel strongly about not promoting Java 17?

This is just a tiny part, but Java 17 has been available in Jenkins for over a year by now. Therefore, this seems like a safe push.