### PR TITLE
[JENKINS-73346] Update packaging tests for EE 9

### DIFF
--- a/molecule/servlet/converge.yml
+++ b/molecule/servlet/converge.yml
@@ -3,4 +3,4 @@
   hosts: all
   tasks:
     - include_tasks: configure-tomcat.yml
-      when: ansible_hostname == 'tomcat-9'
+      when: ansible_hostname == 'tomcat-10'

--- a/molecule/servlet/molecule.yml
+++ b/molecule/servlet/molecule.yml
@@ -4,8 +4,8 @@ dependency:
 driver:
   name: docker
 platforms:
-  - name: tomcat-9
-    image: tomcat:9-jdk17-temurin
+  - name: tomcat-10
+    image: tomcat:10-jdk17-temurin
     volumes:
       - ${MOLECULE_PROJECT_DIRECTORY}/jenkins.war:/usr/local/tomcat/webapps/jenkins.war
 provisioner:

--- a/molecule/servlet/verify.yml
+++ b/molecule/servlet/verify.yml
@@ -11,7 +11,7 @@
         fail_msg: "{{ service_pids.pids | join(',') }}"
     - command:
         cmd: /usr/local/tomcat/bin/catalina.sh start
-      when: ansible_hostname == 'tomcat-9'
+      when: ansible_hostname == 'tomcat-10'
     - uri:
         url: "http://127.0.0.1:8080/jenkins/login"
         return_content: true
@@ -39,7 +39,7 @@
         fail_msg: "{{ jenkins_dir.state }}"
     - command:
         cmd: /usr/local/tomcat/bin/catalina.sh stop
-      when: ansible_hostname == 'tomcat-9'
+      when: ansible_hostname == 'tomcat-10'
     - pids:
         name: java
       register: service_pids


### PR DESCRIPTION
See [JENKINS-73346](https://issues.jenkins.io/browse/JENKINS-73346). In draft until the weekly is released and a CI build can pass.

### Testing done

`molecule test -s servlet` with an EE 9 WAR