### PR TITLE
Replace references to JDK17 by default to JDK21 (backport of #534 into `stable-2.528`)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ if (env.BRANCH_IS_PRIMARY) {
 properties(jobProperties)
 
 podTemplate(
-  inheritFrom: 'jnlp-maven-17',
+  inheritFrom: 'jnlp-maven-21',
   workingDir: '/home/jenkins/agent',
   containers: [
     containerTemplate(name: 'jnlp', image: 'jenkinsciinfra/packaging:latest')

--- a/molecule/default/install-deb.yml
+++ b/molecule/default/install-deb.yml
@@ -8,6 +8,12 @@
     name:
       - openjdk-17-jre
     state: present
+  when: ansible_distribution == "Debian" and ansible_distribution_major_version < "13"
+- package:
+    name:
+      - openjdk-21-jre
+    state: present
+  when: (ansible_distribution == "Debian" and ansible_distribution_major_version == "13") or ansible_distribution == "Ubuntu"
 - find:
     paths: /var/tmp/target/debian
     file_type: file

--- a/molecule/default/install-rpm.yml
+++ b/molecule/default/install-rpm.yml
@@ -6,12 +6,12 @@
     update_cache: true
 - package:
     name:
-      - java-17-openjdk
+      - java-21-openjdk
     state: present
   when: ansible_distribution != 'Amazon' and (ansible_distribution != 'CentOS' or ansible_distribution_major_version != '10')
 - package:
     name:
-      - java-17-amazon-corretto
+      - java-21-amazon-corretto
     state: present
   when: ansible_distribution == 'Amazon'
 - package:

--- a/molecule/default/install-suse.yml
+++ b/molecule/default/install-suse.yml
@@ -3,7 +3,7 @@
     name:
       - dejavu-fonts
       - fontconfig
-      - java-17-openjdk
+      - java-21-openjdk
     state: present
     update_cache: true
 - file:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -22,6 +22,14 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
     privileged: true
+  - name: debian-13  # EOL 2030-06-30 (LTS)
+    image: dokken/debian-13:latest
+    override_command: false
+    volumes:
+      - ${MOLECULE_PROJECT_DIRECTORY}/target:/var/tmp/target
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
   - name: ubuntu-22-04  # EOL 2027-04-01
     image: dokken/ubuntu-22.04:latest
     override_command: false

--- a/molecule/servlet/molecule.yml
+++ b/molecule/servlet/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: docker
 platforms:
   - name: tomcat-10
-    image: tomcat:10-jdk17-temurin
+    image: tomcat:10-jdk21-temurin
     volumes:
       - ${MOLECULE_PROJECT_DIRECTORY}/jenkins.war:/usr/local/tomcat/webapps/jenkins.war
 provisioner:

--- a/msi/build/jenkins.wxs
+++ b/msi/build/jenkins.wxs
@@ -168,7 +168,7 @@
         Return="check"
         Impersonate="no" />
 
-    <!-- This will find the JRE/JDK directory either Java 17 or 21 (prefer 17) -->
+    <!-- This will find the JRE/JDK directory either Java 17 or 21 (prefer 21) -->
     <Property Id="JAVA_HOME">
       <RegistrySearch Id="JDK21_HOME_REGSEARCH" Root="HKLM" Key="SOFTWARE\JavaSoft\JDK\21" Name="JavaHome" Type="raw" Win64="yes" />
       <RegistrySearch Id="JDK17_HOME_REGSEARCH" Root="HKLM" Key="SOFTWARE\JavaSoft\JDK\17" Name="JavaHome" Type="raw" Win64="yes" />

--- a/systemd/jenkins.service
+++ b/systemd/jenkins.service
@@ -50,7 +50,7 @@ Environment="JENKINS_WEBROOT=%C/@@ARTIFACTNAME@@/war"
 #Environment="JENKINS_LOG=%L/@@ARTIFACTNAME@@/@@ARTIFACTNAME@@.log"
 
 # The Java home directory. When left empty, JENKINS_JAVA_CMD and PATH are consulted.
-#Environment="JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64"
+#Environment="JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64"
 
 # The Java executable. When left empty, JAVA_HOME and PATH are consulted.
 #Environment="JENKINS_JAVA_CMD=/etc/alternatives/java"

--- a/templates/header.debian.html
+++ b/templates/header.debian.html
@@ -29,9 +29,10 @@ Update your local package index, then finally install {{product_name}}:
   <pre class="text-white bg-dark">
    <code>
   sudo apt-get update
-  sudo apt-get install fontconfig openjdk-17-jre
+  sudo apt-get install fontconfig openjdk-21-jre
   sudo apt-get install {{artifactName}}</code>
   </pre>
+(Install <code>openjdk-17-jre</code> on Debian 12 or earlier)
 </p>
 
 <p>

--- a/templates/header.opensuse.html
+++ b/templates/header.opensuse.html
@@ -15,7 +15,7 @@ With that set up, the {{ product_name }} package can be installed with:
 
 <pre class="text-white bg-dark">
 
-  zypper install dejavu-fonts fontconfig java-17-openjdk
+  zypper install dejavu-fonts fontconfig java-21-openjdk
   zypper install {{ artifactName }}
 
 </pre>


### PR DESCRIPTION
Ref:
- https://github.com/jenkins-infra/release/issues/772

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
