### PR TITLE
feat(deb,rpm) allow custom GPG public key file through a new environment variable 'GPG_PUBLIC_KEY_FILE' and fix missing Debian HTML

### DIFF
--- a/bin/indexGenerator.py
+++ b/bin/indexGenerator.py
@@ -60,6 +60,7 @@ class IndexGenerator:
         self.product_name = os.getenv("PRODUCTNAME", "Jenkins")
         self.distribution = os.getenv("OS_FAMILY", "debian")
         self.gpg_pub_key_info_file = os.getenv("GPGPUBKEYINFO", ".")
+        self.gpg_public_key_filename = os.getenv("GPG_PUBLIC_KEY_FILENAME", "jenkins.io.key")
         self.target_directory = "./target/" + self.distribution
 
         try:
@@ -107,6 +108,7 @@ class IndexGenerator:
         print("Root header generated: " + self.root_header)
         print("Root footer generated: " + self.root_footer)
         print("GPG Key Info File: " + self.gpg_pub_key_info_file)
+        print("GPG Public Key Filename: " + self.gpg_public_key_filename)
 
     def generate_root_header(self):
 
@@ -169,6 +171,7 @@ class IndexGenerator:
             "releaseline": self.releaseline,
             "web_url": self.web_url,
             "pub_key_info": self.fetch_pubkeyinfo(),
+            "gpg_public_key_filename": self.gpg_public_key_filename,
         }
 
         env = jinja2.Environment(
@@ -192,6 +195,7 @@ class IndexGenerator:
             "releaseline": self.releaseline,
             "web_url": self.web_url,
             "pub_key_info": self.fetch_pubkeyinfo(),
+            "gpg_public_key_filename": self.gpg_public_key_filename,
         }
 
         env = jinja2.Environment(

--- a/deb/publish/publish.sh
+++ b/deb/publish/publish.sh
@@ -93,10 +93,7 @@ function uploadHtmlSite() {
 	rsync --archive \
 		--verbose \
 		--progress \
-		--include "HEADER.html" \
-		--include "FOOTER.html" \
-		--exclude "*" \
-		"$D/html/" "$DEBDIR/"
+		"$D/html/" "$DEB_WEBDIR/"
 }
 
 function show() {

--- a/deb/publish/publish.sh
+++ b/deb/publish/publish.sh
@@ -8,6 +8,7 @@ set -euxo pipefail
 : "${DEBDIR:? Require where to put binary files}"
 : "${DEB_WEBDIR:? Require where to put repository index and other web contents}"
 : "${DEB_URL:? Require Debian repository Url}"
+: "${GPG_PUBLIC_KEY_FILENAME:="${ORGANIZATION}.key"}"
 
 # $$ Contains current pid
 D="$AGENT_WORKDIR/$$"
@@ -22,12 +23,14 @@ function clean() {
 function generateSite() {
 	cp -R "$bin/contents/." "$D/contents"
 
-	gpg --export -a --output "$D/contents/${ORGANIZATION}.key" "${GPG_KEYNAME}"
-	gpg --import-options show-only --import "$D/contents/${ORGANIZATION}.key" >"$D/contents/${ORGANIZATION}.key.info"
+	local gpg_publickey_file="$D/contents/${GPG_PUBLIC_KEY_FILENAME}"
+	local gpg_publickey_info_file="$D/contents/${GPG_PUBLIC_KEY_FILENAME}.info"
+	gpg --export -a --output "${gpg_publickey_file}" "${GPG_KEYNAME}"
+	gpg --import-options show-only --import "${gpg_publickey_file}" > "${gpg_publickey_info_file}"
 
 	"$BASE/bin/indexGenerator.py" \
 		--distribution debian \
-		--gpg-key-info-file "${D}/contents/${ORGANIZATION}.key.info" \
+		--gpg-key-info-file "${gpg_publickey_info_file}" \
 		--targetDir "$D/html"
 
 	"$BASE/bin/branding.py" "$D"
@@ -87,7 +90,6 @@ function uploadPackageSite() {
 }
 
 function uploadHtmlSite() {
-	# Html file need to be located in the binary directory
 	rsync --archive \
 		--verbose \
 		--progress \
@@ -103,6 +105,7 @@ function show() {
 	echo "DEBDIR: $DEBDIR"
 	echo "DEB_WEBDIR: $DEB_WEBDIR"
 	echo "GPG_KEYNAME: $GPG_KEYNAME"
+	echo "GPG_PUBLIC_KEY_FILENAME: $GPG_PUBLIC_KEY_FILENAME"
 	echo "---"
 }
 

--- a/templates/header.debian.html
+++ b/templates/header.debian.html
@@ -10,7 +10,7 @@
   <pre class="text-white bg-dark">
     <code>
   sudo wget -O /etc/apt/keyrings/jenkins-keyring.asc \
-    <a href="{{web_url}}/{{organization}}-2023.key" style="color:white">{{web_url}}/{{organization}}-2023.key</a></code>
+    <a href="{{web_url}}/{{gpg_public_key_filename}}" style="color:white">{{web_url}}/{{gpg_public_key_filename}}</a></code>
   </pre>
 
   Then add a Jenkins apt repository entry:


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4922

This PR ensures that the public GPG key used by the packaging process is:

- Published to the final webserver (`pkg.jenkins.io`) under the filename specified by the `GPG_PUBLIC_KEY_FILE` environment variable
  - It would have avoided the issue https://github.com/jenkins-infra/helpdesk/issues/3519 in 2023. And it will help us with the new 2026 key.
- Ensure the HTML pages for Debian and RPM are properly generated with the GPG key filename passed to the Python template engine
  - Includes a fix where the Debian HTML website was not uploaded to the correct location, so it was missing in our staging tests
  - Note: RPM HTML does not have a direct mention of the GPG key, but better to have it in case we change the documentation

Tested as part of https://github.com/jenkins-infra/release/pull/829 with success:

- The new key is published under the name `jenkins.io-2026.key`
- The HTML content for Debian is present and mentions the new key filename (and its new ID and expiration date)