### PR TITLE
Remove Java 11 from MSI installer (Windows)

### DIFF
--- a/msi/build/jenkins.wxs
+++ b/msi/build/jenkins.wxs
@@ -168,10 +168,9 @@
         Return="check"
         Impersonate="no" />
 
-    <!-- This will find the JRE/JDK directory either Java 11, 17 or 21 (prefer 17) -->
+    <!-- This will find the JRE/JDK directory either Java 17 or 21 (prefer 17) -->
     <Property Id="JAVA_HOME">
       <RegistrySearch Id="JDK21_HOME_REGSEARCH" Root="HKLM" Key="SOFTWARE\JavaSoft\JDK\21" Name="JavaHome" Type="raw" Win64="yes" />
-      <RegistrySearch Id="JDK11_HOME_REGSEARCH" Root="HKLM" Key="SOFTWARE\JavaSoft\JDK\11" Name="JavaHome" Type="raw" Win64="yes" />
       <RegistrySearch Id="JDK17_HOME_REGSEARCH" Root="HKLM" Key="SOFTWARE\JavaSoft\JDK\17" Name="JavaHome" Type="raw" Win64="yes" />
     </Property>
 
@@ -368,9 +367,9 @@
             <Publish Event="DoAction" Value="ValidateJavaHome" Order="1">1</Publish>
 
             <!-- Spawn the error dialog if java.exe can't be found. -->
-            <Publish Property="ERROR_TITLE" Value="!(loc.JavaHomeDlgErrorTitle)" Order="2"><![CDATA[JAVA_EXE_FOUND = "0" OR (JAVA_EXE_VERSION <> "11" AND JAVA_EXE_VERSION <> "17" AND JAVA_EXE_VERSION <> "21")]]></Publish>
-            <Publish Property="ERROR_MESSAGE" Value="!(loc.JavaJomeDlgErrorMessage)" Order="3"><![CDATA[JAVA_EXE_FOUND = "0" OR (JAVA_EXE_VERSION <> "11" AND JAVA_EXE_VERSION = "17" AND JAVA_EXE_VERSION <> "21")]]></Publish>
-            <Publish Event="SpawnDialog" Value="GenericErrorDlg" Order="4"><![CDATA[JAVA_EXE_FOUND = "0" OR (JAVA_EXE_VERSION <> "11" AND JAVA_EXE_VERSION <> "17" AND JAVA_EXE_VERSION <> "21")]]></Publish>
+            <Publish Property="ERROR_TITLE" Value="!(loc.JavaHomeDlgErrorTitle)" Order="2"><![CDATA[JAVA_EXE_FOUND = "0" OR (JAVA_EXE_VERSION <> "17" AND JAVA_EXE_VERSION <> "21")]]></Publish>
+            <Publish Property="ERROR_MESSAGE" Value="!(loc.JavaHomeDlgErrorMessage)" Order="3"><![CDATA[JAVA_EXE_FOUND = "0" OR (JAVA_EXE_VERSION <> "17" AND JAVA_EXE_VERSION <> "21")]]></Publish>
+            <Publish Event="SpawnDialog" Value="GenericErrorDlg" Order="4"><![CDATA[JAVA_EXE_FOUND = "0" OR (JAVA_EXE_VERSION <> "17" AND JAVA_EXE_VERSION <> "21")]]></Publish>
             <Publish Property="JAVA_HOME" Value="[JAVA_HOME]">1</Publish>
           </Control>
           <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="!(loc.WixUIBack)" />

--- a/msi/build/jenkins_en-US.wxl
+++ b/msi/build/jenkins_en-US.wxl
@@ -3,10 +3,10 @@
   <!-- Java Home Dialog Strings -->
   <String Id="JavaHomeDlgTitle" Overridable="yes">[ProductName] Setup</String>
   <String Id="JavaHomeDlgDescription" Overridable="yes">Select Java home directory (JDK or JRE)</String>
-  <String Id="JavaHomeDlgLabel" Overridable="yes">Please select the path of a Java Development Kit or Java Runtime Environment. Only Java 11, 17 and 21 are supported by Jenkins.</String>
+  <String Id="JavaHomeDlgLabel" Overridable="yes">Please select the path of a Java Development Kit or Java Runtime Environment. Only Java 17 and 21 are supported by Jenkins.</String>
   <String Id="JavaHomeDlgChange" Overridable="yes">&amp;Change...</String>
   <String Id="JavaHomeDlgErrorTitle" Overridable="yes">Invalid Java Directory</String>
-  <String Id="JavaJomeDlgErrorMessage" Overridable="yes">Failed to find compatible Java version (11, 17 or 21) in [JAVA_HOME]</String>
+  <String Id="JavaHomeDlgErrorMessage" Overridable="yes">Failed to find compatible Java version (17 or 21) in [JAVA_HOME]</String>
   
   <!-- Java Browse Dialog Strings -->
   <String Id="JavaBrowseDlgDescription" Overridable="yes">Browse to the Java Home directory</String>


### PR DESCRIPTION
## Remove Java 11 from MSI installer (Windows)

Jenkins weekly 2.463 requires Java 17 or Java 21.  Do not offer Java 11 to Windows users as a valid Java installation for Jenkins.

### Testing done

Built the Windows installer with these changes and confirmed that Java 8 and Java 11 are both rejected as invalid Java versions and that Java 17 and Java 21 are accepted as valid Java versions.

Confirmed that a Java home directory that does not contain any Java is also rejected with the expected message.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
