### PR TITLE
Fix: Persist service credentials during silent install (JENKINS-71643)

### DIFF
--- a/msi/build/jenkins.wxs
+++ b/msi/build/jenkins.wxs
@@ -116,9 +116,11 @@
     </Property>
     <SetProperty After='AppSearch' Id='JENKINS_ROOT' Value='%LocalAppData%\Jenkins\'>NOT JENKINS_ROOT</SetProperty>
 
-    <Property Id="SERVICE_USERNAME">
+    <Property Id="SERVICE_USERNAME" Secure="yes">
       <RegistrySearch Id="DetermineServiceUsername" Type="raw" Root="HKLM" Key="Software\Jenkins\InstalledProducts\Jenkins" Name="SU" Win64="yes" />
     </Property>
+
+    <Property Id="SERVICE_PASSWORD" Secure="yes" Hidden="yes" />
 
     <Property Id="SERVICE_PASSWORD_ENC">
       <RegistrySearch Id="DetermineServicePassword" Type="raw" Root="HKLM" Key="Software\Jenkins\InstalledProducts\Jenkins" Name="SP" Win64="yes" />

--- a/msi/build/jenkins.wxs
+++ b/msi/build/jenkins.wxs
@@ -119,8 +119,8 @@
     <Property Id="SERVICE_USERNAME" Secure="yes">
       <RegistrySearch Id="DetermineServiceUsername" Type="raw" Root="HKLM" Key="Software\Jenkins\InstalledProducts\Jenkins" Name="SU" Win64="yes" />
     </Property>
-
-    <Property Id="SERVICE_PASSWORD" Secure="yes" Hidden="yes" />
+    <SetProperty Id="SecureCustomProperties" Value=";SERVICE_PASSWORD" Sequence="first" After="AppSearch" />
+    <SetProperty Id="MsiHiddenProperties" Value="[MsiHiddenProperties];SERVICE_PASSWORD" Sequence="first" After="AppSearch" />
     <Property Id="SERVICE_PASSWORD_ENC">
       <RegistrySearch Id="DetermineServicePassword" Type="raw" Root="HKLM" Key="Software\Jenkins\InstalledProducts\Jenkins" Name="SP" Win64="yes" />
     </Property>

--- a/msi/build/jenkins.wxs
+++ b/msi/build/jenkins.wxs
@@ -121,7 +121,6 @@
     </Property>
 
     <Property Id="SERVICE_PASSWORD" Secure="yes" Hidden="yes" />
-
     <Property Id="SERVICE_PASSWORD_ENC">
       <RegistrySearch Id="DetermineServicePassword" Type="raw" Root="HKLM" Key="Software\Jenkins\InstalledProducts\Jenkins" Name="SP" Win64="yes" />
     </Property>


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/packaging/issues/703

The Issue
During a silent installation (e.g., msiexec /i jenkins.msi /quiet), the SERVICE_USERNAME and SERVICE_PASSWORD properties were being stripped when the Windows Installer switched from the client process (UI sequence) to the elevated system process (Execute sequence). This caused the service to fail to start or default to LocalSystem.

The Fix
SERVICE_USERNAME: Added the Secure="yes" attribute to the property definition.

SERVICE_PASSWORD: Used SetProperty elements (scheduled After="AppSearch") to dynamically add this property to the SecureCustomProperties and MsiHiddenProperties lists at runtime.

Note: This approach was chosen over adding attributes directly to SERVICE_PASSWORD because that property is defined in an imported WiX library, which caused "Duplicate Symbol" errors during compilation when redefined.

Verification
Verified on Windows 10.

I built the MSI locally from this branch and performed a silent installation with verbose logging: msiexec /i "bin\Release\en-US\jenkins-2.544.msi" /quiet /lv! install.log SERVICE_USERNAME="TestUser" SERVICE_PASSWORD="Password123"

Result:

The log confirms SERVICE_USERNAME was successfully passed to the server process.

The log confirms SERVICE_PASSWORD was successfully masked (**********).