### PR TITLE
Support Java 21

### DIFF
--- a/deb/build/debian/jenkins.init
+++ b/deb/build/debian/jenkins.init
@@ -35,7 +35,9 @@ check_arguments() {
 
 	# Work out the JAVA version we are working with:
 	JAVA_VERSION=$("${JAVA}" -version 2>&1 | sed -n ';s/.* version "\([0-9]\{2,\}\|[0-9]\.[0-9]\)\..*".*/\1/p;')
-	if [ "${JAVA_VERSION}" = "17" ]; then
+	if [ "${JAVA_VERSION}" = "21" ]; then
+		echo "Correct java version found" >&2
+	elif [ "${JAVA_VERSION}" = "17" ]; then
 		echo "Correct java version found" >&2
 	elif [ "${JAVA_VERSION}" = "11" ]; then
 		echo "Correct java version found" >&2

--- a/systemd/jenkins.sh
+++ b/systemd/jenkins.sh
@@ -41,7 +41,7 @@ check_java_version() {
 
 	if [ -z "${java_version}" ]; then
 		return 1
-	elif [ "${java_version}" != "17" ] && [ "${java_version}" != "11" ]; then
+	elif [ "${java_version}" != "21" ] && [ "${java_version}" != "17" ] && [ "${java_version}" != "11" ]; then
 		return 1
 	else
 		return 0

--- a/templates/base.html
+++ b/templates/base.html
@@ -80,6 +80,9 @@
             </p>
 
             <dl>
+              <dt>2.419 (August 2023) and newer</dt>
+              <dd>Java 11, Java 17, or Java 21</dd>
+
               <dt>2.357 (June 2022) and newer</dt>
               <dd>Java 11 or Java 17</dd>
 

--- a/templates/header.war.html
+++ b/templates/header.war.html
@@ -22,6 +22,9 @@
   </p>
 
   <dl>
+    <dt>2.419 (August 2023) and newer</dt>
+    <dd>Java 11, Java 17, or Java 21</dd>
+
     <dt>2.357 (June 2022) and newer</dt>
     <dd>Java 11 or Java 17</dd>
 


### PR DESCRIPTION
I was not able to test this because `21-ea` does not match the regex, but the code change is easy enough to verify by visual inspection and should presumably start working in earnest once a production (not early access) build of Java 21 is available.