### PR TITLE
chore(*/publish) preserve file timestamps on remote copies, get rid of remote SSH/rsync of binaries for `war`, `msi` and `deb`

### DIFF
--- a/rpm/publish/publish.sh
+++ b/rpm/publish/publish.sh
@@ -69,6 +69,7 @@ function uploadPackage() {
 	# Local
 	rsync \
 		--verbose \
+		--times \
 		--compress \
 		--ignore-existing \
 		--recursive \
@@ -78,6 +79,7 @@ function uploadPackage() {
 	# Remote
 	rsync \
 		--archive \
+		--times \
 		--verbose \
 		--compress \
 		-e "ssh ${SSH_OPTS[*]}" \
@@ -102,6 +104,7 @@ function uploadSite() {
 	# Disable copy on local network storage
 	#rsync \
 	#  --compress \
+	#  --times \
 	#  --recursive \
 	#  --verbose \
 	#  --exclude RPMS \
@@ -112,6 +115,7 @@ function uploadSite() {
 
 	rsync \
 		--archive \
+		--times \
 		--compress \
 		--verbose \
 		-e "ssh ${SSH_OPTS[*]}" \
@@ -124,6 +128,7 @@ function uploadSite() {
 	# Following html need to be located inside the binary directory
 	rsync \
 		--compress \
+		--times \
 		--verbose \
 		--recursive \
 		--include "HEADER.html" \
@@ -134,6 +139,7 @@ function uploadSite() {
 
 	rsync \
 		--archive \
+		--times \
 		--compress \
 		--verbose \
 		-e "ssh ${SSH_OPTS[*]}" \

--- a/suse/publish/publish.sh
+++ b/suse/publish/publish.sh
@@ -66,6 +66,7 @@ function show() {
 function uploadPackage() {
 	rsync \
 		--recursive \
+		--times \
 		--verbose \
 		--compress \
 		--ignore-existing \
@@ -74,6 +75,7 @@ function uploadPackage() {
 
 	rsync \
 		--archive \
+		--times \
 		--verbose \
 		--compress \
 		--ignore-existing \
@@ -86,6 +88,7 @@ function uploadSite() {
 	pushd $D
 	rsync \
 		--recursive \
+		--times \
 		--verbose \
 		--compress \
 		--progress \
@@ -97,6 +100,7 @@ function uploadSite() {
 	# shellcheck disable=SC2029
 	rsync \
 		--archive \
+		--times \
 		--verbose \
 		--compress \
 		--progress \
@@ -140,6 +144,7 @@ function uploadSite() {
 	# Following html need to be located inside the binary directory
 	rsync \
 		--compress \
+		--times \
 		--verbose \
 		--recursive \
 		--include "HEADER.html" \
@@ -150,6 +155,7 @@ function uploadSite() {
 
 	rsync \
 		--archive \
+		--times \
 		--compress \
 		--verbose \
 		-e "ssh ${SSH_OPTS[*]}" \

--- a/war/publish/publish.sh
+++ b/war/publish/publish.sh
@@ -5,7 +5,6 @@ set -euxo pipefail
 : "${AGENT_WORKDIR:=/tmp}"
 : "${WAR:?Require Jenkins War file}"
 : "${WARDIR:? Require where to put binary files}"
-: "${WAR_WEBDIR:? Require where to put repository index and other web contents}"
 
 # $$ Contains current pid
 D="$AGENT_WORKDIR/$$"
@@ -13,9 +12,6 @@ D="$AGENT_WORKDIR/$$"
 function clean() {
 	rm -rf "$D"
 }
-
-# Convert string to array to correctly escape cli parameter
-SSH_OPTS=($SSH_OPTS)
 
 # Generate and publish site content
 function generateSite() {
@@ -28,12 +24,10 @@ function init() {
 	mkdir -p $D
 
 	mkdir -p "${WARDIR}/${VERSION}/"
-
-	ssh "${SSH_OPTS[@]}" "$PKGSERVER" mkdir -p "$WARDIR/${VERSION}/"
 }
 
 function skipIfAlreadyPublished() {
-	if ssh "${SSH_OPTS[@]}" "$PKGSERVER" test -e "${WARDIR}/${VERSION}/${ARTIFACTNAME}.war"; then
+	if test -e "${WARDIR}/${VERSION}/${ARTIFACTNAME}.war"; then
 		echo "File already published, nothing else todo"
 		exit 0
 	fi
@@ -43,9 +37,9 @@ function uploadPackage() {
 	sha256sum "${WAR}" | sed "s, .*, ${ARTIFACTNAME}.war," >"${WAR_SHASUM}"
 	cat "${WAR_SHASUM}"
 
-	# Local
 	rsync \
 		--compress \
+		--times \
 		--recursive \
 		--verbose \
 		--ignore-existing \
@@ -54,63 +48,34 @@ function uploadPackage() {
 
 	rsync \
 		--compress \
+		--times \
 		--recursive \
 		--verbose \
 		--ignore-existing \
 		--progress \
 		"${WAR_SHASUM}" "${WARDIR}/${VERSION}/"
 
-	# Remote
-	rsync \
-		--archive \
-		--compress \
-		--verbose \
-		-e "ssh ${SSH_OPTS[*]}" \
-		--ignore-existing \
-		--progress \
-		"${WAR}" "$PKGSERVER:${WARDIR}/${VERSION}/${ARTIFACTNAME}.war"
-
-	rsync \
-		--archive \
-		--compress \
-		--verbose \
-		-e "ssh ${SSH_OPTS[*]}" \
-		--ignore-existing \
-		--progress \
-		"${WAR_SHASUM}" "$PKGSERVER:${WARDIR}/${VERSION}/"
+	# TODO: generate symlink like in windows
 }
 
 # Site html need to be located in the binary directory
 function uploadSite() {
 	rsync \
 		--compress \
+		--times \
 		--recursive \
 		--verbose \
 		--include "HEADER.html" \
 		--include "FOOTER.html" \
 		--exclude "*" \
 		--progress \
-		-e "ssh ${SSH_OPTS[*]}" \
 		"${D}/" "${WARDIR// /\\ }/"
-
-	rsync \
-		--archive \
-		--compress \
-		--verbose \
-		--include "HEADER.html" \
-		--include "FOOTER.html" \
-		--exclude "*" \
-		--progress \
-		-e "ssh ${SSH_OPTS[*]}" \
-		"${D}/" "$PKGSERVER:${WARDIR// /\\ }/"
 }
 
 function show() {
 	echo "Parameters:"
 	echo "WAR: $WAR"
 	echo "WARDIR: $WARDIR"
-	echo "SSH_OPTS: ${SSH_OPTS[*]}"
-	echo "PKGSERVER: $PKGSERVER"
 	echo "---"
 }
 


### PR DESCRIPTION
This PR is a cherry-pick of #528 for https://github.com/jenkins-infra/helpdesk/issues/4774#issuecomment-3204695283