### PR TITLE
Remove unnecessary `tzdata-java` workaround

### DIFF
--- a/molecule/default/install-rpm.yml
+++ b/molecule/default/install-rpm.yml
@@ -2,7 +2,6 @@
 - package:
     name:
       - fontconfig
-      - tzdata-java
     state: present
     update_cache: true
 - package:

--- a/templates/header.redhat.html
+++ b/templates/header.redhat.html
@@ -17,7 +17,7 @@
 
   <pre class="text-white bg-dark">
 
-  yum install fontconfig tzdata-java java-17-openjdk
+  yum install fontconfig java-17-openjdk
   yum install {{artifactName}}
   </pre>
 


### PR DESCRIPTION
Part of the never-ending quest to remove temporary workarounds before they become permanent.