### PR TITLE
Remove Java version checks

### DIFF
--- a/deb/build/debian/jenkins.init
+++ b/deb/build/debian/jenkins.init
@@ -33,22 +33,6 @@ check_arguments() {
 		return 2
 	fi
 
-	# Work out the JAVA version we are working with:
-	JAVA_VERSION=$("${JAVA}" -version 2>&1 | sed -n ';s/.* version "\([0-9]\{2,\}\|[0-9]\.[0-9]\)\..*".*/\1/p;')
-	if [ "${JAVA_VERSION}" = "21" ]; then
-		echo "Correct java version found" >&2
-	elif [ "${JAVA_VERSION}" = "17" ]; then
-		echo "Correct java version found" >&2
-	elif [ "${JAVA_VERSION}" = "11" ]; then
-		echo "Correct java version found" >&2
-	else
-		echo "Found an incorrect Java version" >&2
-		echo "Java version found:" >&2
-		"${JAVA}" -version >&2
-		echo "Aborting" >&2
-		return 2
-	fi
-
 	# Make sure we run as root, since setting the max open files through
 	# ulimit requires root access
 	if [ "$(id -u)" -gt 0 ]; then

--- a/systemd/jenkins.sh
+++ b/systemd/jenkins.sh
@@ -33,21 +33,6 @@ infer_java_cmd() {
 	JENKINS_JAVA_CMD="$(command -v java)" || return "$?"
 }
 
-check_java_version() {
-	printf '%s' "${JENKINS_OPTS}" | grep -q '\--enable-future-java' && return 0
-
-	java_version=$("${JENKINS_JAVA_CMD}" -version 2>&1 |
-		sed -n ';s/.* version "\([0-9]\{2,\}\|[0-9]\.[0-9]\)\..*".*/\1/p;')
-
-	if [ -z "${java_version}" ]; then
-		return 1
-	elif [ "${java_version}" != "21" ] && [ "${java_version}" != "17" ] && [ "${java_version}" != "11" ]; then
-		return 1
-	else
-		return 0
-	fi
-}
-
 infer_jenkins_opts() {
 	inferred_jenkins_opts=""
 
@@ -119,9 +104,6 @@ main() {
 	infer_java_cmd || die 'failed to find a valid Java installation'
 
 	infer_jenkins_opts
-
-	check_java_version ||
-		die "invalid Java version: $("${JENKINS_JAVA_CMD}" -version 2>&1)"
 
 	java_opts_tmp="${JAVA_OPTS}"
 	unset JAVA_OPTS


### PR DESCRIPTION
Alternative to #428. Redundant now that core has Java version checking which (though itself implemented in Java) is compiled down to very low (currently Java 8) bytecode so that it can successfully print an error message even when the user is running a very old version of Java.

### Testing done

`git grep -i java.version` did not turn up any results.