### PR TITLE
Update Red Hat instructions & Java support information

### DIFF
--- a/templates/header.redhat.html
+++ b/templates/header.redhat.html
@@ -10,7 +10,8 @@
   </p>
 
   <p>
-  To install Jenkins on Fedora, use the instructions provided in our <a href="https://www.jenkins.io/doc/book/installing/linux/#fedora">Fedora installation guide</a>.
+  To install Jenkins on Fedora, use the instructions provided in our
+  <a href="https://www.jenkins.io/doc/book/installing/linux/#fedora">Fedora installation guide</a>.
   </p>
 
 {% endblock %}

--- a/templates/header.redhat.html
+++ b/templates/header.redhat.html
@@ -4,6 +4,7 @@
 
   <p>
   To install Jenkins on Fedora, use the instructions provided in our <a href="https://www.jenkins.io/doc/book/installing/linux/#fedora">Fedora installation guide</a>.
+  </p>
 
   <p>
   If you are trying to install Jenkins on Red Hat Enterprise Linux, AlmaLinux, Rocky Linux, Oracle Linux, or another Red Hat based distribution, you can utilize the instructions provided in our <a href="https://www.jenkins.io/doc/book/installing/linux/#red-hat-centos">Red Hat Enterprise Linux installation guide.</a> 

--- a/templates/header.redhat.html
+++ b/templates/header.redhat.html
@@ -3,12 +3,14 @@
 {% block distribution_instruction %}
 
   <p>
-  To install Jenkins on Fedora, use the instructions provided in our <a href="https://www.jenkins.io/doc/book/installing/linux/#fedora">Fedora installation guide</a>.
+  To install Jenkins on Red Hat Enterprise Linux, AlmaLinux, Rocky Linux, Oracle Linux, or another Red
+  Hat based distribution, you can utilize the instructions provided in our <a
+  href="https://www.jenkins.io/doc/book/installing/linux/#red-hat-centos">Red Hat Enterprise Linux installation
+  guide.</a>
   </p>
 
   <p>
-  If you are trying to install Jenkins on Red Hat Enterprise Linux, AlmaLinux, Rocky Linux, Oracle Linux, or another Red Hat based distribution, you can utilize the instructions provided in our <a href="https://www.jenkins.io/doc/book/installing/linux/#red-hat-centos">Red Hat Enterprise Linux installation guide.</a> 
-
+  To install Jenkins on Fedora, use the instructions provided in our <a href="https://www.jenkins.io/doc/book/installing/linux/#fedora">Fedora installation guide</a>.
   </p>
 
 {% endblock %}

--- a/templates/header.redhat.html
+++ b/templates/header.redhat.html
@@ -3,30 +3,12 @@
 {% block distribution_instruction %}
 
   <p>
-  To use this repository, run the following command:
-
-  <pre class="text-white bg-dark">
-
-  sudo wget -O /etc/yum.repos.d/{{artifactName}}.repo {{ web_url }}/{{artifactName}}.repo
-  sudo rpm --import {{ web_url }}/{{organization}}-2023.key
-  </pre>
+  To install Jenkins through Fedora, use the instructions provided in our <a href="https://www.jenkins.io/doc/book/installing/linux/#fedora">Fedora installation guide</a>.
 
   <p>
-  If you've previously imported the key from Jenkins, the <code>rpm --import</code> will fail because
-  you already have a key. Please ignore that and move on.
+  If you are trying to install Jenkins through Red Hat Enterprise Linux, Alma Linux, Rocky Linux, Oracle Linux, or another Red Hat based distribution, you can utilize the instructions provided in our <a href="https://www.jenkins.io/doc/book/installing/linux/#red-hat-centos">Red Hat Enterprise Linux installation guide.</a> 
 
-  <pre class="text-white bg-dark">
-
-  yum install fontconfig java-17-openjdk
-  yum install {{artifactName}}
-  </pre>
-
-  <p>
-  The rpm packages were signed using this key:
   </p>
-
-  <pre class="text-white bg-dark" style="box-sizing:border-box; padding:1.5rem 1rem;">{{ pub_key_info|trim }}</pre>
-
 
 {% endblock %}
 

--- a/templates/header.redhat.html
+++ b/templates/header.redhat.html
@@ -6,7 +6,7 @@
   To install Jenkins on Fedora, use the instructions provided in our <a href="https://www.jenkins.io/doc/book/installing/linux/#fedora">Fedora installation guide</a>.
 
   <p>
-  If you are trying to install Jenkins on Red Hat Enterprise Linux, Alma Linux, Rocky Linux, Oracle Linux, or another Red Hat based distribution, you can utilize the instructions provided in our <a href="https://www.jenkins.io/doc/book/installing/linux/#red-hat-centos">Red Hat Enterprise Linux installation guide.</a> 
+  If you are trying to install Jenkins on Red Hat Enterprise Linux, AlmaLinux, Rocky Linux, Oracle Linux, or another Red Hat based distribution, you can utilize the instructions provided in our <a href="https://www.jenkins.io/doc/book/installing/linux/#red-hat-centos">Red Hat Enterprise Linux installation guide.</a> 
 
   </p>
 

