### PR TITLE
Document 2.426.1 supporting Java 21 (#445)

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -105,6 +105,9 @@
             </p>
 
             <dl>
+              <dt>2.426.1 (November 2023) and newer</dt>
+              <dd>Java 11, Java 17 or Java 21</dd>
+
               <dt>2.361.1 (September 2022) and newer</dt>
               <dd>Java 11 or Java 17</dd>
 


### PR DESCRIPTION
(cherry picked from commit 5f234a37d5becb93727501d9d9b74ae7d5fd1253)

To be backported to 2.246.2 and onwards.