### PR TITLE
Revise JDK documentation

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -71,64 +71,10 @@
               (as described above) or another Java vendor (e.g., <a href="https://adoptium.net/">Adoptium</a>).
             </p>
 
-            <h2>
-              Weekly Release Line
-            </h2>
+          <p>
+            To determine the Java version that is supported for your Jenkins environment, please refer to the <a href="https://www.jenkins.io/doc/book/platform-information/support-policy-java/#running-jenkins-system">Java support policy.</a>
+          </p>
 
-            <p>
-              Supported Java versions for the weekly release line are:
-            </p>
-
-            <dl>
-              <dt>2.463 (June 2024) and newer</dt>
-              <dd>Java 17 or Java 21</dd>
-
-              <dt>2.419 (August 2023) and newer</dt>
-              <dd>Java 11, Java 17, or Java 21</dd>
-
-              <dt>2.357 (June 2022) and newer</dt>
-              <dd>Java 11 or Java 17</dd>
-
-              <dt>2.164 (February 2019) and newer</dt>
-              <dd>Java 8 or Java 11</dd>
-
-              <dt>2.54 (April 2017) and newer</dt>
-              <dd>Java 8</dd>
-
-              <dt>1.612 (May 2015) and newer</dt>
-              <dd>Java 7</dd>
-            </dl>
-
-            <h2>
-              <a href="https://www.jenkins.io/download/lts/">Long Term Support (LTS)</a> Release Line
-            </h2>
-
-            <p>
-              Supported Java versions for the LTS release line are:
-            </p>
-
-            <dl>
-              <dt>2.479.1 (October 2024) and newer</dt>
-              <dd>Java 17 or Java 21</dd>
-
-              <dt>2.426.1 (November 2023) and newer</dt>
-              <dd>Java 11, Java 17 or Java 21</dd>
-
-              <dt>2.361.1 (September 2022) and newer</dt>
-              <dd>Java 11 or Java 17</dd>
-
-              <dt>2.346.1 (June 2022) and newer</dt>
-              <dd>Java 8, Java 11, or Java 17</dd>
-
-              <dt>2.164.1 (March 2019) and newer</dt>
-              <dd>Java 8 or Java 11</dd>
-
-              <dt>2.60.1 (June 2017) and newer</dt>
-              <dd>Java 8</dd>
-
-              <dt>1.625.1 (October 2015) and newer</dt>
-              <dd>Java 7</dd>
-            </dl>
           {% endblock %}
 
           <p>


### PR DESCRIPTION
The change proposed removes the redundant JDK table in favor of https://www.jenkins.io/doc/book/platform-information/support-policy-java/#running-jenkins-system.

Our Java support policy page on jenkins.io documents the information needed and is easier to update, when needed, instead of maintaining the same data - but with less information - in two places.