### PR TITLE
Try libfontconfig1 instead of fontconfig

### DIFF
--- a/molecule/default/install-deb.yml
+++ b/molecule/default/install-deb.yml
@@ -1,7 +1,7 @@
 ---
 - package:
     name:
-      - fontconfig
+      - libfontconfig1
     state: present
     update_cache: true
 - package:

--- a/molecule/default/install-rpm.yml
+++ b/molecule/default/install-rpm.yml
@@ -1,7 +1,7 @@
 ---
 - package:
     name:
-      - fontconfig
+      - libfontconfig1
     state: present
     update_cache: true
 - package:

--- a/molecule/default/install-suse.yml
+++ b/molecule/default/install-suse.yml
@@ -2,7 +2,7 @@
 - package:
     name:
       - dejavu-fonts
-      - fontconfig
+      - libfontconfig1
       - java-17-openjdk
     state: present
     update_cache: true

--- a/templates/header.debian.html
+++ b/templates/header.debian.html
@@ -29,7 +29,7 @@ Update your local package index, then finally install {{product_name}}:
   <pre class="text-white bg-dark">
    <code>
   sudo apt-get update
-  sudo apt-get install fontconfig openjdk-17-jre
+  sudo apt-get install libfontconfig1 openjdk-17-jre
   sudo apt-get install {{artifactName}}
    </code>
   </pre>

--- a/templates/header.opensuse.html
+++ b/templates/header.opensuse.html
@@ -15,7 +15,7 @@ With that set up, the {{ product_name }} package can be installed with:
 
 <pre class="text-white bg-dark">
 
-  zypper install dejavu-fonts fontconfig java-17-openjdk
+  zypper install dejavu-fonts libfontconfig1 java-17-openjdk
   zypper install {{ artifactName }}
 
 </pre>

--- a/templates/header.redhat.html
+++ b/templates/header.redhat.html
@@ -17,7 +17,7 @@
 
   <pre class="text-white bg-dark">
 
-  yum install fontconfig java-17-openjdk
+  yum install libfontconfig1 java-17-openjdk
   yum install {{artifactName}}
   </pre>
 


### PR DESCRIPTION
## Try libfontconfig1 instead of fontconfig

The Debian container images use the libfontconfig1 package instead of using the fontconfig package.  The UBI and AlmaLinux containers use the fontconfig package.  The libfontconfig1 is a dependency of the fontconfig package and seems like a good choice for consistency between container images and versions installed with the operating system package manager.

https://github.com/search?q=repo%3Ajenkinsci%2Fdocker%20fontconfig&type=code shows the current use of fontconfig and the differences between platforms.

### Testing done

My running Debian containers have shown no issues with libfontconfig1.  Use ci.jenkins.io to check the impact on the UBI and AlmaLinux containers.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
