### PR TITLE
fix(deb/publish) ensure `SSH_OPTS` are properly parsed

### DIFF
--- a/deb/publish/publish.sh
+++ b/deb/publish/publish.sh
@@ -12,6 +12,9 @@ set -euxo pipefail
 # $$ Contains current pid
 D="$AGENT_WORKDIR/$$"
 
+# Convert string to array to correctly escape cli parameter
+SSH_OPTS=($SSH_OPTS)
+
 bin="$(dirname "$0")"
 
 function clean() {


### PR DESCRIPTION
Pointed out by https://github.com/jenkinsci/packaging/pull/528/files#r2288790948

Caused by #528, it reverts this specific change coming from a batch search and replace without proper care from myself.