### PR TITLE
Add packaging support for unix domain sockets

### DIFF
--- a/deb/build/build.sh
+++ b/deb/build/build.sh
@@ -15,6 +15,7 @@ cp -R "${dir}"/* "${D}"
 cp "${BASE}/systemd/jenkins.service" "${D}/debian"
 cp "${BASE}/systemd/jenkins.sh" "${D}"
 cp "${BASE}/systemd/migrate.sh" "${D}"
+cp "${BASE}/systemd/jenkins.conf" "${D}/debian/jenkins.tmpfiles"
 
 # Create a description temp file
 sed -i.bak -e 's/^\s*$/./' -e 's/^/ /' "${DESCRIPTION_FILE}"

--- a/deb/build/debian/jenkins.install
+++ b/deb/build/debian/jenkins.install
@@ -1,3 +1,4 @@
 @@ARTIFACTNAME@@ usr/bin
 @@ARTIFACTNAME@@.war usr/share/java
 migrate usr/share/@@ARTIFACTNAME@@
+@@ARTIFACTNAME@@.conf usr/lib/tmpfiles.d/

--- a/deb/build/debian/jenkins.install
+++ b/deb/build/debian/jenkins.install
@@ -1,4 +1,3 @@
 @@ARTIFACTNAME@@ usr/bin
 @@ARTIFACTNAME@@.war usr/share/java
 migrate usr/share/@@ARTIFACTNAME@@
-@@ARTIFACTNAME@@.conf usr/lib/tmpfiles.d/

--- a/rpm/build/SPECS/jenkins.spec
+++ b/rpm/build/SPECS/jenkins.spec
@@ -11,6 +11,7 @@ Source:		jenkins.war
 Source1:	jenkins.service
 Source2:	jenkins.sh
 Source3:	migrate.sh
+Source4:	jenkins.conf
 URL:		@@HOMEPAGE@@
 License:	@@LICENSE@@
 BuildRoot:	%{_tmppath}/build-%{name}-%{version}
@@ -42,6 +43,7 @@ rm -rf "%{buildroot}"
 %__install -D -m0644 "%{SOURCE1}" "%{buildroot}%{_unitdir}/%{name}.service"
 %__install -D -m0755 "%{SOURCE2}" "%{buildroot}%{_bindir}/%{name}"
 %__install -D -m0755 "%{SOURCE3}" "%{buildroot}%{_datadir}/%{name}/migrate"
+%__install -D -m0755 "%{SOURCE4}" "%{buildroot}%{_tmpfilesdir}/%{name}.conf"
 
 %pre
 /usr/bin/getent group %{name} &>/dev/null || /usr/sbin/groupadd -r %{name} &>/dev/null
@@ -74,8 +76,11 @@ fi
 %{_unitdir}/%{name}.service
 %{_bindir}/%{name}
 %{_datadir}/%{name}/migrate
+%{_tmpfilesdir}/%{name}.conf
 
 %changelog
+* Mon Nov 06 2023 minfrin@sharp.fm
+- added unix domain socket support
 * Mon Jun 19 2023 projects@unixadm.org
 - removed sysv initscript for el>=7
 - removed logrotate config

--- a/rpm/build/build.sh
+++ b/rpm/build/build.sh
@@ -8,6 +8,7 @@ cp -R "$(dirname "$0")"/* "${D}"
 cp "${BASE}/systemd/jenkins.service" "${D}/SOURCES"
 cp "${BASE}/systemd/jenkins.sh" "${D}/SOURCES"
 cp "${BASE}/systemd/migrate.sh" "${D}/SOURCES"
+cp "${BASE}/systemd/jenkins.conf" "${D}/SOURCES"
 "${BASE}/bin/branding.py" "${D}"
 
 cp "${WAR}" "${D}/SOURCES/jenkins.war"

--- a/systemd/jenkins.conf
+++ b/systemd/jenkins.conf
@@ -1,0 +1,1 @@
+D /run/jenkins 0770 jenkins jenkins -

--- a/systemd/jenkins.service
+++ b/systemd/jenkins.service
@@ -56,6 +56,9 @@ Environment="JENKINS_WEBROOT=%C/@@ARTIFACTNAME@@/war"
 # Arguments for the Jenkins JVM
 Environment="JAVA_OPTS=-Djava.awt.headless=true"
 
+# Unix Domain Socket to listen on for local HTTP requests. Default is disabled.
+#Environment="JENKINS_UNIX_DOMAIN_PATH=/run/jenkins/jenkins.socket"
+
 # IP address to listen on for HTTP requests.
 # The default is to listen on all interfaces (0.0.0.0).
 #Environment="JENKINS_LISTEN_ADDRESS="

--- a/systemd/jenkins.sh
+++ b/systemd/jenkins.sh
@@ -52,6 +52,10 @@ infer_jenkins_opts() {
 		inferred_jenkins_opts="${inferred_jenkins_opts} --httpListenAddress=${JENKINS_LISTEN_ADDRESS}"
 	fi
 
+	if [ -n "${JENKINS_UNIX_DOMAIN_PATH}" ]; then
+		inferred_jenkins_opts="${inferred_jenkins_opts} --httpUnixDomainPath=${JENKINS_UNIX_DOMAIN_PATH}"
+	fi
+
 	if [ -n "${JENKINS_HTTPS_PORT}" ]; then
 		inferred_jenkins_opts="${inferred_jenkins_opts} --httpsPort=${JENKINS_HTTPS_PORT}"
 	fi
@@ -117,6 +121,7 @@ main() {
 	unset JENKINS_HTTPS_PORT
 	java_cmd="${JENKINS_JAVA_CMD}"
 	unset JENKINS_JAVA_CMD
+	unset JENKINS_UNIX_DOMAIN_PATH
 	unset JENKINS_LISTEN_ADDRESS
 	unset JENKINS_LOG
 	unset JENKINS_OPTS
@@ -157,6 +162,7 @@ check_env \
 	JAVA_OPTS \
 	JENKINS_HTTPS_PORT \
 	JENKINS_JAVA_CMD \
+	JENKINS_UNIX_DOMAIN_PATH \
 	JENKINS_LISTEN_ADDRESS \
 	JENKINS_LOG \
 	JENKINS_OPTS \


### PR DESCRIPTION
- Add /run/jenkins path in systemd-tmpfiles as a home for the socket
- Support JENKINS_UNIX_DOMAIN_PATH variable to pass the socket path

Added to winstone: https://github.com/jenkinsci/winstone/pull/346 / https://github.com/jenkinsci/winstone/issues/345

### Testing done

- jenkins.war from most recent master

- RPM created as follows:

```
WAR=/home/minfrin/jenkins.war MSI= BUILDENV=env/release.mk BRAND=branding/jenkins.mk make rpm
```

- /etc/sysconfig/jenkins modified for testing as follows:

```
JAVA_HOME=/etc/alternatives/jre_17

JENKINS_PORT=-1
JENKINS_PREFIX=/jenkins
JENKINS_UNIX_DOMAIN_PATH=/var/run/jenkins/jenkins.socket
```

Apache httpd configured as follows:

```
  ProxyPass unix:///run/jenkins/jenkins.socket|http://localhost/jenkins nocanon
  ProxyPassReverse unix:///run/jenkins/jenkins.socket|http://localhost/jenkins
```


```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
