### PR TITLE
Revert "Test on EuroLinux 9"

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -71,14 +71,6 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
     privileged: true
-  - name: eurolinux-9  # EOL 2032-06-30
-    image: dokken/eurolinux-9:latest
-    override_command: false
-    volumes:
-      - ${MOLECULE_PROJECT_DIRECTORY}/target:/var/tmp/target
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    cgroupns_mode: host
-    privileged: true
   - name: fedora-40  # EOL 2025-05-13
     image: dokken/fedora-40:latest
     override_command: false


### PR DESCRIPTION
Reverts jenkinsci/packaging#483. While this test was passing at the time I integrated it, it's failing now and blocking merges to the default branch. Since this platform isn't very critical, let's revert that PR to restore stability to the default branch.