### PR TITLE
Include 2.463 in docs as first weekly to require Java 17 or newer

### DIFF
--- a/rpm/build/SPECS/jenkins.spec
+++ b/rpm/build/SPECS/jenkins.spec
@@ -18,7 +18,7 @@ BuildRoot:	%{_tmppath}/build-%{name}-%{version}
 # Unfortunately the Oracle Java RPMs do not register as providing anything (including "java" or "jdk")
 # So either we make a hard requirement on the OpenJDK or none at all
 # Only workaround would be to use a java virtual package, see https://github.com/keystep/virtual-java-rpm
-# TODO: If re-enable, fix the matcher for Java 11
+# TODO: If re-enable, fix the matcher for Java 17
 # Requires: java >= 1:1.8.0
 Requires: procps
 Requires(pre): /usr/sbin/useradd, /usr/sbin/groupadd

--- a/suse/build/SPECS/jenkins.spec
+++ b/suse/build/SPECS/jenkins.spec
@@ -22,7 +22,7 @@ BuildRoot:	%{_tmppath}/build-%{name}-%{version}
 # Unfortunately the Oracle Java RPMs do not register as providing anything (including "java" or "jdk")
 # So either we make a hard requirement on the OpenJDK or none at all
 # Only workaround would be to use a java virtual package, see https://github.com/keystep/virtual-java-rpm
-# TODO: Fix the query for Java 11 if it is reenabled
+# TODO: Fix the query for Java 17 if it is reenabled
 # Requires: java >= 1:1.8.0
 Requires:	procps
 Requires(pre): /usr/sbin/useradd, /usr/sbin/groupadd

--- a/templates/base.html
+++ b/templates/base.html
@@ -80,6 +80,9 @@
             </p>
 
             <dl>
+              <dt>2.463 (June 2024) and newer</dt>
+              <dd>Java 17 or Java 21</dd>
+
               <dt>2.419 (August 2023) and newer</dt>
               <dd>Java 11, Java 17, or Java 21</dd>
 

--- a/templates/header.war.html
+++ b/templates/header.war.html
@@ -22,6 +22,9 @@
   </p>
 
   <dl>
+    <dt>2.463 (June 2024) and newer</dt>
+    <dd>Java 17 or Java 21</dd>
+
     <dt>2.419 (August 2023) and newer</dt>
     <dd>Java 11, Java 17, or Java 21</dd>
 


### PR DESCRIPTION
## Include 2.463 in docs as first weekly to require Java 17 or newer

Jenkins 2.463 is the first weekly to require Java 17 as its minimium Java version.

The [blog post](https://www.jenkins.io/blog/2024/06/11/require-java-17/) contains more details.

### Testing done

Confirmed that the text displays as expected from my web browser.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
