### PR TITLE
fix(systemd): Handles the JDK 21 beta versions

### DIFF
--- a/systemd/jenkins.sh
+++ b/systemd/jenkins.sh
@@ -36,8 +36,8 @@ infer_java_cmd() {
 check_java_version() {
 	printf '%s' "${JENKINS_OPTS}" | grep -q '\--enable-future-java' && return 0
 
-	java_version=$("${JENKINS_JAVA_CMD}" -version 2>&1 |
-		sed -n ';s/.* version "\([0-9]\{2,\}\|[0-9]\.[0-9]\)\..*".*/\1/p;')
+  java_version=$("${JENKINS_JAVA_CMD}" -version 2>&1 |
+    sed -n ';s/.* version "\([0-9]*\|-beta\)\{1,\}".*/\1/p;')
 
 	if [ -z "${java_version}" ]; then
 		return 1

--- a/systemd/jenkins.sh
+++ b/systemd/jenkins.sh
@@ -36,8 +36,8 @@ infer_java_cmd() {
 check_java_version() {
 	printf '%s' "${JENKINS_OPTS}" | grep -q '\--enable-future-java' && return 0
 
-  java_version=$("${JENKINS_JAVA_CMD}" -version 2>&1 |
-    awk -F '"' '/version/ {print $2}' | awk -F '.' '{match($1, /^[0-9]+/); print substr($1, RSTART, RLENGTH)}'
+	java_version=$("${JENKINS_JAVA_CMD}" -version 2>&1 |
+    awk -F '"' '/version/ {print $2}' | awk -F '.' '{match($1, /^[0-9]+/); print substr($1, RSTART, RLENGTH)}')
 
 	if [ -z "${java_version}" ]; then
 		return 1

--- a/systemd/jenkins.sh
+++ b/systemd/jenkins.sh
@@ -37,7 +37,7 @@ check_java_version() {
 	printf '%s' "${JENKINS_OPTS}" | grep -q '\--enable-future-java' && return 0
 
   java_version=$("${JENKINS_JAVA_CMD}" -version 2>&1 |
-    sed -n ';s/.* version "\([0-9]*\|-beta\)\{1,\}".*/\1/p;')
+    awk -F '"' '/version/ {print $2}' | awk -F '.' '{match($1, /^[0-9]+/); print substr($1, RSTART, RLENGTH)}'
 
 	if [ -z "${java_version}" ]; then
 		return 1


### PR DESCRIPTION
On certains platforms, Temurin's openJDK build outputs a version such as `openjdk version "21-beta" 2023-09-19`.
This is not recognized as a valid version in the `jenkins.sh` script, so Jenkins can't be properly installed/started.

I'm proposing an alternative version search, so the beta versions also work.

```bash
awk -F '"' '/version/ {print $2}' | awk -F '.' '{match($1, /^[0-9]+/); print substr($1, RSTART, RLENGTH)}'`
```

The `match($1, /^[0-9]+/)` part searches for the first sequence of digits at the beginning of the version string, and `substr($1, RSTART, RLENGTH)` extracts that matched portion, effectively giving us the major version number.
This should handle cases like "21-beta" and "17.0.7", and extract the correct major version number. 🤷 

### Testing done

I haven't been able to build on Debian WLS2 because of `/tmp/tmp.OFSjOSDlKO/debian/jenkinstest.dirs: 2: usr/share/jenkinstest: not found` but I tested directly various `java -version` outputs on several machines, and it worked each and every time.

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- ~~Link to relevant issues in GitHub or Jira~~
- ~~Link to relevant pull requests, esp. upstream and downstream changes~~
- ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~~
