### PR TITLE
Drop Debian 10 support

### DIFF
--- a/molecule/default/install-deb.yml
+++ b/molecule/default/install-deb.yml
@@ -8,12 +8,6 @@
     name:
       - openjdk-17-jre
     state: present
-  when: ansible_hostname != 'debian-10'
-- package:
-    name:
-      - openjdk-11-jre
-    state: present
-  when: ansible_hostname == 'debian-10'
 - find:
     paths: /var/tmp/target/debian
     file_type: file

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,14 +6,6 @@ driver:
 
 platforms:
   # deb
-  - name: debian-10  # EOL 2024-06-30
-    image: dokken/debian-10:latest
-    override_command: false
-    volumes:
-      - ${MOLECULE_PROJECT_DIRECTORY}/target:/var/tmp/target
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    cgroupns_mode: host
-    privileged: true
   - name: debian-11  # EOL 2026-06-30
     image: dokken/debian-11:latest
     override_command: false


### PR DESCRIPTION
## Drop Debian 10 support

Debian 10 is [end of life 30 June 2024](https://www.debian.org/News/2024/20240615).  Debian 10 is only able to install Java 11 and Jenkins 2.463 drops support for Java 11.  Rather than trying to make Debian 10 work until the end of June, let's stop testing it now.

This should fix the failing CI tests on the master branch as well.

### Testing done

Successfully ran the molecule tests as outlined in README

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
