### PR TITLE
fix(rpm) correct openSUSE instructions to ensure autorefresh is enabled on new installations

### DIFF
--- a/rpm/build/SOURCES/jenkins.repo
+++ b/rpm/build/SOURCES/jenkins.repo
@@ -1,6 +1,0 @@
-[@@ARTIFACTNAME@@]
-name=@@PRODUCTNAME@@
-baseurl=@@RPM_URL@@
-# TODO 'jenkins.io' {{ web_url }}/{{organization}}-2023.key
-gpgkey=@@RPM_URL@@/jenkins.io-2023.key
-gpgcheck=1

--- a/rpm/build/build.sh
+++ b/rpm/build/build.sh
@@ -5,6 +5,7 @@ D=$(mktemp -d)
 trap 'rm -rf "${D}"' EXIT
 
 cp -R "$(dirname "$0")"/* "${D}"
+mkdir -p "${D}/SOURCES"
 cp "${BASE}/systemd/jenkins.service" "${D}/SOURCES"
 cp "${BASE}/systemd/jenkins.sh" "${D}/SOURCES"
 cp "${BASE}/systemd/migrate.sh" "${D}/SOURCES"

--- a/rpm/publish/publish.sh
+++ b/rpm/publish/publish.sh
@@ -25,10 +25,16 @@ function generateSite() {
 	cat >"$D/${ARTIFACTNAME}.repo" <<EOF
 [${ARTIFACTNAME}]
 name=${PRODUCTNAME}${RELEASELINE}
+enabled=1
+type=rpm-md
 baseurl=${RPM_URL}
 gpgkey=${RPM_URL}/repodata/repomd.xml.key
 gpgcheck=1
 repo_gpgcheck=1
+
+# Only for SUSE/openSUSE distributions with zypper
+autorefresh=1
+keeppackages=0
 EOF
 
 	"$BASE/bin/indexGenerator.py" \

--- a/templates/header.rpm.html
+++ b/templates/header.rpm.html
@@ -18,19 +18,26 @@
 
   <h2>openSUSE</h2>
 
-  To use this repository with openSUSE, run the following command:
-  
+  To use this repository with openSUSE, start by adding the requirements with the following command:
+
   <pre class="text-white bg-dark">
 
-    sudo zypper addrepo -f {{web_url}}/ {{artifactName}}
+    zypper install dejavu-fonts fontconfig java-21-openjdk wget
   </pre>
-  
+
+  Then add the repository with run the following command:
+
+  <pre class="text-white bg-dark">
+
+    wget -O /etc/zypp/repos.d/jenkins.repo \
+      {{web_url}}/jenkins.repo
+  </pre>
+
   <p>
   With that set up, the {{ product_name }} package can be installed with:
-  
+
   <pre class="text-white bg-dark">
 
-    zypper install dejavu-fonts fontconfig java-21-openjdk
     zypper install {{ artifactName }}
   </pre>
   </p>


### PR DESCRIPTION
Fix https://github.com/jenkinsci/packaging/issues/543 by:

- Updating openSUSE instructions to use the same method as for Redhat to add the repository:
  - Tell end user to install prerequisite at first (including `wget`)
  - Retrieve repository by downloading (with `wget`) our custom `jenkins.repo` file. Have not written "upgrade from existing" instruction though, as I expect instructions to move to www.jenkins.io like for redhat.
  - Finally install the Jenkins package
- Remove the `jenkins.repo` file from RPM sources as it is not used anymore since #430 
  - Note: had to fix the `build.sh` script

### Testing done

- Local build of the RPM to ensure there are no errors due to changes in RPM source of build script
- Opened https://github.com/jenkinsci/packaging/pull/710 for end to end testing in Jenkins infra staging environment
  - Verified that the RPM can be installed with the updated instructions in an opensuse/leap container

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
