### PR TITLE
feat(tests): explicit `python3.14` call and bump ansible to 13.1.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,7 +58,7 @@ nodeWithTimeout('docker') {
         sh '''
             cat /proc/cpuinfo
             cat /proc/meminfo
-            python3 -m venv venv
+            python3.14 -m venv venv
             . venv/bin/activate
             pip install -U pip wheel
             pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ansible==10.7.0
+ansible==13.1.0
 jinja2==3.1.6
 molecule-plugins[docker]==25.8.12


### PR DESCRIPTION
This change updates the "test" stage in the pipeline to explicitly use python3.14 (installed from source in packer images used by ci.jenkins.io agents) so contributors can see which version is required, and bumps ansible to 13.1.0 consequently (without this bump: "Python 3.14 requires ansible-core version >= 2.20.0" error).

Note: this change doesn't concern the "build" stage which is executed from a Kubernetes agent using https://github.com/jenkins-infra/docker-packaging image based on Ubuntu 24.04 and including Python 3.12.3 OOTB (cf https://github.com/jenkins-infra/helpdesk/issues/5124#issuecomment-4797504007).

A follow-up updatecli manifest will keep this python3 version up to date.

Supersedes and closes #716 #722 #727 

Refs:
- https://github.com/jenkins-infra/packer-images/issues/2837

### Testing done

See #727 comments, notably:
```
$ python3 --version
Python 3.10.12
$ python3.14 --version
Python 3.14.6
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
