### PR TITLE
hotfix!: remove JDK17 from packaging (breaking)

### DIFF
--- a/molecule/default/install-deb.yml
+++ b/molecule/default/install-deb.yml
@@ -6,11 +6,6 @@
     update_cache: true
 - package:
     name:
-      - openjdk-17-jre
-    state: present
-  when: ansible_distribution == "Debian" and ansible_distribution_major_version < "13"
-- package:
-    name:
       - openjdk-21-jre
     state: present
   when: (ansible_distribution == "Debian" and ansible_distribution_major_version == "13") or ansible_distribution == "Ubuntu"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,22 +6,23 @@ driver:
 
 platforms:
   # deb
-  - name: debian-11  # EOL 2026-06-30
-    image: dokken/debian-11:latest
-    override_command: false
-    volumes:
-      - ${MOLECULE_PROJECT_DIRECTORY}/target:/var/tmp/target
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    cgroupns_mode: host
-    privileged: true
-  - name: debian-12  # EOL 2028-06-10
-    image: dokken/debian-12:latest
-    override_command: false
-    volumes:
-      - ${MOLECULE_PROJECT_DIRECTORY}/target:/var/tmp/target
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    cgroupns_mode: host
-    privileged: true
+  # TODO: restore older distributions when a temuring installation to retrieve jdk21 has been put in place
+  # - name: debian-11  # EOL 2026-06-30
+  #   image: dokken/debian-11:latest
+  #   override_command: false
+  #   volumes:
+  #     - ${MOLECULE_PROJECT_DIRECTORY}/target:/var/tmp/target
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  #   cgroupns_mode: host
+  #   privileged: true
+  # - name: debian-12  # EOL 2028-06-10
+  #   image: dokken/debian-12:latest
+  #   override_command: false
+  #   volumes:
+  #     - ${MOLECULE_PROJECT_DIRECTORY}/target:/var/tmp/target
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  #   cgroupns_mode: host
+  #   privileged: true
   - name: debian-13  # EOL 2030-06-30 (LTS)
     image: dokken/debian-13:latest
     override_command: false

--- a/msi/build/jenkins_en-US.wxl
+++ b/msi/build/jenkins_en-US.wxl
@@ -3,10 +3,10 @@
   <!-- Java Home Dialog Strings -->
   <String Id="JavaHomeDlgTitle" Overridable="yes">[ProductName] Setup</String>
   <String Id="JavaHomeDlgDescription" Overridable="yes">Select Java home directory (JDK or JRE)</String>
-  <String Id="JavaHomeDlgLabel" Overridable="yes">Please select the path of a Java Development Kit or Java Runtime Environment. Only Java 17, 21 and 25 are supported by Jenkins.</String>
+  <String Id="JavaHomeDlgLabel" Overridable="yes">Please select the path of a Java Development Kit or Java Runtime Environment. Only Java 21 and 25 are supported by Jenkins.</String>
   <String Id="JavaHomeDlgChange" Overridable="yes">&amp;Change...</String>
   <String Id="JavaHomeDlgErrorTitle" Overridable="yes">Invalid Java Directory</String>
-  <String Id="JavaHomeDlgErrorMessage" Overridable="yes">Failed to find compatible Java version (17, 21 or 25) in [JAVA_HOME]</String>
+  <String Id="JavaHomeDlgErrorMessage" Overridable="yes">Failed to find compatible Java version (21 or 25) in [JAVA_HOME]</String>
 
   <!-- Java Browse Dialog Strings -->
   <String Id="JavaBrowseDlgDescription" Overridable="yes">Browse to the Java Home directory</String>

--- a/setup.mk
+++ b/setup.mk
@@ -18,8 +18,9 @@ export MSI_SHASUM:=${MSI}.sha256
 # where to generate Debian/Ubuntu DEB file?
 export DEB=${TARGET}/debian/${ARTIFACTNAME}_${VERSION}_all.deb
 
+# TODO: restore package build number from `-2` to `-1` (hotfix of 2.545, see https://github.com/jenkinsci/packaging/issues/729)
 # where to generate RHEL/CentOS RPM file?
-export RPM=${TARGET}/rpm/${ARTIFACTNAME}-${VERSION}-1.noarch.rpm
+export RPM=${TARGET}/rpm/${ARTIFACTNAME}-${VERSION}-2.noarch.rpm
 
 # anchored to the root of the repository
 export BASE:=$(CURDIR)

--- a/templates/header.debian.html
+++ b/templates/header.debian.html
@@ -32,7 +32,7 @@ Update your local package index, then finally install {{product_name}}:
   sudo apt-get install fontconfig openjdk-21-jre
   sudo apt-get install {{artifactName}}</code>
   </pre>
-(Install <code>openjdk-17-jre</code> on Debian 12 or earlier)
+(Get JDK 21 from https://adoptium.net on Debian 12 or earlier)
 </p>
 
 <p>


### PR DESCRIPTION
This PR removes JDK 17 from packaging as 2.545 now requires JDK21: https://www.jenkins.io/changelog/2.545

Ref:
- https://github.com/jenkinsci/packaging/issues/729#issuecomment-3719079396

### Testing done

CI (molecule fails on Apple Silicon)

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
---

With this PR, we'll run a staging packaging to retrieve those new artifacts that we'll selectively redeploy to override the problematic 2.545 existing ones:

- MSI
- Debian: HTML only
- RPM all: HTML, RPM and index

See https://github.com/jenkinsci/packaging/issues/729#issuecomment-3719079396 for more details.