--- a/templates/header.redhat.html
+++ b/templates/header.redhat.html
@@ -3,10 +3,10 @@
 {% block distribution_instruction %}
 
   <p>
-  To install Jenkins through Fedora, use the instructions provided in our <a href="https://www.jenkins.io/doc/book/installing/linux/#fedora">Fedora installation guide</a>.
+  To install Jenkins on Fedora, use the instructions provided in our <a href="https://www.jenkins.io/doc/book/installing/linux/#fedora">Fedora installation guide</a>.
 
   <p>
-  If you are trying to install Jenkins through Red Hat Enterprise Linux, Alma Linux, Rocky Linux, Oracle Linux, or another Red Hat based distribution, you can utilize the instructions provided in our <a href="https://www.jenkins.io/doc/book/installing/linux/#red-hat-centos">Red Hat Enterprise Linux installation guide.</a> 
+  If you are trying to install Jenkins on Red Hat Enterprise Linux, Alma Linux, Rocky Linux, Oracle Linux, or another Red Hat based distribution, you can utilize the instructions provided in our <a href="https://www.jenkins.io/doc/book/installing/linux/#red-hat-centos">Red Hat Enterprise Linux installation guide.</a> 
 
   </p>
 

--- a/templates/header.war.html
+++ b/templates/header.war.html
@@ -13,64 +13,10 @@
     e.g. <a href="https://adoptium.net/">Eclipse Temurin</a>.
   </p>
 
-  <h2>
-    Weekly Release Line
-  </h2>
-
   <p>
-    Supported Java versions for the weekly release line are:
+    To determine the Java version that is supported for your Jenkins environment, please refer to the <a href="https://www.jenkins.io/doc/book/platform-information/support-policy-java/#running-jenkins-system">Java support policy.</a>
   </p>
 
-  <dl>
-    <dt>2.463 (June 2024) and newer</dt>
-    <dd>Java 17 or Java 21</dd>
-
-    <dt>2.419 (August 2023) and newer</dt>
-    <dd>Java 11, Java 17, or Java 21</dd>
-
-    <dt>2.357 (June 2022) and newer</dt>
-    <dd>Java 11 or Java 17</dd>
-
-    <dt>2.164 (February 2019) and newer</dt>
-    <dd>Java 8 or Java 11</dd>
-
-    <dt>2.54 (April 2017) and newer</dt>
-    <dd>Java 8</dd>
-
-    <dt>1.612 (May 2015) and newer</dt>
-    <dd>Java 7</dd>
-  </dl>
-
-  <h2>
-    <a href="https://www.jenkins.io/download/lts/">Long Term Support (LTS)</a> Release Line
-  </h2>
-
-  <p>
-    Supported Java versions for the LTS release line are:
-  </p>
-
-  <dl>
-     <dt>2.479.1 (October 2024) and newer</dt>
-     <dd>Java 17 or Java 21</dd>
-
-     <dt>2.426.1 (November 2023) and newer</dt>
-     <dd>Java 11, Java 17 or Java 21</dd>
-
-    <dt>2.361.1 (September 2022) and newer</dt>
-    <dd>Java 11 or Java 17</dd>
-
-    <dt>2.346.1 (June 2022) and newer</dt>
-    <dd>Java 8, Java 11, or Java 17</dd>
-
-    <dt>2.164.1 (March 2019) and newer</dt>
-    <dd>Java 8 or Java 11</dd>
-
-    <dt>2.60.1 (June 2017) and newer</dt>
-    <dd>Java 8</dd>
-
-    <dt>1.625.1 (October 2015) and newer</dt>
-    <dd>Java 7</dd>
-  </dl>
 {% endblock %}
 
 {% block  individual_package_instruction  %}


### PR DESCRIPTION
The purpose of this PR is to update the Red Hat installation instructions so that the [Fedora](https://www.jenkins.io/doc/book/installing/linux/#fedora) and [Red Hat Enterprise Linux & other distributions](https://www.jenkins.io/doc/book/installing/linux/#red-hat-centos) are utilized instead of the existing instructions.

Users are having issues where the currently listed instructions are not working for their installation.
https://github.com/jenkins-infra/helpdesk/issues/4429

The goal of this is to update the packaging instructions so that users can find the proper instructions for their distribution and also update the supported Java versions to utilize the [Java support policy page from jenkins.io](https://www.jenkins.io/doc/book/platform-information/support-policy-java/#running-jenkins-system)
### Testing done

This also attempts to address the concerns from https://github.com/jenkinsci/packaging/pull/431 by including the Java support policy page, as well as the updated instructions for Linux.

Comment:
tested in VSCode, the links work and the text is more focused compared to the existing instructions
![Screenshot 2024-12-04 at 10 28 13 AM](https://github.com/user-attachments/assets/46fcd79e-58e9-4e25-ae29-08ede1ac4311)
![Screenshot 2024-12-04 at 10 27 01 AM](https://github.com/user-attachments/assets/ff7573a3-783e-4c52-b208-b37ade874e1e)

### Submitter checklist
- [ x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ x] Ensure that the pull request title represents the desired changelog entry
- [ x] Please describe what you did
- [ x] Link to relevant issues in GitHub or Jira
- [x ] Link to relevant pull requests, esp. upstream and downstream changes
- [x ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

