### PR TITLE
Remove failing Wildfly 26 test

### DIFF
--- a/molecule/servlet/Dockerfile.j2
+++ b/molecule/servlet/Dockerfile.j2
@@ -14,19 +14,9 @@ ENV {{ var }} {{ value }}
 {% endfor %}
 {% endif %}
 
-{% if 'wildfly' in item.image %}
-USER root
-{% endif %}
-
 RUN if [ $(command -v apt-get) ]; then export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -y python3 sudo bash ca-certificates iproute2 python3-apt python3-psutil python3-lxml aptitude && apt-get clean && rm -rf /var/lib/apt/lists/*; \
     elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install /usr/bin/python3 /usr/bin/python3-config /usr/bin/dnf-3 python3-psutil sudo bash iproute && dnf clean all; \
     elif [ $(command -v yum) ]; then yum makecache fast && yum install -y /usr/bin/python3 /usr/bin/python3-config python3-pip gcc sudo yum-plugin-ovl bash iproute && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
     elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python3 sudo bash iproute2 && zypper clean -a; \
     elif [ $(command -v apk) ]; then apk update && apk add --no-cache python3 bash ca-certificates; \
     elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python3 sudo bash ca-certificates iproute2 && xbps-remove -O; fi
-
-{% if 'wildfly' in item.image %}
-RUN chown jboss /opt/jboss
-RUN pip3 install psutil
-USER jboss
-{% endif %}

--- a/molecule/servlet/configure-wildfly.yml
+++ b/molecule/servlet/configure-wildfly.yml
@@ -1,5 +1,0 @@
----
-- lineinfile:
-    path: "/opt/jboss/wildfly/bin/standalone.conf"
-    regexp: '^#?JAVA_OPTS="\$JAVA_OPTS -DJENKINS_HOME='
-    line: 'JAVA_OPTS="$JAVA_OPTS -DJENKINS_HOME=/var/tmp/jenkins_home"'

--- a/molecule/servlet/converge.yml
+++ b/molecule/servlet/converge.yml
@@ -4,5 +4,3 @@
   tasks:
     - include_tasks: configure-tomcat.yml
       when: ansible_hostname == 'tomcat-9'
-    - include_tasks: configure-wildfly.yml
-      when: ansible_hostname == 'wildfly-26'

--- a/molecule/servlet/molecule.yml
+++ b/molecule/servlet/molecule.yml
@@ -8,15 +8,7 @@ platforms:
     image: tomcat:9-jdk17-temurin
     volumes:
       - ${MOLECULE_PROJECT_DIRECTORY}/jenkins.war:/usr/local/tomcat/webapps/jenkins.war
-  - name: wildfly-26
-    image: quay.io/wildfly/wildfly:26.1.3.Final-jdk17
-    volumes:
-      - ${MOLECULE_PROJECT_DIRECTORY}/jenkins.war:/opt/jboss/wildfly/standalone/deployments/jenkins.war
 provisioner:
   name: ansible
-  inventory:
-    host_vars:
-      wildfly-26:
-        ansible_python_interpreter: "/usr/bin/python3"
 verifier:
   name: ansible

--- a/molecule/servlet/verify.yml
+++ b/molecule/servlet/verify.yml
@@ -12,11 +12,6 @@
     - command:
         cmd: /usr/local/tomcat/bin/catalina.sh start
       when: ansible_hostname == 'tomcat-9'
-    - command:
-        cmd: /opt/jboss/wildfly/bin/standalone.sh
-      async: 3600
-      poll: 0
-      when: ansible_hostname == 'wildfly-26'
     - uri:
         url: "http://127.0.0.1:8080/jenkins/login"
         return_content: true
@@ -45,9 +40,6 @@
     - command:
         cmd: /usr/local/tomcat/bin/catalina.sh stop
       when: ansible_hostname == 'tomcat-9'
-    - command:
-        cmd: /opt/jboss/wildfly/bin/jboss-cli.sh --connect command=:shutdown
-      when: ansible_hostname == 'wildfly-26'
     - pids:
         name: java
       register: service_pids


### PR DESCRIPTION
## Remove failing Wildfly 26 test

The Wildfly 26 container image is based on CentOS 7 and as of July 2024 the CentOS 7 update server used by the container is no longer available.  CentOS 7 is end of life as of June 30, 2024.

### Testing done

Reviewed the code changes but will rely on ci.jenkins.io to run full tests.  Running tests on my Ubuntu 22.04 computer to confirm that they pass without the Wildfly 26 tests

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
