### PR TITLE
Define `StartLimitBurst`

### DIFF
--- a/systemd/jenkins.service
+++ b/systemd/jenkins.service
@@ -13,6 +13,8 @@
 Description=Jenkins Continuous Integration Server
 Requires=network.target
 After=network.target
+StartLimitBurst=5
+StartLimitIntervalSec=5m
 
 [Service]
 Type=notify


### PR DESCRIPTION
Defines `StartLimitBurst` (and `StartLimitIntervalSec`) to prevent the Debian packaging from endlessly restarting a failing Jenkins service, as suggested by @basil in https://github.com/jenkinsci/jenkins/pull/9483#issuecomment-2237829184.

### Testing done

Built `make deb` using the Docker Compose environment based on a WAR built from https://github.com/jenkinsci/jenkins/pull/9483/commits/e92c1e9792a09939e052dcd8186efb240ff38242. Took me a while to figure out that you have to

```bash
gpg --import --batch credentials/sandbox.gpg
```

which was not really explained. On my host machine (unsure how to do this inside Docker, and not willing to start a VM) I installed the package, referring to https://www.jenkins.io/doc/book/installing/linux/#debianubuntu (I had not used a native package for Jenkins in many years), and set up Jenkins, installing `configuration-as-code`. Created `/var/lib/jenkins/jenkins.yaml`

```yaml
jenkins:
  systemMessage: 'hello from JCasC #1'
```

and used

```bash
sudo systemctl restart jenkins.service
```

to see the first message. Edited the config to

```yaml
jenkins:
  systemMessage: 'hello from JCasC #1'
  xxx: true
```

and restarted again; used

```bash
journalctl -u jenkins.service
```

to observe that the controller crashed, and the service keeps on restarting it endlessly. Referred to https://www.redhat.com/sysadmin/systemd-automate-recovery https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html https://www.freedesktop.org/software/systemd/man/latest/systemd.time.html to

```bash
sudo systemctl edit jenkins
```

resulting in `/etc/systemd/system/jenkins.service.d/override.conf`

```ini
[Unit]
StartLimitBurst=5
StartLimitIntervalSec=5m
```

and saw that now after five attempts it gives up. Fixed config

```yaml
jenkins:
  systemMessage: 'hello from JCasC #2'
```

and used

```bash
sudo systemctl reset-failed jenkins.service
sudo systemctl restart jenkins.service
```

and then it comes up with the second system message.
