### PR TITLE
Fix RPM tests

### DIFF
--- a/molecule/default/install-rpm.yml
+++ b/molecule/default/install-rpm.yml
@@ -2,6 +2,7 @@
 - package:
     name:
       - fontconfig
+      - tzdata-java
     state: present
     update_cache: true
 - package:


### PR DESCRIPTION
Recent versions of AlmaLinux and Rocky Linux apparently allow you to install OpenJDK without installing the time zone data, without which Jenkins startup fails. Fix the test suite by ensuring the time zone data is installed for all RPM-based distributions before running the test.