### PR TITLE
Use Java 17 for tests and documentation

### DIFF
--- a/molecule/default/install-deb.yml
+++ b/molecule/default/install-deb.yml
@@ -2,9 +2,18 @@
 - package:
     name:
       - fontconfig
-      - openjdk-11-jre
     state: present
     update_cache: true
+- package:
+    name:
+      - openjdk-17-jre
+    state: present
+  when: ansible_hostname != 'debian-10'
+- package:
+    name:
+      - openjdk-11-jre
+    state: present
+  when: ansible_hostname == 'debian-10'
 - find:
     paths: /var/tmp/target/debian
     file_type: file

--- a/molecule/default/install-rpm.yml
+++ b/molecule/default/install-rpm.yml
@@ -7,12 +7,12 @@
     update_cache: true
 - package:
     name:
-      - java-11-openjdk
+      - java-17-openjdk
     state: present
   when: ansible_distribution != 'Amazon'
 - package:
     name:
-      - java-11-amazon-corretto
+      - java-17-amazon-corretto
     state: present
   when: ansible_distribution == 'Amazon'
 - file:

--- a/molecule/default/install-suse.yml
+++ b/molecule/default/install-suse.yml
@@ -3,7 +3,7 @@
     name:
       - dejavu-fonts
       - fontconfig
-      - java-11-openjdk
+      - java-17-openjdk
     state: present
     update_cache: true
 - file:

--- a/molecule/servlet/molecule.yml
+++ b/molecule/servlet/molecule.yml
@@ -5,11 +5,11 @@ driver:
   name: docker
 platforms:
   - name: tomcat-9
-    image: tomcat:9-jdk11-temurin
+    image: tomcat:9-jdk17-temurin
     volumes:
       - ${MOLECULE_PROJECT_DIRECTORY}/jenkins.war:/usr/local/tomcat/webapps/jenkins.war
   - name: wildfly-26
-    image: quay.io/wildfly/wildfly:26.1.3.Final-jdk11
+    image: quay.io/wildfly/wildfly:26.1.3.Final-jdk17
     volumes:
       - ${MOLECULE_PROJECT_DIRECTORY}/jenkins.war:/opt/jboss/wildfly/standalone/deployments/jenkins.war
 provisioner:

--- a/systemd/jenkins.service
+++ b/systemd/jenkins.service
@@ -48,7 +48,7 @@ Environment="JENKINS_WEBROOT=%C/@@ARTIFACTNAME@@/war"
 #Environment="JENKINS_LOG=%L/@@ARTIFACTNAME@@/@@ARTIFACTNAME@@.log"
 
 # The Java home directory. When left empty, JENKINS_JAVA_CMD and PATH are consulted.
-#Environment="JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64"
+#Environment="JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64"
 
 # The Java executable. When left empty, JAVA_HOME and PATH are consulted.
 #Environment="JENKINS_JAVA_CMD=/etc/alternatives/java"

--- a/templates/header.debian.html
+++ b/templates/header.debian.html
@@ -29,7 +29,7 @@ Update your local package index, then finally install {{product_name}}:
   <pre class="text-white bg-dark">
    <code>
   sudo apt-get update
-  sudo apt-get install fontconfig openjdk-11-jre
+  sudo apt-get install fontconfig openjdk-17-jre
   sudo apt-get install {{artifactName}}
    </code>
   </pre>

--- a/templates/header.opensuse.html
+++ b/templates/header.opensuse.html
@@ -15,7 +15,7 @@ With that set up, the {{ product_name }} package can be installed with:
 
 <pre class="text-white bg-dark">
 
-  zypper install dejavu-fonts fontconfig java-11-openjdk
+  zypper install dejavu-fonts fontconfig java-17-openjdk
   zypper install {{ artifactName }}
 
 </pre>

--- a/templates/header.redhat.html
+++ b/templates/header.redhat.html
@@ -17,7 +17,7 @@
 
   <pre class="text-white bg-dark">
 
-  yum install fontconfig tzdata-java java-11-openjdk
+  yum install fontconfig tzdata-java java-17-openjdk
   yum install {{artifactName}}
   </pre>
 


### PR DESCRIPTION
Run tests on Java 17 (except on Debian 10, which does not have a Java 17 package) and refer to Java 17 in the documentation wherever possible.