### PR TITLE
Revert "Require Java 17 or Java 21 for RPM installations and Java 21 for Fedora installations"

### DIFF
--- a/rpm/build/SPECS/jenkins.spec
+++ b/rpm/build/SPECS/jenkins.spec
@@ -19,12 +19,7 @@ BuildRoot:	%{_tmppath}/build-%{name}-%{version}
 # So either we make a hard requirement on the OpenJDK or none at all
 # Only workaround would be to use a java virtual package, see https://github.com/keystep/virtual-java-rpm
 # TODO: If re-enable, fix the matcher for Java 17
-# Fedora 42+ removes openjdk-{8,11,17}. Jenkins now uses Eclipse Temurin JDK 21.
-%if 0%{?fedora}
-Requires: java >= 21
-%else
-Requires: java >= 17
-%endif
+# Requires: java >= 1:1.8.0
 Requires: procps
 Requires(pre): /usr/sbin/useradd, /usr/sbin/groupadd
 BuildArch: noarch


### PR DESCRIPTION
Reverts jenkinsci/packaging#544 which caused https://github.com/jenkinsci/packaging/issues/729 when Jenkins 2.545 was released.

Jenkins Packages are not expected to **require** dependencies such Java given the scope of issues which can happen.
They could eventually **recommend** it. Otherwise we need an extensive set of tests to re-enable.