### PR TITLE
Update keyring location

### DIFF
--- a/templates/header.debian.html
+++ b/templates/header.debian.html
@@ -9,7 +9,7 @@
 
   <pre class="text-white bg-dark">
     <code>
-  sudo wget -O /usr/share/keyrings/jenkins-keyring.asc \
+  sudo wget -O /etc/apt/keyrings/jenkins-keyring.asc \
     <a href="{{web_url}}/{{organization}}-2023.key" style="color:white">{{web_url}}/{{organization}}-2023.key</a></code>
   </pre>
 
@@ -17,7 +17,7 @@
 
   <pre class="text-white bg-dark">
     <code>
-  echo "deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc]" \
+  echo "deb [signed-by=/etc/apt/keyrings/jenkins-keyring.asc]" \
     {{ web_url }} binary/ | sudo tee \
     /etc/apt/sources.list.d/jenkins.list > /dev/null</code>
   </pre>


### PR DESCRIPTION
Per [`sources.list(5)`](https://manpages.ubuntu.com/manpages/plucky/en/man5/sources.list.5.html):

> The recommended locations for keyrings are `/usr/share/keyrings` for keyrings managed by packages, and `/etc/apt/keyrings` for keyrings managed by the system operator.

The package does not manage any keyrings, so `/etc/apt/keyrings` is the more appropriate choice here.

### Testing done

Tested this location on my Ubuntu system; it works the same as before.

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
